### PR TITLE
action to write userdata back to keycloak

### DIFF
--- a/backend/metadata/actions.graphql
+++ b/backend/metadata/actions.graphql
@@ -1,25 +1,25 @@
 type Query {
-  loadFile (
+  loadFile(
     path: String!
   ): loadFileOutput
 }
 
 type Mutation {
-  saveFile (
+  saveFile(
     base64file: String!
     filename: String!
   ): UploadResult
 }
 
 type UploadResult {
-  link : String!
+  link: String!
 }
 
 type Output {
-  link : String!
+  link: String!
 }
 
 type loadFileOutput {
-  link : String!
+  link: String!
 }
 

--- a/backend/metadata/databases/default/tables/public_User.yaml
+++ b/backend/metadata/databases/default/tables/public_User.yaml
@@ -133,3 +133,17 @@ update_permissions:
       id:
         _eq: X-Hasura-User-Id
   role: self_access
+event_triggers:
+- definition:
+    enable_manual: false
+    update:
+      columns:
+      - email
+      - firstName
+      - lastName
+  name: updateKeycloakProfile
+  retry_conf:
+    interval_sec: 10
+    num_retries: 0
+    timeout_sec: 60
+  webhook: "{{CLOUD_FUNCTION_LINK}}/updateKeycloakProfile"


### PR DESCRIPTION
Added action on update of table user on fields email, firstname and lastname and calls serverless function updateKeycloakProfile. This function is supposed to write back the values of these fields back to keycloak.