### PR TITLE
fix a ras isAdmin hook to use admin-ras instead of admin

### DIFF
--- a/frontend-nx/apps/rent-a-scientist/hooks/authentication.ts
+++ b/frontend-nx/apps/rent-a-scientist/hooks/authentication.ts
@@ -19,7 +19,7 @@ export const useIsAdmin = () => {
   return (
     sessionData?.profile?.['https://hasura.io/jwt/claims']?.[
       'x-hasura-allowed-roles'
-    ]?.includes('admin') ?? false
+    ]?.includes('admin-ras') ?? false
   );
 };
 


### PR DESCRIPTION
bugfix für rent-a-scientist