### PR TITLE
Improve wording to not panic teachers

### DIFF
--- a/frontend-nx/apps/rent-a-scientist/components/OffersSearch.tsx
+++ b/frontend-nx/apps/rent-a-scientist/components/OffersSearch.tsx
@@ -270,8 +270,7 @@ export const OffersSearch: FC<IProps> = ({ className }) => {
 
           {!rsaConfig.visibility && (
             <div className="mt-4 text-xl font-bold">
-              Leider ist die Anmeldephase vorbei. Sie können hier aber weiterhin
-              die Angebote einsehen
+              Die Anmeldung ist aktuell nicht möglich. Schauen Sie in den nächsten Tagen nochmal vorbei.
             </div>
           )}
 


### PR DESCRIPTION
With the old wording they might think registration is already over if they already open the page.

Please deploy to production