### PR TITLE
log all git hook logs to stdout

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo "Starting post-checkout script." >> .github/hooks/log.txt
+echo "Starting post-checkout script."
 
 # Check if jq is installed, if not, attempt to install it
 if ! command -v jq &> /dev/null; then


### PR DESCRIPTION
Some log messages from git hooks have previously been written to `.github/hooks/log.txt`. This is not consistent with other log messages which are written to stdout. Also the hook might failt since `.github/hooks` is not guaranteed to exist.

Now it logs to stdout instead.