### PR TITLE
use hardcoded repository in git hook

### DIFF
--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -19,8 +19,8 @@ fi
 echo "jq installed or already exists."
 
 # Define GitHub repository and authentication token
-REPO_OWNER=$(git config --get remote.origin.url | sed 's/.*:\/\/github.com\///' | sed 's/\/.*//')
-REPO_NAME=$(basename `git rev-parse --show-toplevel`)
+REPO_OWNER="eduhub-org"
+REPO_NAME="eduhub"
 
 # Capture the name of the branch that was checked out
 NEW_BRANCH_NAME=$(git symbolic-ref --short HEAD)


### PR DESCRIPTION
Reverts commit [`4a1d7e80c62`](https://github.com/eduhub-org/eduhub/commit/4a1d7e80c62fa510044370e8dad7027ce2682399) since the extraction is too unreliable.