### PR TITLE
fix link to LICENSE in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,4 @@ We welcome contributions from everyone. Please check out the technical details f
 
 ## :memo: License
 
-This project is licensed under [AGPLv3 License](LICENSE.md).
+This project is licensed under [AGPLv3 License](LICENSE).


### PR DESCRIPTION
The license file doesn't have a `.md` at the end.