### PR TITLE
Bug/issue647/download of participation details is not working

### DIFF
--- a/infrastructure/application/06_cloud-functions.tf
+++ b/infrastructure/application/06_cloud-functions.tf
@@ -1,4 +1,31 @@
 ###############################################################################
+# Create Google Cloud Function Service Account
+#####
+resource "google_service_account" "custom_cloud_function_account" {
+  account_id   = "custom-cloud-function-account"
+  display_name = "Custom Cloud Function Service Account"
+  project      = var.project_id
+}
+resource "google_project_iam_member" "cloud_functions_developer" {
+  project = var.project_id
+  role    = "roles/cloudfunctions.developer"
+  member  = "serviceAccount:${google_service_account.custom_cloud_function_account.email}"
+}
+
+resource "google_project_iam_member" "storage_object_admin" {
+  project = var.project_id
+  role    = "roles/storage.objectAdmin"
+  member  = "serviceAccount:${google_service_account.custom_cloud_function_account.email}"
+}
+
+resource "google_project_iam_member" "service_account_token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:${google_service_account.custom_cloud_function_account.email}"
+}
+
+
+###############################################################################
 # Create Google Cloud Function Services
 #####
 
@@ -58,6 +85,7 @@ resource "google_cloudfunctions2_function" "call_python_function" {
     available_memory   = "256M"
     timeout_seconds    = 3600
     ingress_settings   = var.cloud_function_ingress_settings
+    service_account_email = google_service_account.custom_cloud_function_account.email
   }
 }
 

--- a/infrastructure/foundation/04_storage.tf
+++ b/infrastructure/foundation/04_storage.tf
@@ -12,8 +12,8 @@ resource "google_storage_bucket" "main" {
       type = "Delete"
     }
     condition {
-      age              = 7
-      with_prefix      = "temp/"
+      age            = 7
+      matches_prefix = "temp/"
     }
   }
 }


### PR DESCRIPTION
- Merge pull request #819 from eduhub-org/dependabot/npm_and_yarn/frontend-nx/next-auth-4.24.5
- Merge pull request #821 from eduhub-org/feature/issue820/Extend-TableGrid-component-by-a-global-search-field
- Bugfix: Allow read access to `status` in `User` table
- Extend TableGrid component by a global search field Fixes #820
- Bump next-auth from 4.22.1 to 4.24.5 in /frontend-nx
- adjusts gitpod port actions
- updates .gitpod.yml