### PR TITLE
updates githib actions for Google Cloud

### DIFF
--- a/.github/workflows/zip-and-store-cloud-functions.yml
+++ b/.github/workflows/zip-and-store-cloud-functions.yml
@@ -244,14 +244,14 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: "auth"
-        uses: "google-github-actions/auth@v0"
+        uses: "google-github-actions/auth@v2"
         with:
           credentials_json: ${{ secrets.GCP_SERVICE_ACCOUNT_KEY }}
           project_id: ${{ inputs.PROJECT_ID }}
 
       - name: Upload Archives to Google Cloud
         id: "upload-archives"
-        uses: "google-github-actions/upload-cloud-storage@v0"
+        uses: "google-github-actions/upload-cloud-storage@v2"
         with:
           path: "./${{ inputs.CLOUD_FUNCTION_FOLDER }}"
           destination: "${{ inputs.BUCKET_NAME }}/cloud-functions"


### PR DESCRIPTION
- Merge pull request #829 from eduhub-org/bug/issue647/Download-of-Participation-Details-is-not-Working
- updates githib actions for Google Cloud
- Merge pull request #827 from eduhub-org/bug/issue647/Download-of-Participation-Details-is-not-Working
- fixes signed url creation in python storage client
- adds make_signed_upload_url without needing a private key file