### PR TITLE
adds error handler hook

### DIFF
--- a/frontend-nx/apps/edu-hub/components/FormToUploadAchievementRecord.tsx
+++ b/frontend-nx/apps/edu-hub/components/FormToUploadAchievementRecord.tsx
@@ -34,6 +34,7 @@ import EnrolledUserForACourseDialog from './common/dialogs/EnrolledUserForACours
 import Modal from './common/Modal';
 import { User_User_by_pk } from '../queries/__generated__/User';
 import { ErrorMessageDialog } from './common/dialogs/ErrorMessageDialog';
+import useErrorHandler from '../hooks/useErrorHandler';
 
 interface State {
   achievementRecordTableId: number; // book keeping
@@ -74,10 +75,7 @@ const FormToUploadAchievementRecord: FC<IProps> = ({
   isOpen,
   onClose,
 }) => {
-  const [errorMessage, setErrorMessage] = useState('');
-  const handleQueryError = (error: string) => {
-    setErrorMessage(error);
-  };
+  const { error, handleError, resetError } = useErrorHandler();
 
   const [visibleAuthorList, setVisibleAuthorList] = useState(false);
   const [isLoading, setLoading] = useState(false);
@@ -103,21 +101,21 @@ const FormToUploadAchievementRecord: FC<IProps> = ({
     UpdateAchievementRecordByPk,
     UpdateAchievementRecordByPkVariables
   >(UPDATE_AN_ACHIEVEMENT_RECORD, {
-    onError: (error) => handleQueryError(t(error.message)),
+    onError: (error) => handleError(t(error.message)),
   });
 
   const [saveAchievementRecordCoverImage] = useAuthedMutation<
     SaveAchievementRecordCoverImage,
     SaveAchievementRecordCoverImageVariables
   >(SAVE_ACHIEVEMENT_RECORD_COVER_IMAGE, {
-    onError: (error) => handleQueryError(t(error.message)),
+    onError: (error) => handleError(t(error.message)),
   });
 
   const [saveAchievementRecordDocumentation] = useAuthedMutation<
     SaveAchievementRecordDocumentation,
     SaveAchievementRecordDocumentationVariables
   >(SAVE_ACHIEVEMENT_RECORD_DOCUMENTATION, {
-    onError: (error) => handleQueryError(t(error.message)),
+    onError: (error) => handleError(t(error.message)),
   });
 
   const requestDeleteTag = useCallback(
@@ -415,9 +413,7 @@ const FormToUploadAchievementRecord: FC<IProps> = ({
         </div>
       </Modal>
       {/* Error Message Dialog */}
-      {errorMessage && (
-        <ErrorMessageDialog errorMessage={errorMessage} open={!!errorMessage} onClose={() => setErrorMessage('')} />
-      )}
+      {error && <ErrorMessageDialog errorMessage={error} open={!!error} onClose={resetError} />}
     </>
   );
 };

--- a/frontend-nx/apps/edu-hub/hooks/useErrorHandler.ts
+++ b/frontend-nx/apps/edu-hub/hooks/useErrorHandler.ts
@@ -1,0 +1,18 @@
+    import { useState } from 'react';
+
+    const useErrorHandler = (initialState = '') => {
+      const [error, setError] = useState(initialState);
+
+      const handleError = (error: string) => {
+        setError(error);
+      };
+
+      const resetError = () => {
+        setError('');
+      };
+
+      return { error, handleError, resetError };
+    };
+
+    export default useErrorHandler;
+    


### PR DESCRIPTION
- Merge pull request #867 from eduhub-org/chore/issue849/Re-organizing-the-serverless-function-for-loading-and-saving
- updates google-github-actions auth@vo to auth@v2
- Merge pull request #866 from eduhub-org/chore/issue849/Re-organizing-the-serverless-function-for-loading-and-saving
- removes legacy env variables from hasura deployment adds package to fnd unused components
- Merge pull request #864 from eduhub-org/chore/issue849/Re-organizing-the-serverless-function-for-loading-and-saving
- removes error due to unecessary catch
- adds error handling to achievement documentation upload and more informative error message
- removes further linting warnings
- fixes type error in getSignedUrl
- removes linter warnings and errors corrects component and folder naming for managing achivements
- corrects reference to achievementsOptions2
- replace furhter calls of LOAD_FILE
- WIP adds tile image loading according to new saved format loading of course background image still needs correction
- WIP adds further corrections and cleaning further tests still needed
- WIP adds corrections - still in test
- WIP adds all changes to Hasura, github action and terraform Adapting frontend and testing is still missing
- removes legacy imports
- WIP removes all specific save file functions add specific save image function adds new frontend env variable for storage bucket some initial cleaning of not any more needed code
- removes all remaining file specific load functions removes node functions to save certificates
- fixes saving of participant data in local development
- completes replacement of saveAchievementCertificateTemplates and corrects some translations in programs components
- Fixes hasura startup error by increasing wait time until keycloak is ready
- WIP removes and replaces saveAchievementCertificateTemplate
- cleans saveFile function from old file specific code
- removes loadParticipationCertificateTemplate (not used)
- fixes gitignore for nx cache files and adds generated nxdeps to speed up execution
- removes loadAchievementCertificateTemplate (was not used)