### PR TITLE
adds NEXT_PUBLIC_STORAGE_BUCKET_URL as env in terraform

### DIFF
--- a/infrastructure/application/07_edu.tf
+++ b/infrastructure/application/07_edu.tf
@@ -129,6 +129,10 @@ resource "google_cloud_run_service" "eduhub" {
           name  = "STORAGE_BUCKET_URL"
           value = "https://storage.googleapis.com/storage/v1/${var.project_id}"
         }
+        env {
+          name  = "NEXT_PUBLIC_STORAGE_BUCKET_URL"
+          value = "https://storage.googleapis.com/storage/v1/${var.project_id}"
+        }
       }
     }
 

--- a/infrastructure/application/08_rent-a-scientist.tf
+++ b/infrastructure/application/08_rent-a-scientist.tf
@@ -94,6 +94,10 @@ resource "google_cloud_run_service" "rent_a_scientist" {
           value = "https://storage.googleapis.com/storage/v1/${var.project_id}"
         }
         env {
+          name  = "NEXT_PUBLIC_STORAGE_BUCKET_URL"
+          value = "https://storage.googleapis.com/storage/v1/${var.project_id}"
+        }
+        env {
           name = "KEYCLOAK_RAS_CLIENT_SECRET"
           value_from {
             secret_key_ref {


### PR DESCRIPTION
- Merge pull request #869 from eduhub-org/chore/issue849/Re-organizing-the-serverless-function-for-loading-and-saving
- adds NEXT_PUBLIC_STORAGE_BUCKET_URL as env in terraform