### PR TITLE
#861 - adds force login logic to course page

### DIFF
--- a/frontend-nx/apps/edu-hub/README.md
+++ b/frontend-nx/apps/edu-hub/README.md
@@ -55,3 +55,9 @@ When adding new components:
 3. **Documentation:** Document the component's purpose, props, and usage examples in a comment block above the component definition.
 4. **Testing:** Write unit tests for the component's functionality to ensure reliability and prevent regressions.
 
+### Additional Information
+
+## Force redirect to Keycloak login page for specific links
+
+1. Use `withAuthRedirect` from `frontend-nx/apps/edu-hub/helpers/auth.ts` in your page (for reference see `frontend-nx/apps/edu-hub/pages/course/[courseId].tsx`)
+2. Add `?force_redirect=true` parameter to your link's URL

--- a/frontend-nx/apps/edu-hub/helpers/auth.ts
+++ b/frontend-nx/apps/edu-hub/helpers/auth.ts
@@ -1,0 +1,37 @@
+import { GetServerSideProps, GetServerSidePropsContext, GetServerSidePropsResult } from 'next';
+import { getSession } from 'next-auth/react';
+
+interface WithAuthRedirectOptions {
+  redirectTo?: string;
+  forceLoginParam?: string;
+}
+
+export const withAuthRedirect = ({ redirectTo = '/', forceLoginParam = 'force_login' }: WithAuthRedirectOptions = {}): ((
+  gssp?: GetServerSideProps
+) => (context: GetServerSidePropsContext) => Promise<GetServerSidePropsResult<any>>) => {
+  return (gssp?: GetServerSideProps) =>
+    async (context: GetServerSidePropsContext): Promise<GetServerSidePropsResult<any>> => {
+      const session = await getSession({ req: context.req });
+      const { query } = context;
+      const forceLogin = query[forceLoginParam];
+
+      if (forceLogin && !session) {
+        const signInPage = `/auth/signin?provider=keycloak&callbackUrl=${redirectTo}`;
+        if (context.resolvedUrl !== signInPage) {
+          return {
+            redirect: {
+              destination: signInPage,
+              permanent: false,
+            },
+          };
+        }
+      }
+
+      if (gssp) {
+        return gssp(context);
+      }
+
+      return { props: {} };
+    };
+};
+

--- a/frontend-nx/apps/edu-hub/pages/auth/signin.tsx
+++ b/frontend-nx/apps/edu-hub/pages/auth/signin.tsx
@@ -1,0 +1,23 @@
+import { useEffect } from 'react';
+import { useRouter } from 'next/router';
+import { signIn } from 'next-auth/react';
+
+import Loading from '../../components/common/Loading';
+
+const SignIn: React.FC = () => {
+  const router = useRouter();
+  const { provider, callbackUrl } = router.query;
+
+  useEffect(() => {
+    if (typeof provider === 'string' && typeof callbackUrl === 'string') {
+      signIn(provider, { callbackUrl });
+    }
+  }, [provider, callbackUrl]);
+  return (
+    <div className="flex justify-center items-center h-[100vh] w-[100vw]">
+      <Loading />
+    </div>
+  );
+};
+
+export default SignIn;

--- a/frontend-nx/apps/edu-hub/pages/course/[courseId].tsx
+++ b/frontend-nx/apps/edu-hub/pages/course/[courseId].tsx
@@ -1,3 +1,4 @@
+import { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { useRouter } from 'next/router';
 import { FC } from 'react';
@@ -5,6 +6,14 @@ import { Page } from '../../components/layout/Page';
 import CourseContent from '../../components/pages/CourseContent/index';
 import { useIsSessionLoading } from '../../hooks/authentication';
 import { CircularProgress } from '@material-ui/core';
+import { withAuthRedirect } from '../../helpers/auth';
+
+const getServerSidePropsWithRedirect = (redirectTo: string) => withAuthRedirect({ redirectTo })();
+
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const redirectTo = `${context.resolvedUrl}`;
+  return getServerSidePropsWithRedirect(redirectTo)(context);
+};
 
 const CoursePage: FC = () => {
   const router = useRouter();


### PR DESCRIPTION
- adds additional legacy case to getSignedUrl permission check
- further corrects access rights in SessionAddress table
- corrects instructor permission on SessionAddress table
- Merge pull request #898 from eduhub-org/dependabot/npm_and_yarn/frontend-nx/ip-2.0.1
- Merge pull request #893 from eduhub-org/feature/convert-user-table-to-tablegrid
- Bump ip from 2.0.0 to 2.0.1 in /frontend-nx
- corrects data migration for session addresses (as run in console)
- changes link text to show the actual link since link funcionality is not given.
- fixes global type error
- removes link to old user manage view from menu
- fixes type errors
- adds asynchronous global search to TableGrid component
- Merge branch 'develop' into feature/convert-user-table-to-tablegrid
- more cleanup for deployment
- temporary cleanup for deployment
- fixes layout issues and separates UserRow from Content component
- adds single component for second row
- table grid expandability wip
- adds pagination
- table grid pagination wip
- user table wip