### PR TITLE
fixes missing filtering of achievement options for a specific course

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/AchievementRecord/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/AchievementRecord/index.tsx
@@ -51,7 +51,10 @@ const AchievementRecord: FC<IProps> = ({ courseId, achievementRecordUploadDeadli
   const [achievementOptions, setAchievementOptions] = useState([] as MinAchievementOption[]);
 
   /* #region Database */
-  const query = useAuthedQuery<AchievementOptionCourses, AchievementOptionCoursesVariables>(ACHIEVEMENT_OPTION_COURSES);
+  const query = useAuthedQuery<AchievementOptionCourses, AchievementOptionCoursesVariables>(
+    ACHIEVEMENT_OPTION_COURSES,
+    { variables: { where: { courseId: { _eq: courseId } } } }
+  );
 
   useEffect(() => {
     const options = [...(query.data?.AchievementOptionCourse || [])];


### PR DESCRIPTION
- Merge pull request #950 from eduhub-org/issue903/Display-of-last-uploaded-achievement-is-not-course-dependent
- fixes missing filtering of achievement options for a specific course