### PR TITLE
fixes missing courseId on AchievementRecord upload und filtering of last uploaded achievement record for frontend user

### DIFF
--- a/backend/metadata/databases/default/tables/public_AchievementRecord.yaml
+++ b/backend/metadata/databases/default/tables/public_AchievementRecord.yaml
@@ -22,6 +22,7 @@ insert_permissions:
       check: {}
       columns:
         - achievementOptionId
+        - courseId
         - coverImageUrl
         - csvResults
         - description
@@ -73,6 +74,7 @@ select_permissions:
     permission:
       columns:
         - achievementOptionId
+        - courseId
         - coverImageUrl
         - created_at
         - csvResults

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/AchievementRecord/UploadAchievementRecordModal/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/AchievementRecord/UploadAchievementRecordModal/index.tsx
@@ -215,6 +215,7 @@ const UploadAchievementRecordModal: FC<IProps> = ({
           variables: {
             insertInput: {
               coverImageUrl: '', // this is mandatory field
+              courseId: courseId,
               description: state.description ?? '',
               rating: AchievementRecordRating_enum.UNRATED, // this is mandatory field
               score: 0, // because mandatory

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/AchievementRecord/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/AchievementRecord/index.tsx
@@ -65,9 +65,7 @@ const AchievementRecord: FC<IProps> = ({ courseId, achievementRecordUploadDeadli
     ACHIEVEMENT_RECORDS_WITH_AUTHORS,
     {
       variables: {
-        where: {
-          AchievementRecordAuthors: { userId: { _eq: userId } },
-        },
+        where: { _and: [{ AchievementRecordAuthors: { userId: { _eq: userId } } }, { courseId: { _eq: courseId } }] },
         orderBy: { created_at: order_by.desc },
         limit: 1,
       },


### PR DESCRIPTION
- Merge pull request #969 from eduhub-org/issue903/Display-of-last-uploaded-achievement-is-not-course-dependent
- fixes missing courseId on AchievementRecord upload und filtering of last uploaded achievement record for frontend user