### PR TITLE
adds protocol to externa link if not included

### DIFF
--- a/frontend-nx/apps/edu-hub/components/common/UserCard.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/UserCard.tsx
@@ -1,93 +1,69 @@
 import Image from 'next/image';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import mysteryImg from '../../public/images/common/mystery.svg';
 import { Course_Course_by_pk_CourseInstructors_Expert_User } from '../../queries/__generated__/Course';
 import { isLinkFormat } from '../../helpers/util';
 import useTranslation from 'next-translate/useTranslation';
 import { getPublicImageUrl } from '../../helpers/filehandling';
 
-interface ImageSizeMap {
-  small: number;
-  medium: number;
-  large: number;
+type Size = 'small' | 'medium' | 'large';
+
+interface SizeConfig {
+  imageSize: number;
+  imageSolution: number;
+  fontSize: string;
 }
 
-interface FontSizeMap {
-  small: string;
-  medium: string;
-  large: string;
-}
+const sizeConfigs: Record<Size, SizeConfig> = {
+  small: { imageSize: 40, imageSolution: 64, fontSize: 'text-sm' },
+  medium: { imageSize: 75, imageSolution: 400, fontSize: 'text-base' },
+  large: { imageSize: 100, imageSolution: 400, fontSize: 'text-lg' },
+};
 
 interface UserCardProps {
   className?: string;
   user: Course_Course_by_pk_CourseInstructors_Expert_User;
-  role?: string; // Optional role label, e.g., "Instructor"
-  size?: 'small' | 'medium' | 'large';
+  role?: string;
+  size?: Size;
 }
 
 const UserCard: FC<UserCardProps> = ({ user, role, className, size = 'large' }) => {
   const { t } = useTranslation('course');
 
-  const imageSizeMap: ImageSizeMap = {
-    small: 40,
-    medium: 75,
-    large: 100,
-  };
-
-  const imageSolutionMap: ImageSizeMap = {
-    small: 64,
-    medium: 400,
-    large: 400,
-  };
-
-  const fontSizeMap: FontSizeMap = {
-    small: 'text-sm',
-    medium: 'text-base',
-    large: 'text-lg',
-  };
-
-  const imageSize = imageSizeMap[size];
-  const imageSolution = imageSolutionMap[size];
-  const fontSize = fontSizeMap[size];
-  // do not show name if selected size is small
+  const { imageSize, imageSolution, fontSize } = sizeConfigs[size];
   const showName = size !== 'small';
 
-  const userPictureUrl = getPublicImageUrl(user?.picture, imageSolution) || mysteryImg;
+  const userPictureUrl = useMemo(
+    () => getPublicImageUrl(user?.picture, imageSolution) || mysteryImg,
+    [user?.picture, imageSolution]
+  );
 
   const getProfileLink = (url: string) => {
-    if (url.includes('linkedin.com')) {
-      return (
-        <a href={url} target="_blank" rel="noopener noreferrer">
-          {t('linkedinProfile')}
-        </a>
-      );
-    } else if (url.includes('xing.com')) {
-      return (
-        <a href={url} target="_blank" rel="noopener noreferrer" className="underline">
-          {t('xingProfile')}
-        </a>
-      );
-    } else {
-      return (
-        <a href={url} target="_blank" rel="noopener noreferrer" className="underline">
-          {t('externalProfile')}
-        </a>
-      );
-    }
+    const safeUrl = url.startsWith('http://') || url.startsWith('https://') ? url : `https://${url}`;
+
+    const linkTypes = {
+      'linkedin.com': 'linkedinProfile',
+      'xing.com': 'xingProfile',
+    };
+
+    const linkType = Object.keys(linkTypes).find((domain) => safeUrl.includes(domain)) || 'externalProfile';
+
+    return (
+      <a href={safeUrl} target="_blank" rel="noopener noreferrer" className="underline">
+        {t(linkTypes[linkType as keyof typeof linkTypes])}
+      </a>
+    );
   };
 
   return (
-    <div className={className}>
-      <div className={`flex flex-shrink-0 items-start mr-4 ${fontSize}`}>
-        <Image
-          src={userPictureUrl}
-          alt={`${t('common:image_of')} ${user?.firstName}`}
-          width={imageSize}
-          height={imageSize}
-          className="rounded-full object-cover"
-          style={{ width: `${imageSize}px`, height: `${imageSize}px` }}
-        />
-      </div>
+    <div className={`flex items-start ${className}`}>
+      <Image
+        src={userPictureUrl}
+        alt={`${t('common:image_of')} ${user?.firstName}`}
+        width={imageSize}
+        height={imageSize}
+        className="rounded-full object-cover mr-4"
+      />
       {showName && (
         <div className={`flex flex-col ${fontSize}`}>
           <span className="mb-1">


### PR DESCRIPTION
- Merge pull request #1053 from eduhub-org/issue1026/Getting-rid-of-unused-components
- Merge pull request #1055 from eduhub-org/issue960/Default-vaue-for-session-start-and-end-times
- removes unused import warnings removes linting errors in DateTimeHelpers
- corrects new input for getTimeString methods
- updates usage itime display in ApplicationRow
- replace further legacy usages of fromatTime and improves date time helper functions to accept a minimal type including course info.
- adds missing translation
- removes outdated text in info box below the course
- adjusts course location option selection to new EduHubDropdonwSelector component changes file name for DateHelpers to DateTimeHelpers adds a context provider for teh current app settings changes date time helper functions to hooks using the time zone hook from the app settings provider
- corrects formatting of the translations
- formats course start and end times to "time without time zone" replaces all usages of formatTime to one located under dateHelpers adds definition of a global time zone in the app settings improves EduHubDropdownSelector by accepting queries directly
- bug fix regarding dot color
- Deleted unused components and merged two dot components
- changes format of course start and end time to time without time zone
- Deleted Components which aren't used in the edu-hub app