### PR TITLE
reverts slider sorting back to applicationEnd

### DIFF
--- a/frontend-nx/apps/edu-hub/queries/courseQueries.ts
+++ b/frontend-nx/apps/edu-hub/queries/courseQueries.ts
@@ -20,7 +20,7 @@ export const COURSES_BY_INSTRUCTOR = gql`
   ${COURSE_TILE_FRAGMENT}
   query CoursesByInstructor($userId: uuid!) {
     Course(
-      order_by: { updated_at: desc }
+      order_by: { applicationEnd: desc }
       where: {
         CourseInstructors: {
           Expert: {
@@ -40,7 +40,7 @@ export const COURSES_ENROLLED_BY_USER = gql`
   ${COURSE_TILE_FRAGMENT}
   query CoursesEnrolledByUser($userId: uuid!) {
     Course(
-      order_by: { updated_at: desc }
+      order_by: { applicationEnd: desc }
       where: {
         CourseEnrollments: {
           userId: { _eq: $userId }


### PR DESCRIPTION
- Merge pull request #1070 from eduhub-org/bugfix/sort-slider-course-by-updated-at
- changes order of tile slider courses on homepage from application_end to updated_at
- Merge pull request #1064 from eduhub-org/chore/update-package-dependencies
- temporarily downgraded graphql to 5.8.0 for compatibility with deprecated apollo cli
- updates yarn.lock
- reintroduces package updates
- reapply all mui 6 changes again
- Reapply changes from material ui 6 update and additional fixes
- removes duplicate dependencies in yarn.lock to fix dependabot issues
- replaces dnd library to fix error. Other fixes to make build process work again