### PR TITLE
Issue389/Add-application-statistics-in-courses-view

### DIFF
--- a/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
+++ b/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
@@ -108,6 +108,14 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
         </MenuItem>
       )}
 
+      {isAdmin && (
+        <MenuItem onClick={closeMenu}>
+          <Link className="w-full text-lg" href="/statistics">
+            {t('menu-administration-statistics')}
+          </Link>
+        </MenuItem>
+      )}
+
       <MenuItem onClick={() => logout()}>
         <button className="w-full text-lg text-left">{t('menu-logout')}</button>
       </MenuItem>

--- a/frontend-nx/apps/edu-hub/components/pages/EnrollmenteStatisticsContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/EnrollmenteStatisticsContent/index.tsx
@@ -1,0 +1,114 @@
+import { FC, useState, useMemo } from 'react';
+import useTranslation from 'next-translate/useTranslation';
+import { Page } from '../../layout/Page';
+import { MULTI_PROGRAM_ENROLLMENTS } from '../../../queries/multiProgramEnrollments';
+import { MultiProgramEnrollments } from '../../../queries/__generated__/MultiProgramEnrollments';
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import TagSelector from '../../forms/TagSelector';
+import { PROGRAM_LIST } from '../../../queries/programList';
+import { ProgramList } from '../../../queries/__generated__/ProgramList';
+import Loading from '../../common/Loading';
+import CommonPageHeader from '../../common/CommonPageHeader';
+import { useRoleQuery } from '../../../hooks/authedQuery';
+
+const EnrollmentStatisticsContent: FC = () => {
+  const { t } = useTranslation('enrollmentStatistics');
+  const [selectedPrograms, setSelectedPrograms] = useState<{ id: number; name: string }[]>([]);
+  
+  const { data: programsData, loading: programsLoading } = useRoleQuery<ProgramList>(PROGRAM_LIST);
+  
+  const { data, loading, error } = useRoleQuery<MultiProgramEnrollments>(MULTI_PROGRAM_ENROLLMENTS, {
+    variables: { programIds: selectedPrograms.map(program => program.id) },
+  });
+
+  const chartData = useMemo(() => {
+    if (!data) return [];
+    const allDates = new Set<string>();
+    data.Program.forEach(program => {
+      program.Courses.forEach(course => {
+        course.CourseEnrollments.forEach(enrollment => {
+          allDates.add(new Date(enrollment.created_at).toISOString().split('T')[0]);
+        });
+      });
+    });
+
+    return Array.from(allDates).sort().map(date => {
+      const dataPoint: { [key: string]: any } = { date };
+      data.Program.forEach(program => {
+        const count = program.Courses.reduce((total, course) => {
+          return total + course.CourseEnrollments.filter(enrollment => 
+            new Date(enrollment.created_at).toISOString().split('T')[0] === date
+          ).length;
+        }, 0);
+        dataPoint[program.title] = count;
+      });
+      return dataPoint;
+    });
+  }, [data]);
+
+  const handleProgramChange = (selectedTags: { id: number; name: string }[]) => {
+    setSelectedPrograms(selectedTags);
+  };
+
+  const programOptions = programsData?.Program.map(program => ({
+    id: program.id,
+    name: program.title
+  })) || [];
+
+  return (
+    <Page>
+      <div className="max-w-screen-xl mx-auto mt-20 text-gray-200">
+        {loading && <Loading />}
+        {error && <div className="text-red-400">Es ist ein Fehler aufgetreten: {error.message}</div>}
+        {!loading && !error && (
+          <div>
+            <CommonPageHeader headline={t('enrollment_statistics')} />
+
+            <div className="bg-white p-4 rounded-lg mb-6">
+              <TagSelector
+                label={t('select_programs.label')}
+                placeholder={t('select_programs.placeholder')}
+                itemId={0}
+                currentTags={selectedPrograms}
+                tagOptions={programOptions}
+                onSelectedTagsChange={handleProgramChange}
+                refetchQueries={[]}
+                className="text-gray-800"
+              />
+            </div>
+            
+            {selectedPrograms.length > 0 ? (
+              <div className="bg-white p-4 rounded-lg">
+                <ResponsiveContainer width="100%" height={400}>
+                  <LineChart data={chartData}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#e0e0e0" />
+                    <XAxis dataKey="date" stroke="#333" />
+                    <YAxis stroke="#333" />
+                    <Tooltip 
+                      contentStyle={{ backgroundColor: '#fff', border: '1px solid #ccc' }}
+                      labelStyle={{ color: '#333' }}
+                    />
+                    <Legend wrapperStyle={{ color: '#333' }} />
+                    {data?.Program.map((program, index) => (
+                      <Line
+                        key={program.id}
+                        type="monotone"
+                        dataKey={program.title}
+                        stroke={`hsl(${index * 137.5 % 360}, 70%, 50%)`}
+                        strokeWidth={2}
+                      />
+                    ))}
+                  </LineChart>
+                </ResponsiveContainer>
+              </div>
+            ) : (
+              <div className="mt-4 text-gray-300">{t('select_programs.placeholder')}</div>
+            )}
+          </div>
+        )}
+      </div>
+    </Page>
+  );
+};
+
+export default EnrollmentStatisticsContent;

--- a/frontend-nx/apps/edu-hub/i18n.json
+++ b/frontend-nx/apps/edu-hub/i18n.json
@@ -9,6 +9,7 @@
       "course-admin-page",
       "course-application",
       "course-page",
+      "enrollmentStatistics",
       "manageAchievementTemplates",
       "manageAppSettings",
       "manageCourse",

--- a/frontend-nx/apps/edu-hub/locales/de/common.json
+++ b/frontend-nx/apps/edu-hub/locales/de/common.json
@@ -43,6 +43,7 @@
   "menu-administration-achievement-templates": "Leistungsnachweisvorlagen",
   "menu-administration-programs": "Programme",
   "menu-administration-appSettings": "App Einstellungen",
+  "menu-administration-statistics": "Statistiken",
   "menu-logout": "Logout",
   "change-password": "Passwort oder E-Mail ändern",
   "add": "Hinzufügen",

--- a/frontend-nx/apps/edu-hub/locales/de/enrollmentStatistics.json
+++ b/frontend-nx/apps/edu-hub/locales/de/enrollmentStatistics.json
@@ -1,0 +1,7 @@
+{
+    "enrollment_statistics": "Teilnahmestatistiken",
+    "select_programs": {
+        "label": "Progamme oder Semester",
+        "placeholder": "Progamm oder Semester hinzufügen"
+    }
+}

--- a/frontend-nx/apps/edu-hub/locales/en/common.json
+++ b/frontend-nx/apps/edu-hub/locales/en/common.json
@@ -43,6 +43,7 @@
   "menu-administration-achievement-templates": "Achievement Record Templates",
   "menu-administration-programs": "Programs",
   "menu-administration-appSettings": "App Settings",
+  "menu-administration-statistics": "Statistics",
   "menu-logout": "Logout",
   "change-password": "Change email or password",
   "add": "Add",

--- a/frontend-nx/apps/edu-hub/locales/en/enrollmentStatistics.json
+++ b/frontend-nx/apps/edu-hub/locales/en/enrollmentStatistics.json
@@ -1,0 +1,7 @@
+{
+    "enrollment_statistics": "Enrollment Statistics",
+    "select_programs": {
+        "label": "Programs or Semesters",
+        "placeholder": "Add Program or Semester"
+    }
+}

--- a/frontend-nx/apps/edu-hub/pages/statistics/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/statistics/index.tsx
@@ -1,0 +1,20 @@
+import Head from 'next/head';
+import { FC } from 'react';
+import { useIsAdmin } from '../../hooks/authentication';
+import EnrollmentStatisticsContent from '../../components/pages/EnrollmenteStatisticsContent';
+
+const EnrollmentStatisticsPage: FC = () => {
+  const isAdmin = useIsAdmin();
+
+  return (
+    <>
+      <Head>
+        <title>EduHub | Enrollment Statistics</title>
+        <link rel="icon" href="/favicon.png" />
+      </Head>
+      {isAdmin ? <EnrollmentStatisticsContent /> : <div>Access denied</div>}
+    </>
+  );
+};
+
+export default EnrollmentStatisticsPage;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MultiProgramEnrollments.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MultiProgramEnrollments.ts
@@ -1,0 +1,70 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { CourseEnrollmentStatus_enum } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL query operation: MultiProgramEnrollments
+// ====================================================
+
+export interface MultiProgramEnrollments_Program_Courses_CourseEnrollments {
+  __typename: "CourseEnrollment";
+  id: number;
+  /**
+   * The users current enrollment status to this course
+   */
+  status: CourseEnrollmentStatus_enum;
+  /**
+   * URL to the file containing the user's attendance certificate (if he obtained one)
+   */
+  attendanceCertificateURL: string | null;
+  /**
+   * URL to the file containing the user's achievement certificate (if he obtained one)
+   */
+  achievementCertificateURL: string | null;
+  created_at: any | null;
+  updated_at: any | null;
+}
+
+export interface MultiProgramEnrollments_Program_Courses {
+  __typename: "Course";
+  id: number;
+  /**
+   * The title of the course (only editable by an admin user)
+   */
+  title: string;
+  /**
+   * An array relationship
+   */
+  CourseEnrollments: MultiProgramEnrollments_Program_Courses_CourseEnrollments[];
+}
+
+export interface MultiProgramEnrollments_Program {
+  __typename: "Program";
+  id: number;
+  /**
+   * The title of the program
+   */
+  title: string;
+  /**
+   * The 6 letter short title for the program.
+   */
+  shortTitle: string | null;
+  /**
+   * An array relationship
+   */
+  Courses: MultiProgramEnrollments_Program_Courses[];
+}
+
+export interface MultiProgramEnrollments {
+  /**
+   * fetch data from the table: "Program"
+   */
+  Program: MultiProgramEnrollments_Program[];
+}
+
+export interface MultiProgramEnrollmentsVariables {
+  programIds?: number[] | null;
+}

--- a/frontend-nx/apps/edu-hub/queries/multiProgramEnrollments.ts
+++ b/frontend-nx/apps/edu-hub/queries/multiProgramEnrollments.ts
@@ -1,0 +1,23 @@
+import { gql } from '@apollo/client';
+
+export const MULTI_PROGRAM_ENROLLMENTS = gql`
+  query MultiProgramEnrollments($programIds: [Int!]) {
+    Program(where: {id: {_in: $programIds}}) {
+      id
+      title
+      shortTitle
+      Courses {
+        id
+        title
+        CourseEnrollments {
+          id
+          status
+          attendanceCertificateURL
+          achievementCertificateURL
+          created_at
+          updated_at
+        }
+      }
+    }
+  }
+`;

--- a/frontend-nx/package.json
+++ b/frontend-nx/package.json
@@ -51,6 +51,7 @@
     "react-icons": "^5.3.0",
     "react-markdown": "^9.0.1",
     "react-select": "^5.8.0",
+    "recharts": "^2.12.7",
     "remark-gfm": "^4.0.0",
     "sharp": "^0.33.5",
     "swiper": "^11.1.12",

--- a/frontend-nx/yarn.lock
+++ b/frontend-nx/yarn.lock
@@ -5218,6 +5218,75 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/d3-array@npm:^3.0.3":
+  version: 3.2.1
+  resolution: "@types/d3-array@npm:3.2.1"
+  checksum: 8a41cee0969e53bab3f56cc15c4e6c9d76868d6daecb2b7d8c9ce71e0ececccc5a8239697cc52dadf5c665f287426de5c8ef31a49e7ad0f36e8846889a383df4
+  languageName: node
+  linkType: hard
+
+"@types/d3-color@npm:*":
+  version: 3.1.3
+  resolution: "@types/d3-color@npm:3.1.3"
+  checksum: 8a0e79a709929502ec4effcee2c786465b9aec51b653ba0b5d05dbfec3e84f418270dd603002d94021885061ff592f614979193bd7a02ad76317f5608560e357
+  languageName: node
+  linkType: hard
+
+"@types/d3-ease@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@types/d3-ease@npm:3.0.2"
+  checksum: 0885219966294bfc99548f37297e1c75e75da812a5f3ec941977ebb57dcab0a25acec5b2bbd82d09a49d387daafca08521ca269b7e4c27ddca7768189e987b54
+  languageName: node
+  linkType: hard
+
+"@types/d3-interpolate@npm:^3.0.1":
+  version: 3.0.4
+  resolution: "@types/d3-interpolate@npm:3.0.4"
+  dependencies:
+    "@types/d3-color": "*"
+  checksum: efd2770e174e84fc7316fdafe03cf3688451f767dde1fa6211610137f495be7f3923db7e1723a6961a0e0e9ae0ed969f4f47c038189fa0beb1d556b447922622
+  languageName: node
+  linkType: hard
+
+"@types/d3-path@npm:*":
+  version: 3.1.0
+  resolution: "@types/d3-path@npm:3.1.0"
+  checksum: 1e81b56ed33ba1ac954a8c42c78c3fcf2716927fe5d01b2003591193ad3b639572a3dfcedd9bf78b6b73215a5cfb01cede8f25c936e95ac18fbe3858f9b62f5c
+  languageName: node
+  linkType: hard
+
+"@types/d3-scale@npm:^4.0.2":
+  version: 4.0.8
+  resolution: "@types/d3-scale@npm:4.0.8"
+  dependencies:
+    "@types/d3-time": "*"
+  checksum: 3b1906da895564f73bb3d0415033d9a8aefe7c4f516f970176d5b2ff7a417bd27ae98486e9a9aa0472001dc9885a9204279a1973a985553bdb3ee9bbc1b94018
+  languageName: node
+  linkType: hard
+
+"@types/d3-shape@npm:^3.1.0":
+  version: 3.1.6
+  resolution: "@types/d3-shape@npm:3.1.6"
+  dependencies:
+    "@types/d3-path": "*"
+  checksum: bd765be021019c43c8dca066a798a1de28a051d1213db6ca25f76c9e577da7ec40a592e3bda7628383ab48cb87164fe60b95eb5ec23761b2012bd0adb30c549a
+  languageName: node
+  linkType: hard
+
+"@types/d3-time@npm:*, @types/d3-time@npm:^3.0.0":
+  version: 3.0.3
+  resolution: "@types/d3-time@npm:3.0.3"
+  checksum: a071826c80efdb1999e6406fef2db516d45f3906da3a9a4da8517fa863bae53c4c1056ca5347a20921660607d21ec874fd2febe0e961adb7be6954255587d08f
+  languageName: node
+  linkType: hard
+
+"@types/d3-timer@npm:^3.0.0":
+  version: 3.0.2
+  resolution: "@types/d3-timer@npm:3.0.2"
+  checksum: 1643eebfa5f4ae3eb00b556bbc509444d88078208ec2589ddd8e4a24f230dd4cf2301e9365947e70b1bee33f63aaefab84cd907822aae812b9bc4871b98ab0e1
+  languageName: node
+  linkType: hard
+
 "@types/debug@npm:^4.0.0":
   version: 4.1.7
   resolution: "@types/debug@npm:4.1.7"
@@ -9093,6 +9162,99 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3-array@npm:2 - 3, d3-array@npm:2.10.0 - 3, d3-array@npm:^3.1.6":
+  version: 3.2.4
+  resolution: "d3-array@npm:3.2.4"
+  dependencies:
+    internmap: 1 - 2
+  checksum: a5976a6d6205f69208478bb44920dd7ce3e788c9dceb86b304dbe401a4bfb42ecc8b04c20facde486e9adcb488b5d1800d49393a3f81a23902b68158e12cddd0
+  languageName: node
+  linkType: hard
+
+"d3-color@npm:1 - 3":
+  version: 3.1.0
+  resolution: "d3-color@npm:3.1.0"
+  checksum: 4931fbfda5d7c4b5cfa283a13c91a954f86e3b69d75ce588d06cde6c3628cebfc3af2069ccf225e982e8987c612aa7948b3932163ce15eb3c11cd7c003f3ee3b
+  languageName: node
+  linkType: hard
+
+"d3-ease@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-ease@npm:3.0.1"
+  checksum: 06e2ee5326d1e3545eab4e2c0f84046a123dcd3b612e68858219aa034da1160333d9ce3da20a1d3486d98cb5c2a06f7d233eee1bc19ce42d1533458bd85dedcd
+  languageName: node
+  linkType: hard
+
+"d3-format@npm:1 - 3":
+  version: 3.1.0
+  resolution: "d3-format@npm:3.1.0"
+  checksum: f345ec3b8ad3cab19bff5dead395bd9f5590628eb97a389b1dd89f0b204c7c4fc1d9520f13231c2c7cf14b7c9a8cf10f8ef15bde2befbab41454a569bd706ca2
+  languageName: node
+  linkType: hard
+
+"d3-interpolate@npm:1.2.0 - 3, d3-interpolate@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-interpolate@npm:3.0.1"
+  dependencies:
+    d3-color: 1 - 3
+  checksum: a42ba314e295e95e5365eff0f604834e67e4a3b3c7102458781c477bd67e9b24b6bb9d8e41ff5521050a3f2c7c0c4bbbb6e187fd586daa3980943095b267e78b
+  languageName: node
+  linkType: hard
+
+"d3-path@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "d3-path@npm:3.1.0"
+  checksum: 2306f1bd9191e1eac895ec13e3064f732a85f243d6e627d242a313f9777756838a2215ea11562f0c7630c7c3b16a19ec1fe0948b1c82f3317fac55882f6ee5d8
+  languageName: node
+  linkType: hard
+
+"d3-scale@npm:^4.0.2":
+  version: 4.0.2
+  resolution: "d3-scale@npm:4.0.2"
+  dependencies:
+    d3-array: 2.10.0 - 3
+    d3-format: 1 - 3
+    d3-interpolate: 1.2.0 - 3
+    d3-time: 2.1.1 - 3
+    d3-time-format: 2 - 4
+  checksum: a9c770d283162c3bd11477c3d9d485d07f8db2071665f1a4ad23eec3e515e2cefbd369059ec677c9ac849877d1a765494e90e92051d4f21111aa56791c98729e
+  languageName: node
+  linkType: hard
+
+"d3-shape@npm:^3.1.0":
+  version: 3.2.0
+  resolution: "d3-shape@npm:3.2.0"
+  dependencies:
+    d3-path: ^3.1.0
+  checksum: de2af5fc9a93036a7b68581ca0bfc4aca2d5a328aa7ba7064c11aedd44d24f310c20c40157cb654359d4c15c3ef369f95ee53d71221017276e34172c7b719cfa
+  languageName: node
+  linkType: hard
+
+"d3-time-format@npm:2 - 4":
+  version: 4.1.0
+  resolution: "d3-time-format@npm:4.1.0"
+  dependencies:
+    d3-time: 1 - 3
+  checksum: 7342bce28355378152bbd4db4e275405439cabba082d9cd01946d40581140481c8328456d91740b0fe513c51ec4a467f4471ffa390c7e0e30ea30e9ec98fcdf4
+  languageName: node
+  linkType: hard
+
+"d3-time@npm:1 - 3, d3-time@npm:2.1.1 - 3, d3-time@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "d3-time@npm:3.1.0"
+  dependencies:
+    d3-array: 2 - 3
+  checksum: 613b435352a78d9f31b7f68540788186d8c331b63feca60ad21c88e9db1989fe888f97f242322ebd6365e45ec3fb206a4324cd4ca0dfffa1d9b5feb856ba00a7
+  languageName: node
+  linkType: hard
+
+"d3-timer@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "d3-timer@npm:3.0.1"
+  checksum: 1cfddf86d7bca22f73f2c427f52dfa35c49f50d64e187eb788dcad6e927625c636aa18ae4edd44d084eb9d1f81d8ca4ec305dae7f733c15846a824575b789d73
+  languageName: node
+  linkType: hard
+
 "damerau-levenshtein@npm:^1.0.8":
   version: 1.0.8
   resolution: "damerau-levenshtein@npm:1.0.8"
@@ -9227,6 +9389,13 @@ __metadata:
   dependencies:
     ms: 2.0.0
   checksum: 0b52718ab957254a5b3ca07fc34543bc778f358620c206a08452251eb7fc193c3ea3505072acbf4350219c14e2d71ceb7bdaa0d3370aa630b50da790458d08b3
+  languageName: node
+  linkType: hard
+
+"decimal.js-light@npm:^2.4.1":
+  version: 2.5.1
+  resolution: "decimal.js-light@npm:2.5.1"
+  checksum: f5a2c7eac1c4541c8ab8a5c8abea64fc1761cefc7794bd5f8afd57a8a78d1b51785e0c4e4f85f4895a043eaa90ddca1edc3981d1263eb6ddce60f32bf5fe66c9
   languageName: node
   linkType: hard
 
@@ -10733,7 +10902,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eventemitter3@npm:^4.0.0":
+"eventemitter3@npm:^4.0.0, eventemitter3@npm:^4.0.1":
   version: 4.0.7
   resolution: "eventemitter3@npm:4.0.7"
   checksum: 1875311c42fcfe9c707b2712c32664a245629b42bb0a5a84439762dd0fd637fc54d078155ea83c2af9e0323c9ac13687e03cfba79b03af9f40c89b4960099374
@@ -10932,6 +11101,13 @@ __metadata:
   version: 1.2.0
   resolution: "fast-diff@npm:1.2.0"
   checksum: 1b5306eaa9e826564d9e5ffcd6ebd881eb5f770b3f977fcbf38f05c824e42172b53c79920e8429c54eb742ce15a0caf268b0fdd5b38f6de52234c4a8368131ae
+  languageName: node
+  linkType: hard
+
+"fast-equals@npm:^5.0.1":
+  version: 5.0.1
+  resolution: "fast-equals@npm:5.0.1"
+  checksum: fbb3b6a74f3a0fa930afac151ff7d01639159b4fddd2678b5d50708e0ba38e9ec14602222d10dadb8398187342692c04fbef5a62b1cfcc7942fe03e754e064bc
   languageName: node
   linkType: hard
 
@@ -12726,6 +12902,13 @@ __metadata:
     hasown: ^2.0.0
     side-channel: ^1.0.4
   checksum: cadc5eea5d7d9bc2342e93aae9f31f04c196afebb11bde97448327049f492cd7081e18623ae71388aac9cd237b692ca3a105be9c68ac39c1dec679d7409e33eb
+  languageName: node
+  linkType: hard
+
+"internmap@npm:1 - 2":
+  version: 2.0.3
+  resolution: "internmap@npm:2.0.3"
+  checksum: 7ca41ec6aba8f0072fc32fa8a023450a9f44503e2d8e403583c55714b25efd6390c38a87161ec456bf42d7bc83aab62eb28f5aef34876b1ac4e60693d5e1d241
   languageName: node
   linkType: hard
 
@@ -16811,6 +16994,7 @@ __metadata:
     react-icons: ^5.3.0
     react-markdown: ^9.0.1
     react-select: ^5.8.0
+    recharts: ^2.12.7
     remark-gfm: ^4.0.0
     sharp: ^0.33.5
     swiper: ^11.1.12
@@ -18264,7 +18448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
+"react-is@npm:^16.10.2, react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -18385,6 +18569,20 @@ __metadata:
     react: ^16.8.0 || ^17.0.0 || ^18.0.0
     react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
   checksum: c8398cc0aefb5ee5438b6176c86676e2d3fed7457c16b0769f423a0da0ae431a7df25c2cadf13b709700882b8ebd80a58b1e557fec3e22ad3cbf60164ca9e745
+  languageName: node
+  linkType: hard
+
+"react-smooth@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "react-smooth@npm:4.0.1"
+  dependencies:
+    fast-equals: ^5.0.1
+    prop-types: ^15.8.1
+    react-transition-group: ^4.4.5
+  peerDependencies:
+    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+  checksum: 42c17803dcb3892a284bbb692d745d438e3bb204ecfc3c9f4f3ff808253ab783f6c64de85a0e84a20c2ea20cf0af39e78b947417ced328164d8dd4eca2918e01
   languageName: node
   linkType: hard
 
@@ -18510,6 +18708,34 @@ __metadata:
     source-map: ~0.6.1
     tslib: ^2.0.1
   checksum: 03cc7f57562238ba258d468be67bf7446ce7a707bc87a087891dad15afead46c36e9aaeedf2130e2ab5a465244a9c62bfd4127849761cf8f4085abe2f3e5f485
+  languageName: node
+  linkType: hard
+
+"recharts-scale@npm:^0.4.4":
+  version: 0.4.5
+  resolution: "recharts-scale@npm:0.4.5"
+  dependencies:
+    decimal.js-light: ^2.4.1
+  checksum: e970377190a610e684a32c7461c7684ac3603c2e0ac0020bbba1eea9d099b38138143a8e80bf769bb49c0b7cecf22a2f5c6854885efed2d56f4540d4aa7052bd
+  languageName: node
+  linkType: hard
+
+"recharts@npm:^2.12.7":
+  version: 2.12.7
+  resolution: "recharts@npm:2.12.7"
+  dependencies:
+    clsx: ^2.0.0
+    eventemitter3: ^4.0.1
+    lodash: ^4.17.21
+    react-is: ^16.10.2
+    react-smooth: ^4.0.0
+    recharts-scale: ^0.4.4
+    tiny-invariant: ^1.3.1
+    victory-vendor: ^36.6.8
+  peerDependencies:
+    react: ^16.0.0 || ^17.0.0 || ^18.0.0
+    react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0
+  checksum: c6f6b6d7de51dde17827f77f5dadfa0548422b1aa55c79d7104606dc47f8f4aabd7c6a226d9a8f6edf863788f33c99aafead784c842d2852b2bd9dac176460ea
   languageName: node
   linkType: hard
 
@@ -20696,7 +20922,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.6":
+"tiny-invariant@npm:^1.0.6, tiny-invariant@npm:^1.3.1":
   version: 1.3.3
   resolution: "tiny-invariant@npm:1.3.3"
   checksum: 5e185c8cc2266967984ce3b352a4e57cb89dad5a8abb0dea21468a6ecaa67cd5bb47a3b7a85d08041008644af4f667fb8b6575ba38ba5fb00b3b5068306e59fe
@@ -21710,6 +21936,28 @@ __metadata:
     "@types/unist": ^3.0.0
     vfile-message: ^4.0.0
   checksum: 152b6729be1af70df723efb65c1a1170fd483d41086557da3651eea69a1dd1f0c22ea4344834d56d30734b9185bcab63e22edc81d3f0e9bed8aa4660d61080af
+  languageName: node
+  linkType: hard
+
+"victory-vendor@npm:^36.6.8":
+  version: 36.9.2
+  resolution: "victory-vendor@npm:36.9.2"
+  dependencies:
+    "@types/d3-array": ^3.0.3
+    "@types/d3-ease": ^3.0.0
+    "@types/d3-interpolate": ^3.0.1
+    "@types/d3-scale": ^4.0.2
+    "@types/d3-shape": ^3.1.0
+    "@types/d3-time": ^3.0.0
+    "@types/d3-timer": ^3.0.0
+    d3-array: ^3.1.6
+    d3-ease: ^3.0.1
+    d3-interpolate: ^3.0.1
+    d3-scale: ^4.0.2
+    d3-shape: ^3.1.0
+    d3-time: ^3.0.0
+    d3-timer: ^3.0.1
+  checksum: a755110e287b700202d08ac81982093ab100edaa9d61beef1476d59e9705605bd8299a3aa41fa04b933a12bd66737f4c8f7d18448dd6488c69d4f72480023a2e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Merge pull request #1073 from eduhub-org/bugfix/sort-slider-course-by-updated-at
- Merge pull request #1072 from eduhub-org/issue1063/AchievementOption---InsertAnAchievementOption-does-not-save-the-AchievementTemplate-when-inserting-a-new-record
- reverts slider sorting back to applicationEnd
- fixes missing insertion of data.achievementDocumentationTemplateId for a new AchievementOption
- Merge pull request #1070 from eduhub-org/bugfix/sort-slider-course-by-updated-at
- changes order of tile slider courses on homepage from application_end to updated_at
- Merge pull request #1064 from eduhub-org/chore/update-package-dependencies
- temporarily downgraded graphql to 5.8.0 for compatibility with deprecated apollo cli
- updates yarn.lock
- reintroduces package updates
- reapply all mui 6 changes again
- Reapply changes from material ui 6 update and additional fixes
- removes duplicate dependencies in yarn.lock to fix dependabot issues
- replaces dnd library to fix error. Other fixes to make build process work again