### PR TITLE
sets user table email field to unique

### DIFF
--- a/backend/metadata/databases/default/tables/public_User.yaml
+++ b/backend/metadata/databases/default/tables/public_User.yaml
@@ -2,9 +2,6 @@ table:
   name: User
   schema: public
 object_relationships:
-  - name: Organization
-    using:
-      foreign_key_constraint_on: organizationId
   - name: UserStatus
     using:
       foreign_key_constraint_on: status
@@ -83,7 +80,6 @@ select_permissions:
         - firstName
         - id
         - lastName
-        - organizationId
         - otherUniversity
         - picture
         - university
@@ -138,7 +134,6 @@ update_permissions:
         - lastName
         - matriculationNumber
         - newsletterRegistration
-        - organizationId
         - otherUniversity
         - picture
         - university
@@ -146,21 +141,3 @@ update_permissions:
         id:
           _eq: X-Hasura-User-Id
       check: null
-event_triggers:
-  - name: update_keycloak_user
-    definition:
-      enable_manual: false
-      update:
-        columns:
-          - firstName
-          - lastName
-    retry_conf:
-      interval_sec: 10
-      num_retries: 5
-      timeout_sec: 60
-    webhook: '{{CLOUD_FUNCTION_LINK_CALL_NODE_FUNCTION}}'
-    headers:
-      - name: secret
-        value_from_env: HASURA_CLOUD_FUNCTION_SECRET
-      - name: name
-        value: updateKeycloakUser

--- a/backend/metadata/databases/default/tables/tables.yaml
+++ b/backend/metadata/databases/default/tables/tables.yaml
@@ -31,8 +31,6 @@
 - "!include public_MailStatus.yaml"
 - "!include public_MailTemplate.yaml"
 - "!include public_MotivationRating.yaml"
-- "!include public_Organization.yaml"
-- "!include public_OrganizationType.yaml"
 - "!include public_Program.yaml"
 - "!include public_Session.yaml"
 - "!include public_SessionAddress.yaml"

--- a/backend/migrations/default/1729590148483_alter_table_public_User_alter_column_email/down.sql
+++ b/backend/migrations/default/1729590148483_alter_table_public_User_alter_column_email/down.sql
@@ -1,0 +1,1 @@
+alter table "public"."User" drop constraint "User_email_key";

--- a/backend/migrations/default/1729590148483_alter_table_public_User_alter_column_email/up.sql
+++ b/backend/migrations/default/1729590148483_alter_table_public_User_alter_column_email/up.sql
@@ -1,0 +1,1 @@
+alter table "public"."User" add constraint "User_email_key" unique ("email");


### PR DESCRIPTION
- Merge pull request #1110 from eduhub-org/dependabot/npm_and_yarn/functions/updateFromKeycloak/node-fetch-2.6.7
- Merge pull request #1114 from eduhub-org/dependabot/npm_and_yarn/functions/callPythonFunction/body-parser-1.20.3
- Merge pull request #1115 from eduhub-org/dependabot/npm_and_yarn/functions/sendQuestionaires/body-parser-1.20.3
- Merge pull request #1097 from eduhub-org/dependabot/npm_and_yarn/frontend-nx/next-14.2.10
- Merge pull request #1120 from eduhub-org/issue1118/Unify-input-fields-by-providing-a-prop-for-the-design
- removes hook error
- removes direct path
- removes usage of old text field editor component adds snackbar when text field is saved to backend
- creates unified text field editor component replaced the currently use ones in manage organizations
- chore(deps): bump body-parser in /functions/sendQuestionaires
- chore(deps): bump body-parser in /functions/callPythonFunction
- chore(deps): bump node-fetch in /functions/updateFromKeycloak
- chore(deps): bump next from 14.2.7 to 14.2.10 in /frontend-nx