### PR TITLE
Issue1118/Unify-input-fields-by-providing-a-prop-for-the-design

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/AddParticipantsForm.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/AddParticipantsForm.tsx
@@ -79,8 +79,7 @@ export const AddParticipantsForm: FC<AddParticipantsFormProps> = ({ courseId, on
   return (
     <form onSubmit={handleSubmit} className="bg-white shadow-lg rounded-lg p-6 w-[400px] h-[400px]">
       <TagSelector
-        variant="eduhub" // or "material" depending on your design
-        immediateUpdate={false}
+        variant="material"
         label={t('selected_users')}
         placeholder={t('name_or_email')}
         itemId={0}

--- a/frontend-nx/apps/edu-hub/components/pages/StatisticsContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/StatisticsContent/index.tsx
@@ -236,7 +236,6 @@ const StatisticsContent: FC = () => {
                 onValueUpdated={handleProgramChange}
                 refetchQueries={[]}
                 className="text-gray-800"
-                immediateUpdate={false}
               />
             </div>
             {renderCharts()}


### PR DESCRIPTION
- Merge pull request #1125 from eduhub-org/chore/fix-user-email-column-unique
- makes email column in user table unique
- Merge pull request #1124 from eduhub-org/revert-1121-chore/set-user-email-field-to-unique
- Revert "sets user table email field to unique"
- Merge pull request #1123 from eduhub-org/dependabot/npm_and_yarn/frontend-nx/http-proxy-middleware-2.0.7
- Merge pull request #1122 from eduhub-org/issue1118/Unify-input-fields-by-providing-a-prop-for-the-design
- removes another conditional hook and somw warnins
- removes conditional hooks
- renames forms folder to inputs
- adds funcitionality to tag selecor and input filed to be used without immeditae update (e.g. in a form) moves RadioButtonSelector
- Merge pull request #1121 from eduhub-org/chore/set-user-email-field-to-unique
- chore(deps): bump http-proxy-middleware in /frontend-nx
- removes lexical declaration in case block
- add improved props for creatableTabSelector component
- adds improved tag selector component
- Merge pull request #1110 from eduhub-org/dependabot/npm_and_yarn/functions/updateFromKeycloak/node-fetch-2.6.7
- Merge pull request #1114 from eduhub-org/dependabot/npm_and_yarn/functions/callPythonFunction/body-parser-1.20.3
- Merge pull request #1115 from eduhub-org/dependabot/npm_and_yarn/functions/sendQuestionaires/body-parser-1.20.3
- Merge pull request #1097 from eduhub-org/dependabot/npm_and_yarn/frontend-nx/next-14.2.10
- sets user table email field to unique
- updates the dropdown selector and optimizes various props
- renames TextFieldEditor to InputField
- optimizes TextFieldEditor componnt exports definition of snackbar notification
- improves InputFieldEditor component
- adds unified file uploader and unified time picker component
- adds unified dropdown textfieldeditor and time picker and removes old versions
- changes eduHub variant to eduhub add unified dropdown component
- adds snackbar to material variant
- Merge pull request #1120 from eduhub-org/issue1118/Unify-input-fields-by-providing-a-prop-for-the-design
- removes hook error
- removes direct path
- removes usage of old text field editor component adds snackbar when text field is saved to backend
- creates unified text field editor component replaced the currently use ones in manage organizations
- chore(deps): bump body-parser in /functions/sendQuestionaires
- chore(deps): bump body-parser in /functions/callPythonFunction
- chore(deps): bump node-fetch in /functions/updateFromKeycloak
- chore(deps): bump next from 14.2.7 to 14.2.10 in /frontend-nx