### PR TITLE
Issue1128/re organize profile view and add input field for the users organization

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/AchievementRecord/UploadAchievementRecordModal/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/AchievementRecord/UploadAchievementRecordModal/index.tsx
@@ -276,15 +276,17 @@ const UploadAchievementRecordModal: FC<IProps> = ({
   return (
     <>
       <Modal isOpen={isOpen} onClose={onClose} maxWidth="xl" title={t('course-page:upload_achievement_record')}>
-        <div className="flex flex-col space-y-5 w-full pb-5">
-          <div onClick={onAchievementOptionDropdown}>
-            <Button>{`${t('course-page:choose-achievement-option')} ↓`}</Button>
+        <div className="flex flex-col space-y-5 w-full p-4 sm:p-5">
+          <div className="w-full sm:w-auto">
+            <div onClick={onAchievementOptionDropdown}>
+              <Button>{`${t('course-page:choose-achievement-option')} ↓`}</Button>
+            </div>
           </div>
 
           {selectedAchievementOption && (
-            <div>
+            <div className="w-full">
               <div className="text-lg mb-6">
-                {t('course-page:selected_achievement_option')}:<br></br>
+                {t('course-page:selected_achievement_option')}:<br />
                 {selectedAchievementOption.title}
               </div>
               {selectedAchievementOption.AchievementOptionTemplate && (
@@ -300,14 +302,15 @@ const UploadAchievementRecordModal: FC<IProps> = ({
               )}
             </div>
           )}
-          <form onSubmit={save} className="flex flex-col space-y-5 mx-10">
-            <div className="flex flex-row gap-6">
-              <p className="w-2/6">{t('authors')}:</p>
-              <div className="w-4/6 flex flex-row">
+
+          <form onSubmit={save} className="flex flex-col space-y-5 mx-2 sm:mx-4 md:mx-6 lg:mx-8">
+            <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
+              <p className="w-full sm:w-2/6">{t('authors')}:</p>
+              <div className="w-full sm:w-4/6 flex flex-col sm:flex-row">
                 <div className="items-center pt-1 pr-3">
                   <MdAddCircleOutline className="cursor-pointer" onClick={makeAuthorListVisible} size="1.4em" />
                 </div>
-                <div className="grid grid-cols-2 gap-6">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6 w-full">
                   {state.authors.map((user, index) => (
                     <EhTagStingId
                       key={`record-authors-${index}`}
@@ -319,9 +322,10 @@ const UploadAchievementRecordModal: FC<IProps> = ({
                 </div>
               </div>
             </div>
-            <div className="flex flex-row gap-6">
-              <p className="w-2/6">{t('documentation')}:</p>
-              <div className="w-4/6">
+
+            <div className="flex flex-col sm:flex-row gap-4 sm:gap-6">
+              <p className="w-full sm:w-2/6">{t('documentation')}:</p>
+              <div className="w-full sm:w-4/6">
                 <UploadUI
                   onFileSelected={onFileChange}
                   acceptedFileTypes=""
@@ -331,11 +335,13 @@ const UploadAchievementRecordModal: FC<IProps> = ({
                 />
               </div>
             </div>
+
             <div className="text-xs italic text-right">{t('course:maxFileSize')}</div>
             <div className="flex justify-center items-center">
-              <Button>{isLoading ? <CircularProgress></CircularProgress> : t('upload')}</Button>
+              <Button>{isLoading ? <CircularProgress /> : t('upload')}</Button>
             </div>
           </form>
+
           {isVisibleAchievementOptions && (
             <AchievementOptionDropDown
               anchorElement={archiveOptionsAnchorElement}
@@ -355,7 +361,6 @@ const UploadAchievementRecordModal: FC<IProps> = ({
           )}
         </div>
       </Modal>
-      {/* Error Message Dialog */}
       {error && <ErrorMessageDialog errorMessage={error} open={!!error} onClose={resetError} />}
     </>
   );

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Sessions.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Sessions.tsx
@@ -37,22 +37,22 @@ export const Sessions: FC<SessionsProps> = ({ sessions, isLoggedInParticipant })
       {visibleSessions.length > 0 && (
         <>
           <span className="text-3xl font-semibold mt-24">{t('course_sessions')}</span>
-          <ul>
+          <ul className="max-w-2xl">
             {visibleSessions.map(({ startDateTime, endDateTime, title, SessionSpeakers, SessionAddresses }, index) => (
               <li key={index} className="flex mb-4">
                 <div className="flex flex-wrap items-start flex-shrink-0 mb-2">
                   <div className="flex flex-col mr-6">
                     <span className="block text-sm sm:text-lg font-semibold">{displayDate(startDateTime)}</span>
-                    <span className="text-sm">
+                    <span className="text-sm whitespace-nowrap">
                       {formatTimeString(startDateTime)}
                       {' - '}
                       {formatTimeString(endDateTime)}
                     </span>
                   </div>
                 </div>
-                <div className="flex flex-col">
-                  <span className="block text-sm sm:text-lg whitespace-nowrap sm:whitespace-normal">{title}</span>
-                  <div className="whitespace-nowrap ml-0 pl-0">
+                <div className="flex flex-col flex-1">
+                  <span className="block text-sm sm:text-lg break-words">{title}</span>
+                  <div className="break-words">
                     {SessionAddresses.map(({ address, CourseLocation }, addressIndex) => {
                       // Debugging: Log CourseLocation and address for each SessionAddress
                       console.log(


### PR DESCRIPTION
- Merge pull request #1134 from eduhub-org/issue822/Deleting-Leistungsnachweise-is-not-possible
- Merge pull request #1135 from eduhub-org/issue1128/Re-organize-profile-view-and-add-input-field-for-the-users-organization
- fixes further error due to legacy email field
- removes error due to legacy email field
- fixes re-rendering after nboarding confirmation several fixes for the mobile layout
- updates onboarding to use the same components as in the profile page
- Merge branch 'issue1128/Re-organize-profile-view-and-add-input-field-for-the-users-organization' of github.com:eduhub-org/eduhub into issue1128/Re-organize-profile-view-and-add-input-field-for-the-users-organization
- fixes futher type error and unnecessary re-rendering warning updates seed data to include organization migration
- fixes type error and necessary re-rendering warning
- fixes type errors
- adds migration for university data adds filtering on aliases
- adds script for seed generation and updates seeds including user occupation
- adds remaining profile fields fixes some ui issues for the creatable component
- removes erroneoues profile page
- fixes visibility of material component
- Finishes implmentation of creatable dropdown component WIP: layout errors of material dropdown (not (input field not visible) and eduhub (tool tip mispositioned)
- enables cascading delete of AchievementOptionMentors when an AchievementRecord is deleted
- adds translation for occupation input adds eduhub style for creatable tag selector WIP: first insert of creatable tag selector for organization
- WIP: adds new occupation field to user table uses new standard inputs for profile page
- mend
- renames component file name to index