### PR TITLE
Bugfix where participant data is not exported correctly

### DIFF
--- a/functions/callPythonFunction/pythonFunctions/load_participation_data.py
+++ b/functions/callPythonFunction/pythonFunctions/load_participation_data.py
@@ -54,14 +54,16 @@ def load_participation_data(arguments):
         
         return {
             "success": True,
-            "link": url
+            "link": url,
+            "messageKey": "SUCCESS"
         }
 
     except Exception as e:
         logging.error(f"Error loading participation data: {str(e)}")
         return {
             "success": False,
-            "error": str(e)
+            "error": str(e),
+            "messageKey": "FAILURE"
         }
 
 


### PR DESCRIPTION
- Merge pull request #1299 from eduhub-org/bugfix/participant-data-csv-export-apolloerror
- Add messageKey to return dict in load_participation_data function