### PR TITLE
Fix invalid sql database instance settings

### DIFF
--- a/infrastructure/application/03_databases.tf
+++ b/infrastructure/application/03_databases.tf
@@ -16,7 +16,6 @@ resource "google_sql_database_instance" "default" {
     }
     backup_configuration {
       enabled                        = var.enable_db_backup
-      binary_log_enabled             = var.enable_db_backup
       start_time                     = "02:00"
       point_in_time_recovery_enabled = var.enable_db_backup
       backup_retention_settings {


### PR DESCRIPTION
Remove `binary_log_enabled` from PostgreSQL Cloud SQL instance to fix deployment error.

The `binary_log_enabled` setting is only valid for MySQL instances, but it was being applied to a PostgreSQL instance, causing a Terraform `Error 400: Invalid request: Binary log can only be enabled for MySQL instances.` Removing this attribute resolves the conflict.

---
<a href="https://cursor.com/background-agent?bcId=bc-edca3b96-78af-479c-a550-bc3d784acad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-edca3b96-78af-479c-a550-bc3d784acad6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database backup infrastructure configuration with refined binary logging settings in the backup configuration. All essential backup capabilities continue to function as designed and are fully operational, including automatic backups, retention policy management, point-in-time recovery options, and backup scheduling features. Database disaster recovery and data protection services remain unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->