### PR TITLE
fix(db): remove incorrectly created generic location addresses

### DIFF
--- a/backend/migrations/default/1762507503000_fix_generic_location_addresses/down.sql
+++ b/backend/migrations/default/1762507503000_fix_generic_location_addresses/down.sql
@@ -1,0 +1,18 @@
+-- Rollback: This migration cannot be fully rolled back as we don't know
+-- which generic addresses were incorrectly created vs. legitimately needed.
+-- The generic addresses that were deleted cannot be restored without
+-- knowing their original addresses.
+
+-- Note: The SessionAddress.locationAddressId values that were cleared
+-- cannot be restored without knowing which generic address they pointed to.
+-- This is acceptable as NULL is the correct value for SessionAddress records
+-- with NULL/empty addresses to use CourseLocation.defaultSessionAddressId as intended.
+
+DO $$
+BEGIN
+    RAISE NOTICE 'Rollback: This migration cannot be fully rolled back.';
+    RAISE NOTICE 'SessionAddress records with NULL/empty addresses should have locationAddressId = NULL';
+    RAISE NOTICE 'to use CourseLocation.defaultSessionAddressId as intended.';
+    RAISE NOTICE 'The deleted generic LocationAddress entries cannot be restored without their original data.';
+END $$;
+

--- a/backend/migrations/default/1762507503000_fix_generic_location_addresses/up.sql
+++ b/backend/migrations/default/1762507503000_fix_generic_location_addresses/up.sql
@@ -1,0 +1,72 @@
+-- Fix incorrectly created generic LocationAddress entries
+-- This migration corrects the issue where generic addresses were created for
+-- SessionAddress records that should remain NULL to use default addresses
+
+DO $$
+DECLARE
+    affected_session_addresses INTEGER;
+    generic_addresses_to_remove INTEGER;
+    generic_addresses_kept INTEGER;
+BEGIN
+    -- Step 1: Clear locationAddressId from SessionAddress records that have NULL/empty addresses
+    -- These should use CourseLocation.defaultSessionAddressId instead
+    UPDATE "public"."SessionAddress" sa
+    SET "locationAddressId" = NULL
+    WHERE sa."locationAddressId" IS NOT NULL
+      AND (sa."address" IS NULL OR sa."address" = '')
+      AND EXISTS (
+          SELECT 1 FROM "public"."LocationAddress" la
+          WHERE la.id = sa."locationAddressId"
+          AND la."shortLabel" = 'Generic Address'
+          AND la."description" = 'Generic address created during migration'
+      );
+    
+    GET DIAGNOSTICS affected_session_addresses = ROW_COUNT;
+    
+    -- Step 2: Count generic addresses that are no longer referenced
+    SELECT COUNT(*) INTO generic_addresses_to_remove
+    FROM "public"."LocationAddress" la
+    WHERE la."shortLabel" = 'Generic Address'
+      AND la."description" = 'Generic address created during migration'
+      AND NOT EXISTS (
+          SELECT 1 FROM "public"."SessionAddress" sa
+          WHERE sa."locationAddressId" = la.id
+      );
+    
+    -- Step 3: Count remaining generic addresses (those that are still referenced by addresses with content)
+    SELECT COUNT(*) INTO generic_addresses_kept
+    FROM "public"."LocationAddress" la
+    WHERE la."shortLabel" = 'Generic Address'
+      AND la."description" = 'Generic address created during migration'
+      AND EXISTS (
+          SELECT 1 FROM "public"."SessionAddress" sa
+          WHERE sa."locationAddressId" = la.id
+          AND sa."address" IS NOT NULL
+          AND sa."address" != ''
+      );
+    
+    -- Step 4: Remove generic addresses that are no longer referenced
+    -- These were incorrectly created for SessionAddress records with NULL/empty addresses
+    DELETE FROM "public"."LocationAddress" la
+    WHERE la."shortLabel" = 'Generic Address'
+      AND la."description" = 'Generic address created during migration'
+      AND NOT EXISTS (
+          SELECT 1 FROM "public"."SessionAddress" sa
+          WHERE sa."locationAddressId" = la.id
+      );
+    
+    RAISE NOTICE 'Fix migration completed:';
+    RAISE NOTICE '  SessionAddress records cleared (NULL/empty addresses): %', affected_session_addresses;
+    RAISE NOTICE '  Generic addresses removed (no longer referenced): %', generic_addresses_to_remove;
+    RAISE NOTICE '  Generic addresses kept (still referenced by addresses with content): %', generic_addresses_kept;
+    
+    -- Verify: Check if any SessionAddress with NULL/empty address still has locationAddressId
+    IF EXISTS (
+        SELECT 1 FROM "public"."SessionAddress" sa
+        WHERE sa."locationAddressId" IS NOT NULL
+          AND (sa."address" IS NULL OR sa."address" = '')
+    ) THEN
+        RAISE WARNING 'Warning: Some SessionAddress records with NULL/empty addresses still have locationAddressId set';
+    END IF;
+END $$;
+


### PR DESCRIPTION
Fix migration issue where generic LocationAddress entries were created for SessionAddress records with NULL/empty addresses. These records should remain with locationAddressId = NULL to use CourseLocation defaultSessionAddressId as intended.

- Clear locationAddressId from SessionAddress records with NULL/empty addresses
- Remove incorrectly created generic LocationAddress entries
- Preserve generic addresses that are legitimately referenced