### PR TITLE
refactor(certificates): improve LinkedIn sharing UX with single button and radio selection

### DIFF
--- a/backend/metadata/actions.graphql
+++ b/backend/metadata/actions.graphql
@@ -31,6 +31,12 @@ type Query {
 }
 
 type Query {
+  makeCertificatePublic(
+    certificatePath: String!
+  ): makeCertificatePublicOutput
+}
+
+type Query {
   loadParticipationData(
     programId: Int!
   ): LoadParticipationDataResult!
@@ -179,6 +185,13 @@ type Image {
 
 type getSignedUrlOutput {
   link: String!
+}
+
+type makeCertificatePublicOutput {
+  success: Boolean!
+  messageKey: String!
+  error: String
+  publicUrl: String
 }
 
 type DeleteUserResult {

--- a/backend/metadata/actions.graphql
+++ b/backend/metadata/actions.graphql
@@ -30,7 +30,7 @@ type Query {
   ): getSignedUrlOutput
 }
 
-type Query {
+type Mutation {
   makeCertificatePublic(
     certificatePath: String!
   ): makeCertificatePublicOutput

--- a/backend/metadata/actions.yaml
+++ b/backend/metadata/actions.yaml
@@ -62,7 +62,7 @@ actions:
     comment: Gets a signed url for a file in the Google Storage Bucket
   - name: makeCertificatePublic
     definition:
-      kind: ""
+      kind: synchronous
       handler: '{{CLOUD_FUNCTION_LINK_CALL_NODE_FUNCTION}}'
       headers:
         - name: secret

--- a/backend/metadata/actions.yaml
+++ b/backend/metadata/actions.yaml
@@ -60,6 +60,20 @@ actions:
     permissions:
       - role: user_access
     comment: Gets a signed url for a file in the Google Storage Bucket
+  - name: makeCertificatePublic
+    definition:
+      kind: ""
+      handler: '{{CLOUD_FUNCTION_LINK_CALL_NODE_FUNCTION}}'
+      headers:
+        - name: secret
+          value_from_env: HASURA_CLOUD_FUNCTION_SECRET
+        - name: bucket
+          value_from_env: HASURA_BUCKET
+        - name: name
+          value: makeCertificatePublic
+    permissions:
+      - role: user_access
+    comment: Makes a certificate file public in storage bucket for LinkedIn sharing
   - name: loadParticipationData
     definition:
       kind: ""

--- a/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
@@ -6,7 +6,7 @@ import { useRoleQuery } from '../../hooks/authedQuery';
 import { useRoleMutation } from '../../hooks/authedMutation';
 import { GET_SIGNED_URL, MAKE_CERTIFICATE_PUBLIC } from '../../queries/actions';
 import { GetSignedUrl, GetSignedUrlVariables } from '../../queries/__generated__/GetSignedUrl';
-// import { MakeCertificatePublic, MakeCertificatePublicVariables } from '../../queries/__generated__/MakeCertificatePublic';
+import { MakeCertificatePublic, MakeCertificatePublicVariables } from '../../queries/__generated__/MakeCertificatePublic';
 import { Button } from './Button';
 import { LinkedInSharingDialog } from './dialogs/LinkedInSharingDialog';
 import { ErrorMessageDialog } from './dialogs/ErrorMessageDialog';
@@ -48,7 +48,7 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
   });
 
   // Mutation for making certificate public
-  const [makeCertificatePublic, { loading: makingPublic }] = useRoleMutation<any, { certificatePath: string }>(
+  const [makeCertificatePublic, { loading: makingPublic }] = useRoleMutation<MakeCertificatePublic, MakeCertificatePublicVariables>(
     MAKE_CERTIFICATE_PUBLIC
   );
 

--- a/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
@@ -1,0 +1,188 @@
+import React, { FC, useState } from 'react';
+import useTranslation from 'next-translate/useTranslation';
+import { School as SchoolIcon, Event as EventIcon } from '@mui/icons-material';
+import { TileBase } from './TileSlider/TileBase';
+import { useRoleQuery, useLazyRoleQuery } from '../../hooks/authedQuery';
+import { GET_SIGNED_URL, MAKE_CERTIFICATE_PUBLIC } from '../../queries/actions';
+import { GetSignedUrl, GetSignedUrlVariables } from '../../queries/__generated__/GetSignedUrl';
+import { MakeCertificatePublic, MakeCertificatePublicVariables } from '../../queries/__generated__/MakeCertificatePublic';
+import { Button } from './Button';
+import { LinkedInSharingDialog } from './dialogs/LinkedInSharingDialog';
+import { ErrorMessageDialog } from './dialogs/ErrorMessageDialog';
+import { MyCertificates_CourseEnrollment } from '../../queries/__generated__/MyCertificates';
+
+interface CertificateTileProps {
+  enrollment: MyCertificates_CourseEnrollment;
+}
+
+export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
+  const { t } = useTranslation('certificates');
+  const [linkedInDialogOpen, setLinkedInDialogOpen] = useState(false);
+  const [selectedCertificateType, setSelectedCertificateType] = useState<'achievement' | 'attendance' | null>(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  const course = enrollment.Course;
+  const program = course?.Program;
+
+  // Query for achievement certificate URL
+  const { data: achievementData, loading: achievementLoading } = useRoleQuery<
+    GetSignedUrl,
+    GetSignedUrlVariables
+  >(GET_SIGNED_URL, {
+    variables: {
+      path: enrollment.achievementCertificateURL || '',
+    },
+    skip: !enrollment.achievementCertificateURL,
+  });
+
+  // Query for attendance certificate URL
+  const { data: attendanceData, loading: attendanceLoading } = useRoleQuery<
+    GetSignedUrl,
+    GetSignedUrlVariables
+  >(GET_SIGNED_URL, {
+    variables: {
+      path: enrollment.attendanceCertificateURL || '',
+    },
+    skip: !enrollment.attendanceCertificateURL,
+  });
+
+  // Lazy query for making certificate public
+  const [makeCertificatePublic, { loading: makingPublic }] = useLazyRoleQuery<
+    MakeCertificatePublic,
+    MakeCertificatePublicVariables
+  >(MAKE_CERTIFICATE_PUBLIC);
+
+  const handleCertificateClick = (type: 'achievement' | 'attendance') => {
+    const url = type === 'achievement' 
+      ? achievementData?.getSignedUrl?.link 
+      : attendanceData?.getSignedUrl?.link;
+    
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
+  };
+
+  const handleLinkedInClick = (type: 'achievement' | 'attendance') => {
+    setSelectedCertificateType(type);
+    setLinkedInDialogOpen(true);
+  };
+
+  const handleLinkedInConfirm = async () => {
+    if (!selectedCertificateType) return;
+
+    const certificatePath = selectedCertificateType === 'achievement'
+      ? enrollment.achievementCertificateURL
+      : enrollment.attendanceCertificateURL;
+
+    if (!certificatePath) {
+      setErrorMessage(t('errorMessages:certificate_not_found', {}, { fallback: 'Certificate not found' }));
+      setLinkedInDialogOpen(false);
+      return;
+    }
+
+    try {
+      const result = await makeCertificatePublic({
+        variables: { certificatePath },
+      });
+
+      if (result?.data?.makeCertificatePublic?.success && result?.data?.makeCertificatePublic?.publicUrl) {
+        const publicUrl = result.data.makeCertificatePublic.publicUrl;
+        const linkedInUrl = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(publicUrl)}`;
+        window.open(linkedInUrl, '_blank', 'noopener,noreferrer');
+      } else {
+        setErrorMessage(result?.data?.makeCertificatePublic?.error || t('errorMessages:linkedin_share_error', {}, { fallback: 'Failed to share certificate on LinkedIn' }));
+      }
+    } catch (error) {
+      setErrorMessage(t('errorMessages:linkedin_share_error', {}, { fallback: 'Failed to share certificate on LinkedIn' }));
+    } finally {
+      setLinkedInDialogOpen(false);
+      setSelectedCertificateType(null);
+    }
+  };
+
+  const hasAchievement = !!enrollment.achievementCertificateURL;
+  const hasAttendance = !!enrollment.attendanceCertificateURL;
+
+  return (
+    <>
+      <TileBase
+        coverImage={course?.coverImage || null}
+        title={course?.title || ''}
+      >
+        <div className="flex flex-col h-full justify-between">
+          <div className="flex flex-col gap-3">
+            {/* Certificate Icons */}
+            <div className="flex gap-4 items-center">
+              {hasAchievement && (
+                <button
+                  onClick={() => handleCertificateClick('achievement')}
+                  className="flex items-center gap-2 p-2 rounded-lg hover:bg-gray-100 transition-colors"
+                  title={t('achievement_certificate')}
+                  disabled={achievementLoading}
+                >
+                  <SchoolIcon className="text-edu-black" fontSize="large" />
+                </button>
+              )}
+              {hasAttendance && (
+                <button
+                  onClick={() => handleCertificateClick('attendance')}
+                  className="flex items-center gap-2 p-2 rounded-lg hover:bg-gray-100 transition-colors"
+                  title={t('attendance_certificate')}
+                  disabled={attendanceLoading}
+                >
+                  <EventIcon className="text-edu-black" fontSize="large" />
+                </button>
+              )}
+            </div>
+
+            {/* LinkedIn Share Buttons */}
+            {hasAchievement && (
+              <Button
+                filled
+                onClick={() => handleLinkedInClick('achievement')}
+                disabled={makingPublic}
+                className="text-sm"
+              >
+                {t('share_on_linkedin')} - {t('achievement_certificate')}
+              </Button>
+            )}
+            {hasAttendance && (
+              <Button
+                filled
+                onClick={() => handleLinkedInClick('attendance')}
+                disabled={makingPublic}
+                className="text-sm"
+              >
+                {t('share_on_linkedin')} - {t('attendance_certificate')}
+              </Button>
+            )}
+          </div>
+
+          {/* Program Title at bottom */}
+          {program && (
+            <div className="text-xs tracking-wider mt-auto">
+              {!program.published && program.title}
+            </div>
+          )}
+        </div>
+      </TileBase>
+
+      <LinkedInSharingDialog
+        open={linkedInDialogOpen}
+        onClose={() => {
+          setLinkedInDialogOpen(false);
+          setSelectedCertificateType(null);
+        }}
+        onConfirm={handleLinkedInConfirm}
+      />
+
+      {errorMessage && (
+        <ErrorMessageDialog
+          errorMessage={errorMessage}
+          open={!!errorMessage}
+          onClose={() => setErrorMessage('')}
+        />
+      )}
+    </>
+  );
+};

--- a/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
@@ -1,11 +1,12 @@
 import React, { FC, useState } from 'react';
 import useTranslation from 'next-translate/useTranslation';
-import { School as SchoolIcon, Event as EventIcon } from '@mui/icons-material';
+import { GetApp } from '@mui/icons-material';
 import { TileBase } from './TileSlider/TileBase';
-import { useRoleQuery, useLazyRoleQuery } from '../../hooks/authedQuery';
+import { useRoleQuery } from '../../hooks/authedQuery';
+import { useRoleMutation } from '../../hooks/authedMutation';
 import { GET_SIGNED_URL, MAKE_CERTIFICATE_PUBLIC } from '../../queries/actions';
 import { GetSignedUrl, GetSignedUrlVariables } from '../../queries/__generated__/GetSignedUrl';
-import { MakeCertificatePublic, MakeCertificatePublicVariables } from '../../queries/__generated__/MakeCertificatePublic';
+// import { MakeCertificatePublic, MakeCertificatePublicVariables } from '../../queries/__generated__/MakeCertificatePublic';
 import { Button } from './Button';
 import { LinkedInSharingDialog } from './dialogs/LinkedInSharingDialog';
 import { ErrorMessageDialog } from './dialogs/ErrorMessageDialog';
@@ -17,8 +18,8 @@ interface CertificateTileProps {
 
 export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
   const { t } = useTranslation('certificates');
+  const { t: tCommon } = useTranslation('common');
   const [linkedInDialogOpen, setLinkedInDialogOpen] = useState(false);
-  const [selectedCertificateType, setSelectedCertificateType] = useState<'achievement' | 'attendance' | null>(null);
   const [errorMessage, setErrorMessage] = useState('');
 
   const course = enrollment.Course;
@@ -46,11 +47,10 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
     skip: !enrollment.attendanceCertificateURL,
   });
 
-  // Lazy query for making certificate public
-  const [makeCertificatePublic, { loading: makingPublic }] = useLazyRoleQuery<
-    MakeCertificatePublic,
-    MakeCertificatePublicVariables
-  >(MAKE_CERTIFICATE_PUBLIC);
+  // Mutation for making certificate public
+  const [makeCertificatePublic, { loading: makingPublic }] = useRoleMutation<any, { certificatePath: string }>(
+    MAKE_CERTIFICATE_PUBLIC
+  );
 
   const handleCertificateClick = (type: 'achievement' | 'attendance') => {
     const url = type === 'achievement' 
@@ -62,15 +62,12 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
     }
   };
 
-  const handleLinkedInClick = (type: 'achievement' | 'attendance') => {
-    setSelectedCertificateType(type);
+  const handleLinkedInClick = () => {
     setLinkedInDialogOpen(true);
   };
 
-  const handleLinkedInConfirm = async () => {
-    if (!selectedCertificateType) return;
-
-    const certificatePath = selectedCertificateType === 'achievement'
+  const handleLinkedInConfirm = async (selectedType: 'achievement' | 'attendance') => {
+    const certificatePath = selectedType === 'achievement'
       ? enrollment.achievementCertificateURL
       : enrollment.attendanceCertificateURL;
 
@@ -92,16 +89,17 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
       } else {
         setErrorMessage(result?.data?.makeCertificatePublic?.error || t('errorMessages:linkedin_share_error', {}, { fallback: 'Failed to share certificate on LinkedIn' }));
       }
-    } catch (error) {
-      setErrorMessage(t('errorMessages:linkedin_share_error', {}, { fallback: 'Failed to share certificate on LinkedIn' }));
+    } catch (error: any) {
+      console.error('LinkedIn share error:', error);
+      setErrorMessage(error?.message || t('errorMessages:linkedin_share_error', {}, { fallback: 'Failed to share certificate on LinkedIn' }));
     } finally {
       setLinkedInDialogOpen(false);
-      setSelectedCertificateType(null);
     }
   };
 
   const hasAchievement = !!enrollment.achievementCertificateURL;
   const hasAttendance = !!enrollment.attendanceCertificateURL;
+  const hasAnyCertificate = hasAchievement || hasAttendance;
 
   return (
     <>
@@ -111,57 +109,46 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
       >
         <div className="flex flex-col h-full justify-between">
           <div className="flex flex-col gap-3">
-            {/* Certificate Icons */}
-            <div className="flex gap-4 items-center">
-              {hasAchievement && (
-                <button
-                  onClick={() => handleCertificateClick('achievement')}
-                  className="flex items-center gap-2 p-2 rounded-lg hover:bg-gray-100 transition-colors"
-                  title={t('achievement_certificate')}
-                  disabled={achievementLoading}
-                >
-                  <SchoolIcon className="text-edu-black" fontSize="large" />
-                </button>
-              )}
-              {hasAttendance && (
-                <button
-                  onClick={() => handleCertificateClick('attendance')}
-                  className="flex items-center gap-2 p-2 rounded-lg hover:bg-gray-100 transition-colors"
-                  title={t('attendance_certificate')}
-                  disabled={attendanceLoading}
-                >
-                  <EventIcon className="text-edu-black" fontSize="large" />
-                </button>
-              )}
-            </div>
-
-            {/* LinkedIn Share Buttons */}
+            {/* Download Certificate Buttons */}
             {hasAchievement && (
               <Button
                 filled
-                onClick={() => handleLinkedInClick('achievement')}
-                disabled={makingPublic}
-                className="text-sm"
+                onClick={() => handleCertificateClick('achievement')}
+                disabled={achievementLoading}
+                className="flex items-center justify-center gap-2 text-sm py-2 px-3"
               >
-                {t('share_on_linkedin')} - {t('achievement_certificate')}
+                <GetApp fontSize="small" />
+                {t('achievement_certificate')}
               </Button>
             )}
             {hasAttendance && (
               <Button
                 filled
-                onClick={() => handleLinkedInClick('attendance')}
-                disabled={makingPublic}
-                className="text-sm"
+                onClick={() => handleCertificateClick('attendance')}
+                disabled={attendanceLoading}
+                className="flex items-center justify-center gap-2 text-sm py-2 px-3"
               >
-                {t('share_on_linkedin')} - {t('attendance_certificate')}
+                <GetApp fontSize="small" />
+                {t('attendance_certificate')}
+              </Button>
+            )}
+
+            {/* Single LinkedIn Share Button */}
+            {hasAnyCertificate && (
+              <Button
+                onClick={handleLinkedInClick}
+                disabled={makingPublic}
+                className="text-xs py-1 px-2"
+              >
+                {t('share_on_linkedin')}
               </Button>
             )}
           </div>
 
           {/* Program Title at bottom */}
-          {program && (
-            <div className="text-xs tracking-wider mt-auto">
-              {!program.published && program.title}
+          {program && program.title && (
+            <div className="text-xs tracking-wider mt-auto text-right">
+              {program.title}
             </div>
           )}
         </div>
@@ -171,9 +158,10 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
         open={linkedInDialogOpen}
         onClose={() => {
           setLinkedInDialogOpen(false);
-          setSelectedCertificateType(null);
         }}
         onConfirm={handleLinkedInConfirm}
+        hasAchievement={hasAchievement}
+        hasAttendance={hasAttendance}
       />
 
       {errorMessage && (

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/Tile.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/Tile.tsx
@@ -1,16 +1,16 @@
 import Image from 'next/image';
 import Link from 'next/link';
-import { FC, useEffect, useState } from 'react';
+import { FC } from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import { CourseList_Course } from '../../../queries/__generated__/CourseList';
 import { CoursesEnrolledByUser_Course } from '../../../queries/__generated__/CoursesEnrolledByUser';
 import languageIcon from '../../../public/images/course/language.svg';
 import locationIcon from '../../../public/images/course/pin.svg';
-import { getTileImage } from '../../../helpers/imageHandling';
 import {
   useWeekdayStartAndEndString,
 } from '../../../helpers/dateTimeHelpers';
 import React from 'react';
+import { TileBase } from './TileBase';
 
 type CourseType = CourseList_Course | CoursesEnrolledByUser_Course;
 
@@ -23,61 +23,32 @@ export const Tile: FC<TileProps> = ({ course, isManage }) => {
   const { t } = useTranslation('common');
   const getWeekdayStartAndEndString = useWeekdayStartAndEndString();
 
-  // Needed for legacy reasons: For cases where the image in the optimal image size does not exist but only the original image size
-  const [coverImage, setCoverImage] = useState(null);
-  useEffect(() => {
-    const loadCoverImage = async () => {
-      const img = await getTileImage(course?.coverImage);
-      setCoverImage(img);
-    };
-    loadCoverImage();
-  }, [course]);
-
   return (
     <Link href={isManage ? `/manage/course/${course.id}` : `/course/${course.id}`}>
-      <div className="flex flex-col rounded-2xl overflow-hidden font-medium text-edu-black cursor-pointer">
-        <div className="relative h-[230px] flex justify-start items-end">
-          <div
-            className="absolute inset-0 bg-cover bg-center bg-no-repeat"
-            style={{
-              backgroundImage: `url("${coverImage}")`,
-            }}
-          ></div>
-          <div
-            className="absolute inset-0"
-            style={{
-              background: 'linear-gradient(51.32deg, rgba(0, 0, 0, 0.7) 17.57%, rgba(0, 0, 0, 0) 85.36%)',
-            }}
-          ></div>
-          <div className="absolute inset-0 flex justify-start items-end p-3">
-            <span className="text-3xl text-white">{course.title}</span>
+      <TileBase coverImage={course?.coverImage} title={course.title}>
+        <div className="flex justify-between mb-3 text-sm tracking-wider">
+          {course.weekDay !== 'NONE' && course.startTime && course.endTime
+            ? getWeekdayStartAndEndString(course, t)
+            : null}{' '}
+          <div className="flex items-center">
+            <Image src={languageIcon} alt="language icon" width={16} height={16} className="mr-1" />
+            {t(course.language)}
           </div>
         </div>
-        <div className="flex flex-col h-[201px] justify-between bg-white p-5">
-          <div className="flex justify-between mb-3 text-sm tracking-wider">
-            {course.weekDay !== 'NONE' && course.startTime && course.endTime
-              ? getWeekdayStartAndEndString(course, t)
-              : null}{' '}
-            <div className="flex items-center">
-              <Image src={languageIcon} alt="language icon" width={16} height={16} className="mr-1" />
-              {t(course.language)}
-            </div>
+        <span className="text-lg mb-auto line-clamp-3">{course.tagline}</span>
+        <div className="flex justify-between text-xs items-center tracking-wider">
+          <div className="flex uppercase">
+            <Image src={locationIcon} alt="location icon" width={12} height={12} className="mr-1" />
+            {course.CourseLocations.map((location, index) => (
+              <React.Fragment key={index}>
+                {location.locationOption}
+                {index < course.CourseLocations.length - 1 && ' + '}
+              </React.Fragment>
+            ))}
           </div>
-          <span className="text-lg mb-auto line-clamp-3">{course.tagline}</span>
-          <div className="flex justify-between text-xs items-center tracking-wider">
-            <div className="flex uppercase">
-              <Image src={locationIcon} alt="location icon" width={12} height={12} className="mr-1" />
-              {course.CourseLocations.map((location, index) => (
-                <React.Fragment key={index}>
-                  {location.locationOption}
-                  {index < course.CourseLocations.length - 1 && ' + '}
-                </React.Fragment>
-              ))}
-            </div>
-            {!course.Program.published && course.Program.title}
-          </div>
+          {!course.Program.published && course.Program.title}
         </div>
-      </div>
+      </TileBase>
     </Link>
   );
 };

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/TileBase.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/TileBase.tsx
@@ -1,0 +1,52 @@
+import Image from 'next/image';
+import { FC, useEffect, useState, ReactNode } from 'react';
+import { getTileImage } from '../../../helpers/imageHandling';
+
+interface TileBaseProps {
+  coverImage: string | null;
+  title: string;
+  children: ReactNode;
+  onClick?: () => void;
+  className?: string;
+}
+
+export const TileBase: FC<TileBaseProps> = ({ coverImage: coverImageProp, title, children, onClick, className = '' }) => {
+  const [coverImage, setCoverImage] = useState<string | null>(null);
+
+  useEffect(() => {
+    const loadCoverImage = async () => {
+      const img = await getTileImage(coverImageProp);
+      setCoverImage(img);
+    };
+    loadCoverImage();
+  }, [coverImageProp]);
+
+  return (
+    <div 
+      className={`flex flex-col rounded-2xl overflow-hidden font-medium text-edu-black ${onClick ? 'cursor-pointer' : ''} ${className}`}
+      onClick={onClick}
+    >
+      <div className="relative h-[230px] flex justify-start items-end">
+        <div
+          className="absolute inset-0 bg-cover bg-center bg-no-repeat"
+          style={{
+            backgroundImage: `url("${coverImage}")`,
+          }}
+        ></div>
+        <div
+          className="absolute inset-0"
+          style={{
+            background: 'linear-gradient(51.32deg, rgba(0, 0, 0, 0.7) 17.57%, rgba(0, 0, 0, 0) 85.36%)',
+          }}
+        ></div>
+        <div className="absolute inset-0 flex justify-start items-end p-3">
+          <span className="text-3xl text-white">{title}</span>
+        </div>
+      </div>
+      <div className="flex flex-col h-[201px] justify-between bg-white p-5">
+        {children}
+      </div>
+    </div>
+  );
+};
+

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/TileBase.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/TileBase.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image';
-import { FC, useEffect, useState, ReactNode } from 'react';
+import { FC, useEffect, useState, ReactNode, memo } from 'react';
 import { getTileImage } from '../../../helpers/imageHandling';
 
 interface TileBaseProps {
@@ -10,15 +10,32 @@ interface TileBaseProps {
   className?: string;
 }
 
-export const TileBase: FC<TileBaseProps> = ({ coverImage: coverImageProp, title, children, onClick, className = '' }) => {
-  const [coverImage, setCoverImage] = useState<string | null>(null);
+const TileBaseComponent: FC<TileBaseProps> = ({ coverImage: coverImageProp, title, children, onClick, className = '' }) => {
+  // Initialize with placeholder immediately to prevent layout shifts
+  const [coverImage, setCoverImage] = useState<string>('https://picsum.photos/240/144');
 
   useEffect(() => {
+    let isMounted = true;
+    
     const loadCoverImage = async () => {
-      const img = await getTileImage(coverImageProp);
-      setCoverImage(img);
+      if (coverImageProp) {
+        try {
+          const img = await getTileImage(coverImageProp);
+          if (isMounted) {
+            setCoverImage(img);
+          }
+        } catch (error) {
+          // Keep placeholder on error
+          console.warn('Failed to load tile image:', error);
+        }
+      }
     };
+    
     loadCoverImage();
+    
+    return () => {
+      isMounted = false;
+    };
   }, [coverImageProp]);
 
   return (
@@ -49,4 +66,7 @@ export const TileBase: FC<TileBaseProps> = ({ coverImage: coverImageProp, title,
     </div>
   );
 };
+
+// Memoize to prevent unnecessary re-renders that could interfere with Swiper
+export const TileBase = memo(TileBaseComponent);
 

--- a/frontend-nx/apps/edu-hub/components/common/dialogs/LinkedInSharingDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/dialogs/LinkedInSharingDialog.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { QuestionConfirmationDialog } from './QuestionConfirmationDialog';
+import useTranslation from 'next-translate/useTranslation';
+
+interface LinkedInSharingDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  onCancel?: () => void;
+}
+
+export const LinkedInSharingDialog: React.FC<LinkedInSharingDialogProps> = ({
+  open,
+  onClose,
+  onConfirm,
+  onCancel,
+}) => {
+  const { t: tCertificates } = useTranslation('certificates');
+  const { t: tCommon } = useTranslation('common');
+
+  return (
+    <QuestionConfirmationDialog
+      open={open}
+      question={tCertificates('linkedin_sharing_warning')}
+      confirmationText={tCertificates('make_public_confirm')}
+      cancelText={tCommon('cancel')}
+      onClose={onClose}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
+  );
+};
+

--- a/frontend-nx/apps/edu-hub/components/common/dialogs/LinkedInSharingDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/dialogs/LinkedInSharingDialog.tsx
@@ -1,12 +1,14 @@
-import React from 'react';
-import { QuestionConfirmationDialog } from './QuestionConfirmationDialog';
+import React, { useState, useEffect } from 'react';
+import { BaseDialog } from './BaseDialog';
 import useTranslation from 'next-translate/useTranslation';
 
 interface LinkedInSharingDialogProps {
   open: boolean;
   onClose: () => void;
-  onConfirm: () => void;
+  onConfirm: (selectedType: 'achievement' | 'attendance') => void;
   onCancel?: () => void;
+  hasAchievement: boolean;
+  hasAttendance: boolean;
 }
 
 export const LinkedInSharingDialog: React.FC<LinkedInSharingDialogProps> = ({
@@ -14,20 +16,85 @@ export const LinkedInSharingDialog: React.FC<LinkedInSharingDialogProps> = ({
   onClose,
   onConfirm,
   onCancel,
+  hasAchievement,
+  hasAttendance,
 }) => {
   const { t: tCertificates } = useTranslation('certificates');
   const { t: tCommon } = useTranslation('common');
+  
+  // Single selection - default to achievement if available, otherwise attendance
+  const [selectedType, setSelectedType] = useState<'achievement' | 'attendance' | null>(null);
+
+  useEffect(() => {
+    // Reset selection when dialog opens - default to achievement if available, otherwise attendance
+    if (open) {
+      if (hasAchievement) {
+        setSelectedType('achievement');
+      } else if (hasAttendance) {
+        setSelectedType('attendance');
+      }
+    }
+  }, [open, hasAchievement, hasAttendance]);
+
+  const handleRadioChange = (type: 'achievement' | 'attendance') => {
+    setSelectedType(type);
+  };
+
+  const handleConfirm = () => {
+    if (selectedType) {
+      onConfirm(selectedType);
+    }
+  };
+
+  const showSelection = hasAchievement && hasAttendance;
 
   return (
-    <QuestionConfirmationDialog
+    <BaseDialog
       open={open}
-      question={tCertificates('linkedin_sharing_warning')}
-      confirmationText={tCertificates('make_public_confirm')}
-      cancelText={tCommon('cancel')}
       onClose={onClose}
-      onConfirm={onConfirm}
+      onConfirm={handleConfirm}
+      confirmText={tCertificates('make_public_confirm')}
       onCancel={onCancel}
-    />
+      cancelText={tCommon('cancel')}
+    >
+      <div className="flex flex-col gap-4">
+        <p>{tCertificates('linkedin_sharing_warning')}</p>
+        
+        {showSelection && (
+          <div className="flex flex-col gap-3 mt-2">
+            <p className="text-sm font-medium">{tCertificates('select_certificate_to_share')}</p>
+            <div className="flex flex-col gap-2">
+              {hasAchievement && (
+                <label className="flex items-center cursor-pointer">
+                  <input
+                    type="radio"
+                    name="certificate-type"
+                    value="achievement"
+                    checked={selectedType === 'achievement'}
+                    onChange={() => handleRadioChange('achievement')}
+                    className="mr-3 w-4 h-4 text-blue-600 focus:ring-blue-500"
+                  />
+                  <span className="text-sm">{tCertificates('achievement_certificate')}</span>
+                </label>
+              )}
+              {hasAttendance && (
+                <label className="flex items-center cursor-pointer">
+                  <input
+                    type="radio"
+                    name="certificate-type"
+                    value="attendance"
+                    checked={selectedType === 'attendance'}
+                    onChange={() => handleRadioChange('attendance')}
+                    className="mr-3 w-4 h-4 text-blue-600 focus:ring-blue-500"
+                  />
+                  <span className="text-sm">{tCertificates('attendance_certificate')}</span>
+                </label>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </BaseDialog>
   );
 };
 

--- a/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
+++ b/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
@@ -57,6 +57,12 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
         </Link>
       </MenuItem>
 
+      <MenuItem onClick={closeMenu}>
+        <Link className="w-full text-lg" href="/my-certificates">
+          {t('menu.my_certificates')}
+        </Link>
+      </MenuItem>
+
       {isAdmin && (
         <MenuItem onClick={closeMenu}>
           <Link className="w-full text-lg" href="/manage/courses">

--- a/frontend-nx/apps/edu-hub/components/pages/CertificatesContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CertificatesContent/index.tsx
@@ -1,4 +1,4 @@
-import { FC } from 'react';
+import React, { FC, useState, useEffect, ErrorInfo, ReactNode } from 'react';
 import { useSession } from 'next-auth/react';
 import useTranslation from 'next-translate/useTranslation';
 import { CircularProgress } from '@mui/material';
@@ -10,12 +10,34 @@ import { CertificateTile } from '../../common/CertificateTile';
 import { ErrorMessageDialog } from '../../common/dialogs/ErrorMessageDialog';
 import { Button } from '../../common/Button';
 import { PageBlock } from '../../common/PageBlock';
-import { useState } from 'react';
+
+class ErrorBoundary extends React.Component<{ children: ReactNode }, { hasError: boolean }> {
+  constructor(props: { children: ReactNode }) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Error caught by boundary:', error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <h1>Something went wrong. Please try again later.</h1>;
+    }
+
+    return this.props.children;
+  }
+}
 
 const CertificatesContent: FC = () => {
   const { t } = useTranslation('certificates');
   const { data: sessionData, status: sessionStatus } = useSession();
-  const [showError, setShowError] = useState(true);
+  const [showError, setShowError] = useState(false);
 
   const {
     data: certificatesData,
@@ -27,6 +49,12 @@ const CertificatesContent: FC = () => {
     },
     skip: !sessionData?.profile?.sub || sessionStatus === 'loading',
   });
+
+  useEffect(() => {
+    if (error) {
+      setShowError(true);
+    }
+  }, [error]);
 
   if (sessionStatus === 'loading' || loading) {
     return (
@@ -40,58 +68,54 @@ const CertificatesContent: FC = () => {
     return <div>{t('not_authenticated', {}, { fallback: 'Not authenticated' })}</div>;
   }
 
-  if (error) {
-    return (
-      <ErrorMessageDialog
-        errorMessage={error.message}
-        open={showError}
-        onClose={() => setShowError(false)}
-      />
-    );
-  }
-
   const enrollments = certificatesData?.CourseEnrollment || [];
 
-  if (enrollments.length === 0) {
-    return (
+  return (
+    <>
       <PageBlock>
         <div className="max-w-screen-xl mx-auto mt-20">
           <div className="flex flex-row mb-12 text-white">
             <h1 className="text-4xl font-bold mt-24">{t('title')}</h1>
           </div>
-          <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
-            <div className="max-w-2xl">
-              <p className="text-xl mb-4 text-white">{t('no_certificates_title')}</p>
-              <p className="text-lg mb-8 text-gray-300">{t('no_certificates_description')}</p>
-              <Link href="/">
-                <Button filled className="text-lg px-8 py-3">
-                  {t('browse_courses')}
-                </Button>
-              </Link>
+          {enrollments.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+              <div className="max-w-2xl">
+                <p className="text-xl mb-4 text-white">{t('no_certificates_title')}</p>
+                <p className="text-lg mb-8 text-gray-300">{t('no_certificates_description')}</p>
+                <Link href="/">
+                  <Button filled className="text-lg px-8 py-3">
+                    {t('browse_courses')}
+                  </Button>
+                </Link>
+              </div>
             </div>
-          </div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+              {enrollments.map((enrollment) => (
+                <div key={enrollment.id} className="w-full max-w-[325px]">
+                  <CertificateTile enrollment={enrollment} />
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </PageBlock>
-    );
-  }
-
-  return (
-    <PageBlock>
-      <div className="max-w-screen-xl mx-auto mt-20">
-        <div className="flex flex-row mb-12 text-white">
-          <h1 className="text-4xl font-bold mt-24">{t('title')}</h1>
-        </div>
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-          {enrollments.map((enrollment) => (
-            <div key={enrollment.id} className="w-full max-w-[325px]">
-              <CertificateTile enrollment={enrollment} />
-            </div>
-          ))}
-        </div>
-      </div>
-    </PageBlock>
+      {error && (
+        <ErrorMessageDialog
+          errorMessage={error.message}
+          open={showError}
+          onClose={() => setShowError(false)}
+        />
+      )}
+    </>
   );
 };
 
-export default CertificatesContent;
+const WrappedCertificatesContent: FC = () => (
+  <ErrorBoundary>
+    <CertificatesContent />
+  </ErrorBoundary>
+);
+
+export default WrappedCertificatesContent;
 

--- a/frontend-nx/apps/edu-hub/components/pages/CertificatesContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CertificatesContent/index.tsx
@@ -9,6 +9,7 @@ import { MyCertificates, MyCertificatesVariables } from '../../../queries/__gene
 import { CertificateTile } from '../../common/CertificateTile';
 import { ErrorMessageDialog } from '../../common/dialogs/ErrorMessageDialog';
 import { Button } from '../../common/Button';
+import { PageBlock } from '../../common/PageBlock';
 import { useState } from 'react';
 
 const CertificatesContent: FC = () => {
@@ -53,32 +54,42 @@ const CertificatesContent: FC = () => {
 
   if (enrollments.length === 0) {
     return (
-      <div className="px-3 mt-20 max-w-screen-xl mx-auto">
-        <h1 className="text-4xl font-bold mb-8">{t('title')}</h1>
-        <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
-          <div className="max-w-2xl">
-            <p className="text-xl mb-4 text-gray-700">{t('no_certificates_title')}</p>
-            <p className="text-lg mb-8 text-gray-600">{t('no_certificates_description')}</p>
-            <Link href="/">
-              <Button filled className="text-lg px-8 py-3">
-                {t('browse_courses')}
-              </Button>
-            </Link>
+      <PageBlock>
+        <div className="max-w-screen-xl mx-auto mt-20">
+          <div className="flex flex-row mb-12 text-white">
+            <h1 className="text-4xl font-bold mt-24">{t('title')}</h1>
+          </div>
+          <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+            <div className="max-w-2xl">
+              <p className="text-xl mb-4 text-white">{t('no_certificates_title')}</p>
+              <p className="text-lg mb-8 text-gray-300">{t('no_certificates_description')}</p>
+              <Link href="/">
+                <Button filled className="text-lg px-8 py-3">
+                  {t('browse_courses')}
+                </Button>
+              </Link>
+            </div>
           </div>
         </div>
-      </div>
+      </PageBlock>
     );
   }
 
   return (
-    <div className="px-3 mt-20 max-w-screen-xl mx-auto">
-      <h1 className="text-4xl font-bold mb-8">{t('title')}</h1>
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
-        {enrollments.map((enrollment) => (
-          <CertificateTile key={enrollment.id} enrollment={enrollment} />
-        ))}
+    <PageBlock>
+      <div className="max-w-screen-xl mx-auto mt-20">
+        <div className="flex flex-row mb-12 text-white">
+          <h1 className="text-4xl font-bold mt-24">{t('title')}</h1>
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          {enrollments.map((enrollment) => (
+            <div key={enrollment.id} className="w-full max-w-[325px]">
+              <CertificateTile enrollment={enrollment} />
+            </div>
+          ))}
+        </div>
       </div>
-    </div>
+    </PageBlock>
   );
 };
 

--- a/frontend-nx/apps/edu-hub/components/pages/CertificatesContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CertificatesContent/index.tsx
@@ -1,0 +1,86 @@
+import { FC } from 'react';
+import { useSession } from 'next-auth/react';
+import useTranslation from 'next-translate/useTranslation';
+import { CircularProgress } from '@mui/material';
+import Link from 'next/link';
+import { useRoleQuery } from '../../../hooks/authedQuery';
+import { MY_CERTIFICATES } from '../../../queries/myCertificates';
+import { MyCertificates, MyCertificatesVariables } from '../../../queries/__generated__/MyCertificates';
+import { CertificateTile } from '../../common/CertificateTile';
+import { ErrorMessageDialog } from '../../common/dialogs/ErrorMessageDialog';
+import { Button } from '../../common/Button';
+import { useState } from 'react';
+
+const CertificatesContent: FC = () => {
+  const { t } = useTranslation('certificates');
+  const { data: sessionData, status: sessionStatus } = useSession();
+  const [showError, setShowError] = useState(true);
+
+  const {
+    data: certificatesData,
+    loading,
+    error,
+  } = useRoleQuery<MyCertificates, MyCertificatesVariables>(MY_CERTIFICATES, {
+    variables: {
+      userId: sessionData?.profile?.sub || '',
+    },
+    skip: !sessionData?.profile?.sub || sessionStatus === 'loading',
+  });
+
+  if (sessionStatus === 'loading' || loading) {
+    return (
+      <div className="flex justify-center items-center min-h-[77vh]">
+        <CircularProgress />
+      </div>
+    );
+  }
+
+  if (!sessionData?.profile?.sub) {
+    return <div>{t('not_authenticated', {}, { fallback: 'Not authenticated' })}</div>;
+  }
+
+  if (error) {
+    return (
+      <ErrorMessageDialog
+        errorMessage={error.message}
+        open={showError}
+        onClose={() => setShowError(false)}
+      />
+    );
+  }
+
+  const enrollments = certificatesData?.CourseEnrollment || [];
+
+  if (enrollments.length === 0) {
+    return (
+      <div className="px-3 mt-20 max-w-screen-xl mx-auto">
+        <h1 className="text-4xl font-bold mb-8">{t('title')}</h1>
+        <div className="flex flex-col items-center justify-center py-16 px-4 text-center">
+          <div className="max-w-2xl">
+            <p className="text-xl mb-4 text-gray-700">{t('no_certificates_title')}</p>
+            <p className="text-lg mb-8 text-gray-600">{t('no_certificates_description')}</p>
+            <Link href="/">
+              <Button filled className="text-lg px-8 py-3">
+                {t('browse_courses')}
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-3 mt-20 max-w-screen-xl mx-auto">
+      <h1 className="text-4xl font-bold mb-8">{t('title')}</h1>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+        {enrollments.map((enrollment) => (
+          <CertificateTile key={enrollment.id} enrollment={enrollment} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default CertificatesContent;
+

--- a/frontend-nx/apps/edu-hub/i18n.json
+++ b/frontend-nx/apps/edu-hub/i18n.json
@@ -20,7 +20,8 @@
       "manageLocationAddresses",
       "manageEmailTemplates",
       "profile",
-      "start-page"
+      "start-page",
+      "certificates"
     ]
   },
   "defaultNS": "common"

--- a/frontend-nx/apps/edu-hub/locales/de/certificates.json
+++ b/frontend-nx/apps/edu-hub/locales/de/certificates.json
@@ -1,0 +1,18 @@
+{
+  "title": "Meine Zertifikate",
+  "no_certificates": "Du hast noch keine Zertifikate.",
+  "no_certificates_title": "Noch keine Zertifikate",
+  "no_certificates_description": "Du hast noch keine Zertifikate erhalten. Schließe Kurse ab und erreiche Deine Lernziele, um Zertifikate zu erhalten, die Deine Erfolge zeigen!",
+  "browse_courses": "Kurse durchsuchen",
+  "linkedin_sharing_warning": "Um Dein Zertifikat auf LinkedIn zu teilen, muss es öffentlich zugänglich gemacht werden. Das bedeutet, dass jeder mit dem Link Dein Zertifikat einsehen kann. Möchtest Du fortfahren?",
+  "make_public_confirm": "Öffentlich machen und teilen",
+  "share_on_linkedin": "Auf LinkedIn teilen",
+  "achievement_certificate": "Leistungsnachweis",
+  "attendance_certificate": "Teilnahmebescheinigung",
+  "not_authenticated": "Du musst angemeldet sein, um Deine Zertifikate anzusehen.",
+  "errorMessages": {
+    "certificate_not_found": "Zertifikat nicht gefunden",
+    "linkedin_share_error": "Zertifikat konnte nicht auf LinkedIn geteilt werden. Bitte versuche es später erneut."
+  }
+}
+

--- a/frontend-nx/apps/edu-hub/locales/de/certificates.json
+++ b/frontend-nx/apps/edu-hub/locales/de/certificates.json
@@ -5,6 +5,7 @@
   "no_certificates_description": "Du hast noch keine Zertifikate erhalten. Schließe Kurse ab und erreiche Deine Lernziele, um Zertifikate zu erhalten, die Deine Erfolge zeigen!",
   "browse_courses": "Kurse durchsuchen",
   "linkedin_sharing_warning": "Um Dein Zertifikat auf LinkedIn zu teilen, muss es öffentlich zugänglich gemacht werden. Das bedeutet, dass jeder mit dem Link Dein Zertifikat einsehen kann. Möchtest Du fortfahren?",
+  "select_certificate_to_share": "Wähle aus, welches Zertifikat Du teilen möchtest:",
   "make_public_confirm": "Öffentlich machen und teilen",
   "share_on_linkedin": "Auf LinkedIn teilen",
   "achievement_certificate": "Leistungsnachweis",

--- a/frontend-nx/apps/edu-hub/locales/de/common.json
+++ b/frontend-nx/apps/edu-hub/locales/de/common.json
@@ -35,6 +35,7 @@
   "end": "Ende",
   "menu": {
     "profile": "Mein Profil",
+    "my_certificates": "Meine Zertifikate",
     "faq": "FAQ",
     "user": "Benutzer",
     "courses": "Kurse",

--- a/frontend-nx/apps/edu-hub/locales/en/certificates.json
+++ b/frontend-nx/apps/edu-hub/locales/en/certificates.json
@@ -1,0 +1,18 @@
+{
+  "title": "My Certificates",
+  "no_certificates": "You don't have any certificates yet.",
+  "no_certificates_title": "No certificates yet",
+  "no_certificates_description": "You haven't received any certificates yet. Complete courses and achieve your learning goals to earn certificates that showcase your accomplishments!",
+  "browse_courses": "Browse Courses",
+  "linkedin_sharing_warning": "To share your certificate on LinkedIn, it needs to be made publicly accessible. This means anyone with the link will be able to view your certificate. Do you want to continue?",
+  "make_public_confirm": "Make Public and Share",
+  "share_on_linkedin": "Share on LinkedIn",
+  "achievement_certificate": "Achievement Certificate",
+  "attendance_certificate": "Attendance Certificate",
+  "not_authenticated": "You need to be logged in to view your certificates.",
+  "errorMessages": {
+    "certificate_not_found": "Certificate not found",
+    "linkedin_share_error": "Failed to share certificate on LinkedIn. Please try again later."
+  }
+}
+

--- a/frontend-nx/apps/edu-hub/locales/en/certificates.json
+++ b/frontend-nx/apps/edu-hub/locales/en/certificates.json
@@ -5,6 +5,7 @@
   "no_certificates_description": "You haven't received any certificates yet. Complete courses and achieve your learning goals to earn certificates that showcase your accomplishments!",
   "browse_courses": "Browse Courses",
   "linkedin_sharing_warning": "To share your certificate on LinkedIn, it needs to be made publicly accessible. This means anyone with the link will be able to view your certificate. Do you want to continue?",
+  "select_certificate_to_share": "Select which certificate to share:",
   "make_public_confirm": "Make Public and Share",
   "share_on_linkedin": "Share on LinkedIn",
   "achievement_certificate": "Achievement Certificate",

--- a/frontend-nx/apps/edu-hub/locales/en/common.json
+++ b/frontend-nx/apps/edu-hub/locales/en/common.json
@@ -35,6 +35,7 @@
   "end": "End",
   "menu": {
     "profile": "My Profile",
+    "my_certificates": "My Certificates",
     "faq": "FAQ",
     "user": "User",
     "courses": "Courses",

--- a/frontend-nx/apps/edu-hub/pages/my-certificates/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/my-certificates/index.tsx
@@ -1,10 +1,12 @@
 import Head from 'next/head';
 import { FC } from 'react';
+import useTranslation from 'next-translate/useTranslation';
 import { Page } from '../../components/layout/Page';
 import { useIsLoggedIn } from '../../hooks/authentication';
 import CertificatesContent from '../../components/pages/CertificatesContent';
 
 const MyCertificates: FC = () => {
+  const { t } = useTranslation('certificates');
   const isLoggedIn = useIsLoggedIn();
 
   return (
@@ -15,7 +17,15 @@ const MyCertificates: FC = () => {
           <link rel="icon" href="/favicon.png" />
         </Head>
         <Page>
-          <div className="min-h-[77vh]">{isLoggedIn && <CertificatesContent />}</div>
+          <div className="min-h-[77vh]">
+            {isLoggedIn ? (
+              <CertificatesContent />
+            ) : (
+              <div className="text-center py-12">
+                <p className="text-lg">{t('not_authenticated')}</p>
+              </div>
+            )}
+          </div>
         </Page>
       </div>
     </>

--- a/frontend-nx/apps/edu-hub/pages/my-certificates/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/my-certificates/index.tsx
@@ -1,0 +1,26 @@
+import Head from 'next/head';
+import { FC } from 'react';
+import { Page } from '../../components/layout/Page';
+import { useIsLoggedIn } from '../../hooks/authentication';
+import CertificatesContent from '../../components/pages/CertificatesContent';
+
+const MyCertificates: FC = () => {
+  const isLoggedIn = useIsLoggedIn();
+
+  return (
+    <>
+      <div className="max-w-screen-xl mx-auto">
+        <Head>
+          <title>My Certificates | EduHub | opencampus.sh</title>
+          <link rel="icon" href="/favicon.png" />
+        </Head>
+        <Page>
+          <div className="min-h-[77vh]">{isLoggedIn && <CertificatesContent />}</div>
+        </Page>
+      </div>
+    </>
+  );
+};
+
+export default MyCertificates;
+

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MakeCertificatePublic.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MakeCertificatePublic.ts
@@ -1,0 +1,27 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: MakeCertificatePublic
+// ====================================================
+
+export interface MakeCertificatePublic_makeCertificatePublic {
+  __typename: "makeCertificatePublicOutput";
+  success: boolean;
+  messageKey: string;
+  error: string | null;
+  publicUrl: string | null;
+}
+
+export interface MakeCertificatePublic {
+  /**
+   * Makes a certificate file public in storage bucket for LinkedIn sharing
+   */
+  makeCertificatePublic: MakeCertificatePublic_makeCertificatePublic | null;
+}
+
+export interface MakeCertificatePublicVariables {
+  certificatePath: string;
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MyCertificates.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MyCertificates.ts
@@ -1,0 +1,182 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { CourseEnrollmentStatus_enum, CourseStatus_enum, Weekday_enum, CourseRegistrationType_enum, ProgramType_enum } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL query operation: MyCertificates
+// ====================================================
+
+export interface MyCertificates_CourseEnrollment_Course_Program {
+  __typename: "Program";
+  id: number;
+  /**
+   * The title of the program
+   */
+  title: string;
+  /**
+   * The 6 letter short title for the program.
+   */
+  shortTitle: string | null;
+  /**
+   * The first day a course lecture can possibly be in this program.
+   */
+  lectureStart: any | null;
+  /**
+   * The last day a course lecture can possibly be in this program.
+   */
+  lectureEnd: any | null;
+  /**
+   * The default application deadline for a course. It can be changed on the course level.
+   */
+  defaultApplicationEnd: any | null;
+  /**
+   * The deadline for the achievement record uploads.
+   */
+  achievementRecordUploadDeadline: any | null;
+  /**
+   * Decides whether the courses of this program can be published or not. (Courses are ony published if the filed publised in the Course table is also set to true.)
+   */
+  published: boolean;
+  /**
+   * Sets the achievement certificates for all courses of htis program to be visible for the recipients.
+   */
+  visibilityAchievementCertificate: boolean | null;
+  /**
+   * Sets the participation certificates for all courses of htis program to be visible for the recipients.
+   */
+  visibilityAttendanceCertificate: boolean | null;
+  type: ProgramType_enum;
+}
+
+export interface MyCertificates_CourseEnrollment_Course {
+  __typename: "Course";
+  id: number;
+  /**
+   * The title of the course (only editable by an admin user)
+   */
+  title: string;
+  /**
+   * Shows whether the current status is DRAFT, READY_FOR_PUBLICATION, READY_FOR_APPLICATION, APPLICANTS_INVITED, or PARTICIPANTS_RATED, which is set in correspondance to the tabs completed on the course administration page
+   */
+  status: CourseStatus_enum;
+  /**
+   * The number of ECTS of the course (only editable by an admin user))
+   */
+  ects: string;
+  /**
+   * Shown below the title on the course page
+   */
+  tagline: string;
+  /**
+   * The language the course is given in.
+   */
+  language: string | null;
+  /**
+   * Last day before applications are closed. (Set to the program's default value when the course is created.)
+   */
+  applicationEnd: any;
+  /**
+   * A text providing info about the costs of a participation.
+   */
+  cost: string;
+  /**
+   * Indicates whether participants can get an achievement certificate. If the course is offering ECTS, it must be possible to obtain this certificate for the course
+   */
+  achievementCertificatePossible: boolean;
+  /**
+   * Indicates whether participants will get a certificate showing the list of attendances (only issued if the did not miss then maxMissedCourses)
+   */
+  attendanceCertificatePossible: boolean;
+  /**
+   * The maximum number of sessions a participant can miss while still receiving a certificate
+   */
+  maxMissedSessions: number;
+  /**
+   * The day of the week the course takes place.
+   */
+  weekDay: Weekday_enum;
+  /**
+   * The cover image for the course
+   */
+  coverImage: string | null;
+  /**
+   * Id of the program to which the course belongs.
+   */
+  programId: number;
+  /**
+   * An array of texts including the learning goals for the course
+   */
+  learningGoals: string | null;
+  /**
+   * The link to the chat of the course (e.g. a mattermost channel)
+   */
+  chatLink: string | null;
+  /**
+   * Decides whether the course is published for all users or not.
+   */
+  published: boolean;
+  /**
+   * The number of maximum participants in the course.
+   */
+  maxParticipants: number | null;
+  /**
+   * The time the course ends each week.
+   */
+  endTime: any | null;
+  /**
+   * The time the course starts each week.
+   */
+  startTime: any | null;
+  registrationType: CourseRegistrationType_enum | null;
+  /**
+   * An object relationship
+   */
+  Program: MyCertificates_CourseEnrollment_Course_Program;
+}
+
+export interface MyCertificates_CourseEnrollment {
+  __typename: "CourseEnrollment";
+  /**
+   * The ID of the user that enrolled for the given course
+   */
+  userId: any;
+  /**
+   * The ID of the course of this enrollment from the given user
+   */
+  courseId: number;
+  /**
+   * The last day a user can confirm his/her invitation to the given course
+   */
+  invitationExpirationDate: any | null;
+  id: number;
+  /**
+   * The users current enrollment status to this course
+   */
+  status: CourseEnrollmentStatus_enum;
+  /**
+   * URL to the file containing the user's achievement certificate (if he obtained one)
+   */
+  achievementCertificateURL: string | null;
+  /**
+   * URL to the file containing the user's attendance certificate (if he obtained one)
+   */
+  attendanceCertificateURL: string | null;
+  /**
+   * An object relationship
+   */
+  Course: MyCertificates_CourseEnrollment_Course;
+}
+
+export interface MyCertificates {
+  /**
+   * fetch data from the table: "CourseEnrollment"
+   */
+  CourseEnrollment: MyCertificates_CourseEnrollment[];
+}
+
+export interface MyCertificatesVariables {
+  userId: any;
+}

--- a/frontend-nx/apps/edu-hub/queries/actions.ts
+++ b/frontend-nx/apps/edu-hub/queries/actions.ts
@@ -124,6 +124,17 @@ export const GET_SIGNED_URL = gql`
   }
 `;
 
+export const MAKE_CERTIFICATE_PUBLIC = gql`
+  query MakeCertificatePublic($certificatePath: String!) {
+    makeCertificatePublic(certificatePath: $certificatePath) {
+      success
+      messageKey
+      error
+      publicUrl
+    }
+  }
+`;
+
 export const SAVE_USER_PROFILE_IMAGE = gql`
   mutation SaveUserProfileImage(
     $base64File: String!

--- a/frontend-nx/apps/edu-hub/queries/actions.ts
+++ b/frontend-nx/apps/edu-hub/queries/actions.ts
@@ -125,7 +125,7 @@ export const GET_SIGNED_URL = gql`
 `;
 
 export const MAKE_CERTIFICATE_PUBLIC = gql`
-  query MakeCertificatePublic($certificatePath: String!) {
+  mutation MakeCertificatePublic($certificatePath: String!) {
     makeCertificatePublic(certificatePath: $certificatePath) {
       success
       messageKey

--- a/frontend-nx/apps/edu-hub/queries/myCertificates.ts
+++ b/frontend-nx/apps/edu-hub/queries/myCertificates.ts
@@ -1,0 +1,32 @@
+import { gql } from '@apollo/client';
+import { ENROLLMENT_FRAGMENT } from './enrollmentFragment';
+import { COURSE_FRAGMENT_MINIMUM } from './courseFragment';
+import { PROGRAM_FRAGMENT_MINIMUM_PROPERTIES } from './programFragment';
+
+export const MY_CERTIFICATES = gql`
+  ${ENROLLMENT_FRAGMENT}
+  ${COURSE_FRAGMENT_MINIMUM}
+  ${PROGRAM_FRAGMENT_MINIMUM_PROPERTIES}
+  query MyCertificates($userId: uuid!) {
+    CourseEnrollment(
+      where: {
+        userId: { _eq: $userId }
+        _or: [
+          { achievementCertificateURL: { _is_null: false } }
+          { attendanceCertificateURL: { _is_null: false } }
+        ]
+      }
+      order_by: { created_at: desc }
+    ) {
+      ...EnrollmentFragment
+      Course {
+        ...CourseFragmentMinimum
+        coverImage
+        Program {
+          ...ProgramFragmentMinimumProperties
+        }
+      }
+    }
+  }
+`;
+

--- a/functions/callNodeFunction/index.js
+++ b/functions/callNodeFunction/index.js
@@ -9,6 +9,7 @@ import updateAdminUser from "./updateAdminUser/index.js";
 import getAdminUsers from "./getAdminUsers/index.js";
 import sendEnrollmentEmail from "./sendEnrollmentEmail/index.js";
 import sendSessionReminders from "./sendSessionReminders/index.js";
+import makeCertificatePublic from "./makeCertificatePublic/index.js";
 
 /**
  * Creates a logger instance with structured logging.
@@ -38,7 +39,8 @@ const functionMap = {
   updateAdminUser,
   getAdminUsers,
   sendEnrollmentEmail,
-  sendSessionReminders
+  sendSessionReminders,
+  makeCertificatePublic
 };
 
 /**

--- a/functions/callNodeFunction/makeCertificatePublic/index.js
+++ b/functions/callNodeFunction/makeCertificatePublic/index.js
@@ -70,8 +70,7 @@ const makeCertificatePublic = async (req) => {
       };
     } else {
       // In production, use actual Storage API
-      const storageInstance = new Storage();
-      const bucket = storageInstance.bucket(bucketName);
+      const bucket = storage.bucket(bucketName);
       const file = bucket.file(certificatePath);
       
       // Check if file already is public

--- a/functions/callNodeFunction/makeCertificatePublic/index.js
+++ b/functions/callNodeFunction/makeCertificatePublic/index.js
@@ -1,0 +1,112 @@
+import { Storage } from "@google-cloud/storage";
+import { buildCloudStorage } from "../lib/cloud-storage.js";
+import { logger } from "../index.js";
+
+/**
+ * Makes a certificate file public in cloud storage and returns the public URL.
+ *
+ * @param {Object} req Request object containing:
+ *   - input.certificatePath (string): Path to the certificate file in storage
+ *   - session_variables['x-hasura-role'] (string): User role
+ *   - session_variables['x-hasura-user-id'] (string): User UUID
+ * @returns {Object} Response containing:
+ *   - success (boolean): Whether the operation was successful
+ *   - messageKey (string): Translation key for messages
+ *   - error (string, optional): Error message if operation failed
+ *   - publicUrl (string, optional): The public URL if successful
+ */
+const makeCertificatePublic = async (req) => {
+  logger.info("########## Make Certificate Public ##########");
+  logger.debug("Request parameters", { 
+    certificatePath: req.body.input.certificatePath,
+    role: req.body.session_variables['x-hasura-role'],
+    userId: req.body.session_variables['x-hasura-user-id']
+  });
+
+  const storage = buildCloudStorage(Storage);
+  const certificatePath = req.body.input.certificatePath;
+  const userRole = req.body.session_variables['x-hasura-role'];
+  const userUUID = req.body.session_variables['x-hasura-user-id'];
+
+  try {
+    // Validate input
+    if (!certificatePath) {
+      logger.warn("Missing certificate path");
+      return {
+        success: false,
+        messageKey: "MISSING_CERTIFICATE_PATH",
+        error: "Certificate path is required."
+      };
+    }
+
+    // Validate user has permission (user can only make their own certificates public)
+    const hasPermission = 
+      userRole === 'admin' ||
+      userRole === 'instructor' ||
+      (userUUID && certificatePath.includes("/user-" + userUUID + "/")) ||
+      (userUUID && certificatePath.startsWith(userUUID + "/")) || // included for legacy names
+      (userUUID && certificatePath.startsWith("/user-" + userUUID + "/")); // included for legacy names
+
+    if (!hasPermission) {
+      logger.warn("Access denied for making certificate public", { certificatePath, userRole, userUUID });
+      return {
+        success: false,
+        messageKey: "CERTIFICATE_ACCESS_DENIED",
+        error: "You do not have permission to make this certificate public."
+      };
+    }
+
+    // Make the certificate public and get public URL
+    const bucketName = req.headers.bucket;
+    
+    if (process.env.ENVIRONMENT === "development") {
+      // In development/emulated mode, just return a mock public URL
+      logger.debug(`[Emulated] Making certificate public: ${bucketName}/${certificatePath}`);
+      const publicUrl = `http://localhost:${process.env.STORAGE_PORT}/${bucketName}/${certificatePath}`;
+      return {
+        success: true,
+        messageKey: "CERTIFICATE_MADE_PUBLIC",
+        publicUrl
+      };
+    } else {
+      // In production, use actual Storage API
+      const storageInstance = new Storage();
+      const bucket = storageInstance.bucket(bucketName);
+      const file = bucket.file(certificatePath);
+      
+      // Check if file already is public
+      const [isPublic] = await file.isPublic();
+      
+      if (!isPublic) {
+        await file.makePublic();
+        logger.info("Certificate made public", { certificatePath, userRole, userUUID });
+      } else {
+        logger.debug("Certificate already public", { certificatePath });
+      }
+      
+      const publicUrl = await file.publicUrl();
+      
+      return {
+        success: true,
+        messageKey: "CERTIFICATE_MADE_PUBLIC",
+        publicUrl
+      };
+    }
+  } catch (error) {
+    logger.error("Error making certificate public", { 
+      error: error.message, 
+      certificatePath, 
+      userRole, 
+      userUUID, 
+      stack: error.stack 
+    });
+    return {
+      success: false,
+      messageKey: "CERTIFICATE_PUBLIC_ERROR",
+      error: "An error occurred while making the certificate public."
+    };
+  }
+};
+
+export default makeCertificatePublic;
+


### PR DESCRIPTION
## Changes

- Replace multiple LinkedIn share buttons with single button to save space
- Add radio button selection dialog when both certificates are available
- Default to achievement certificate if available, otherwise attendance
- Fix program title display (always show, aligned right)
- Update translations for certificate selection dialog

## Testing

- Tested LinkedIn sharing flow with single and multiple certificates
- Verified radio button selection works correctly
- Confirmed program title displays and aligns properly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "My Certificates" page accessible from the main menu
  * View all earned achievement and attendance certificates for completed courses
  * Download individual certificates directly
  * Share certificates on LinkedIn with publicly generated URLs
  * Responsive certificate cards displaying program information and enrollment details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->