### PR TITLE
Implement moochub api location and keywords

### DIFF
--- a/functions/apiProxy/main.py
+++ b/functions/apiProxy/main.py
@@ -23,37 +23,37 @@ request_counts = {}  # In-memory storage for rate limiting
 # Hardcoded location address mapping
 LOCATION_ADDRESS_MAPPING = {
     320: {
-        "learning_zone": "Eventraum",
+        "name": "Eventraum",
         "streetAddress": "Kuhnkestr. 6",
         "city": "Kiel",
         "description": "Starterkitchen by opencampus.sh"
     },
     321: {
-        "learning_zone": "Konferenzraum",
+        "name": "Konferenzraum",
         "streetAddress": "Kuhnkestr. 6",
         "city": "Kiel",
         "description": "Starterkitchen by opencampus.sh"
     },
     322: {
-        "learning_zone": "Café",
+        "name": "Café",
         "streetAddress": "Legienstraße 40",
         "city": "Kiel",
         "description": "COBL by opencampus.sh"
     },
     323: {
-        "learning_zone": "Loft",
+        "name": "Loft",
         "streetAddress": "Legienstraße 40",
         "city": "Kiel",
         "description": "COBL by opencampus.sh"
     },
     324: {
-        "learning_zone": "Club",
+        "name": "Club",
         "streetAddress": "Legienstraße 40",
         "city": "Kiel",
         "description": "COBL by opencampus.sh"
     },
     325: {
-        "learning_zone": "FabLab",
+        "name": "FabLab",
         "streetAddress": "Fraunhoferstraße 2-4",
         "city": "Kiel",
         "description": "FabLab.SH by opencampus.sh"
@@ -275,7 +275,7 @@ def handle_moochub_data(page=1, per_page=25):
                     if address_id in LOCATION_ADDRESS_MAPPING:
                         location_data = LOCATION_ADDRESS_MAPPING[address_id]
                         attributes["contentLocation"] = {
-                            "name": location_data["learning_zone"],
+                            "name": location_data["name"],
                             "address": {
                                 "streetAddress": location_data["streetAddress"],
                                 "city": location_data["city"],

--- a/functions/apiProxy/main.py
+++ b/functions/apiProxy/main.py
@@ -20,6 +20,46 @@ RATE_LIMIT = 60
 RATE_WINDOW = 3600  # 1 hour in seconds
 request_counts = {}  # In-memory storage for rate limiting
 
+# Hardcoded location address mapping
+LOCATION_ADDRESS_MAPPING = {
+    320: {
+        "learning_zone": "Eventraum",
+        "streetAddress": "Kuhnkestr. 6",
+        "city": "Kiel",
+        "description": "Starterkitchen by opencampus.sh"
+    },
+    321: {
+        "learning_zone": "Konferenzraum",
+        "streetAddress": "Kuhnkestr. 6",
+        "city": "Kiel",
+        "description": "Starterkitchen by opencampus.sh"
+    },
+    322: {
+        "learning_zone": "Café",
+        "streetAddress": "Legienstraße 40",
+        "city": "Kiel",
+        "description": "COBL by opencampus.sh"
+    },
+    323: {
+        "learning_zone": "Loft",
+        "streetAddress": "Legienstraße 40",
+        "city": "Kiel",
+        "description": "COBL by opencampus.sh"
+    },
+    324: {
+        "learning_zone": "Club",
+        "streetAddress": "Legienstraße 40",
+        "city": "Kiel",
+        "description": "COBL by opencampus.sh"
+    },
+    325: {
+        "learning_zone": "FabLab",
+        "streetAddress": "Fraunhoferstraße 2-4",
+        "city": "Kiel",
+        "description": "FabLab.SH by opencampus.sh"
+    }
+}
+
 def check_rate_limit(ip_address):
     current_time = datetime.now().timestamp()
     if ip_address in request_counts:
@@ -98,6 +138,13 @@ def handle_moochub_data(page=1, per_page=25):
                 CourseLocations {
                     id
                     locationOption
+                    defaultSessionAddressId
+                    DefaultSessionAddress {
+                        id
+                        shortLabel
+                        address
+                        description
+                    }
                 }
                 CourseGroups {
                     CourseGroupOption {
@@ -171,6 +218,14 @@ def handle_moochub_data(page=1, per_page=25):
                 html_content = markdown.markdown(course["contentDescriptionField2"])
                 description_parts.append(html_content)
 
+            # Check for DLC CourseGroup to add keywords
+            has_dlc_group = False
+            for group in course.get("CourseGroups", []):
+                group_option = group.get("CourseGroupOption", {})
+                if group_option.get("title", "").upper() == "DLC":
+                    has_dlc_group = True
+                    break
+            
             # Create one entry per course location
             for location in course["CourseLocations"]:
                 # Determine courseMode based on location
@@ -206,47 +261,27 @@ def handle_moochub_data(page=1, per_page=25):
                     }]
                 }
                 
+                # Add keywords for DLC Original courses
+                if has_dlc_group:
+                    attributes["keywords"] = ["DLC-Original"]
+                
                 # Set URL based on location type with MOOCHub tracking parameters
                 moochub_params = "source=moochub&provider=opencampus-sh&feed_version=3.0.1"
-                if location["locationOption"] == "ONLINE":
-                    # For online courses, use the course's existing URL with MOOCHub tracking
-                    attributes["url"] = f"{api_base_url}/course/{course['id']}?{moochub_params}"
-                else:
-                    # For physical locations, use the course URL but add location-specific attributes
-                    attributes["url"] = f"{api_base_url}/course/{course['id']}?{moochub_params}"
-                    
-                    # Add custom attributes for physical locations
-                    # Note: These are provider-specific extensions to the schema
-                    custom_attrs = {}
-                    
-                    # learning_region
-                    custom_attrs["learning_region"] = location["locationOption"]
-                    
-                    # learning_location and learning_zone logic
-                    group_titles = [group.get("CourseGroupOption", {}).get("title", "") for group in course.get("CourseGroups", [])]
-                    
-                    # Check for Starterkitchen or COBL
-                    if "Starterkitchen" in group_titles:
-                        custom_attrs["learning_location"] = "Starterkitchen"
-                        # Check for Eventraum or Konferenzraum
-                        if "Eventraum" in group_titles:
-                            custom_attrs["learning_zone"] = "Eventraum"
-                        elif "Konferenzraum" in group_titles:
-                            custom_attrs["learning_zone"] = "Konferenzraum"
-                    elif "COBL" in group_titles:
-                        custom_attrs["learning_location"] = "COBL"
-                        # Check for Café, Loft, or Club
-                        if "Café" in group_titles:
-                            custom_attrs["learning_zone"] = "Café"
-                        elif "Loft" in group_titles:
-                            custom_attrs["learning_zone"] = "Loft"
-                        elif "Club" in group_titles:
-                            custom_attrs["learning_zone"] = "Club"
-                    
-                    # Add custom attributes to the main attributes object
-                    # These are provider-specific extensions and may not be validated by the schema
-                    for key, value in custom_attrs.items():
-                        attributes[key] = value
+                attributes["url"] = f"{api_base_url}/course/{course['id']}?{moochub_params}"
+                
+                # Add contentLocation for onsite courses with valid defaultSessionAddressId
+                if location["locationOption"] != "ONLINE" and location.get("defaultSessionAddressId"):
+                    address_id = location["defaultSessionAddressId"]
+                    if address_id in LOCATION_ADDRESS_MAPPING:
+                        location_data = LOCATION_ADDRESS_MAPPING[address_id]
+                        attributes["contentLocation"] = {
+                            "name": location_data["learning_zone"],
+                            "address": {
+                                "streetAddress": location_data["streetAddress"],
+                                "city": location_data["city"],
+                                "description": location_data["description"]
+                            }
+                        }
                 
                 # Note: metadata_tags are collected but not included in the feed
                 # They are used internally for determining funding and other custom attributes
@@ -378,21 +413,6 @@ def handle_moochub_schema():
                 if "attributes" in course_props and "properties" in course_props["attributes"]:
                     # Add our custom attributes to the course attributes
                     course_props["attributes"]["properties"].update({
-                        "learning_region": {
-                            "type": "string",
-                            "description": "Physical location region where the course takes place (only for onsite courses)",
-                            "example": "KIEL"
-                        },
-                        "learning_location": {
-                            "type": "string",
-                            "description": "Specific learning location within the region (only for onsite courses)",
-                            "example": "Starterkitchen"
-                        },
-                        "learning_zone": {
-                            "type": "string",
-                            "description": "Specific zone within the learning location (only for onsite courses)",
-                            "example": "Eventraum"
-                        },
                         "funding": {
                             "type": "array",
                             "description": "Array of funding organizations supporting the course",
@@ -441,20 +461,10 @@ def handle_moochub_schema():
             "schema_url": "/schemas/moochub-opencampus-extensions-v1.0.0.json",
             "schema_latest_url": "/schemas/moochub/latest.json",
             "custom_extensions": {
-                "learning_region": {
-                    "type": "string", 
-                    "description": "Physical location region where the course takes place (only for onsite courses)",
-                    "example": "KIEL"
-                },
-                "learning_location": {
-                    "type": "string",
-                    "description": "Specific learning location within the region (only for onsite courses)",
-                    "example": "Starterkitchen"
-                },
-                "learning_zone": {
-                    "type": "string",
-                    "description": "Specific zone within the learning location (only for onsite courses)",
-                    "example": "Eventraum"
+                "keywords": {
+                    "type": "array",
+                    "description": "Keywords array used to identify course characteristics. Courses with 'DLC' CourseGroup are tagged with ['DLC-Original']",
+                    "example": ["DLC-Original"]
                 },
                 "funding": {
                     "type": "array",


### PR DESCRIPTION
Implement MOOCHub API location and keywords by using `contentLocation` for onsite courses and adding `DLC-Original` keywords, aligning with the specified plan.

---
<a href="https://cursor.com/background-agent?bcId=bc-728b0bce-dcd7-4723-b3b2-2afb9f43840f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-728b0bce-dcd7-4723-b3b2-2afb9f43840f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed location address mapping and display for courses
  * Implemented DLC-Original keyword system for improved course categorization
  * Enhanced course location data with structured session address information

* **Refactor**
  * Updated course metadata schema: replaced location attributes with new keywords extension

<!-- end of auto-generated comment: release notes by coderabbit.ai -->