### PR TITLE
fix: use funding organization instead of CourseGroup for DLC-Original…

### DIFF
--- a/functions/apiProxy/main.py
+++ b/functions/apiProxy/main.py
@@ -218,12 +218,12 @@ def handle_moochub_data(page=1, per_page=25):
                 html_content = markdown.markdown(course["contentDescriptionField2"])
                 description_parts.append(html_content)
 
-            # Check for DLC CourseGroup to add keywords
-            has_dlc_group = False
-            for group in course.get("CourseGroups", []):
-                group_option = group.get("CourseGroupOption", {})
-                if group_option.get("title", "").upper() == "DLC":
-                    has_dlc_group = True
+            # Check for Digital Learning Campus funding organization to add keywords
+            has_dlc_funding = False
+            for funding_org in course.get("CourseFundingOrganizations", []):
+                organization = funding_org.get("Organization", {})
+                if organization.get("name", "").upper() == "DIGITAL LEARNING CAMPUS":
+                    has_dlc_funding = True
                     break
             
             # Create one entry per course location
@@ -261,8 +261,8 @@ def handle_moochub_data(page=1, per_page=25):
                     }]
                 }
                 
-                # Add keywords for DLC Original courses
-                if has_dlc_group:
+                # Add keywords for DLC Original courses (courses with Digital Learning Campus funding)
+                if has_dlc_funding:
                     attributes["keywords"] = ["DLC-Original"]
                 
                 # Set URL based on location type with MOOCHub tracking parameters
@@ -463,7 +463,7 @@ def handle_moochub_schema():
             "custom_extensions": {
                 "keywords": {
                     "type": "array",
-                    "description": "Keywords array used to identify course characteristics. Courses with 'DLC' CourseGroup are tagged with ['DLC-Original']",
+                    "description": "Keywords array used to identify course characteristics. Courses with funding organization 'Digital Learning Campus' are tagged with ['DLC-Original']",
                     "example": ["DLC-Original"]
                 },
                 "funding": {

--- a/functions/apiProxy/main.py
+++ b/functions/apiProxy/main.py
@@ -161,6 +161,7 @@ def handle_moochub_data(page=1, per_page=25):
                         description
                         type
                         logo
+                        aliases
                     }
                 }
             }
@@ -219,12 +220,27 @@ def handle_moochub_data(page=1, per_page=25):
                 description_parts.append(html_content)
 
             # Check for Digital Learning Campus funding organization to add keywords
+            # Matches organization name or aliases that normalize to "DLC" or "DIGITAL LEARNING CAMPUS"
             has_dlc_funding = False
             for funding_org in course.get("CourseFundingOrganizations", []):
                 organization = funding_org.get("Organization", {})
-                if organization.get("name", "").upper() == "DIGITAL LEARNING CAMPUS":
+                
+                # Normalize organization name
+                org_name_normalized = organization.get("name", "").strip().upper()
+                if org_name_normalized in ("DIGITAL LEARNING CAMPUS", "DLC"):
                     has_dlc_funding = True
                     break
+                
+                # Check aliases if present
+                aliases = organization.get("aliases")
+                if aliases and isinstance(aliases, list):
+                    for alias in aliases:
+                        alias_normalized = str(alias).strip().upper() if alias else ""
+                        if alias_normalized in ("DIGITAL LEARNING CAMPUS", "DLC"):
+                            has_dlc_funding = True
+                            break
+                    if has_dlc_funding:
+                        break
             
             # Create one entry per course location
             for location in course["CourseLocations"]:
@@ -463,7 +479,7 @@ def handle_moochub_schema():
             "custom_extensions": {
                 "keywords": {
                     "type": "array",
-                    "description": "Keywords array used to identify course characteristics. Courses with funding organization 'Digital Learning Campus' are tagged with ['DLC-Original']",
+                    "description": "Keywords array used to identify course characteristics. Courses with funding organization name or alias matching 'Digital Learning Campus' or 'DLC' (case-insensitive, normalized) are tagged with ['DLC-Original']. The stored keyword value is 'DLC-Original' regardless of whether the organization name uses the short form 'DLC' or the full form 'Digital Learning Campus'.",
                     "example": ["DLC-Original"]
                 },
                 "funding": {


### PR DESCRIPTION
… keyword

Change the logic for adding the DLC-Original keyword in MOOCHub export to check for funding organization name 'Digital Learning Campus' instead of CourseGroup title 'DLC'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DLC detection so courses funded by the Digital Learning Campus are correctly identified and tagged as DLC-Original.
* **Documentation**
  * Updated public schema descriptions to reference funding organizations and alias handling for clearer DLC tagging behavior.
* **Data**
  * Public data now exposes organization aliases to improve funding-based matching and tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->