### PR TITLE
fix: switch frontend dev container from Alpine to Debian for SWC compatibility

### DIFF
--- a/frontend-nx/Dockerfile-dev
+++ b/frontend-nx/Dockerfile-dev
@@ -1,8 +1,8 @@
 ## https://blog.nrwl.io/create-a-next-js-web-app-with-nx-bcf2ab54613
 
-FROM node:18-alpine
+FROM node:18-bullseye-slim
 
-RUN apk add --no-cache libc6-compat socat
+RUN apt-get update && apt-get install -y socat && rm -rf /var/lib/apt/lists/*
 
 RUN corepack enable
 


### PR DESCRIPTION
## Problem

The frontend container was failing to start after reinstalling `node_modules`. The issue occurred because:

- Alpine Linux uses **musl libc**
- Next.js SWC compiler binary requires **glibc**
- The `__register_atfork` symbol required by SWC is not available in musl
- Fresh `yarn install` in Alpine container couldn't properly install the musl-compatible SWC binary

Error message:
```
⚠ Attempted to load @next/swc-linux-x64-gnu, but an error occurred: Error relocating .../next-swc.linux-x64-gnu.node: __register_atfork: symbol not found
⚠ Attempted to load @next/swc-linux-x64-musl, but it was not installed
⨯ Failed to load SWC binary for linux/x64
```

## Solution

Switch from `node:18-alpine` to `node:18-bullseye-slim` for the development Docker image.

### Changes
- Replace Alpine base image with Debian Bullseye slim
- Update package manager commands from `apk` to `apt-get`
- Remove `libc6-compat` (not needed with native glibc)
- Add proper apt cache cleanup

### Benefits
✅ Full compatibility with Next.js native SWC compiler
✅ Faster builds with native SWC vs Babel fallback
✅ Better compatibility with other Node.js native modules
✅ Closer to production environment parity
✅ Eliminates Alpine-specific compatibility issues

### Trade-offs
- Image size increases by ~100MB (negligible for development)
- No functional disadvantages for development workflow

## Testing

- ✅ Container builds successfully
- ✅ Both Next.js apps (edu-hub, rent-a-scientist) start without errors
- ✅ No SWC loading errors in logs
- ✅ Pages compile successfully
- ✅ Hot reload working

## Related
This issue was latent but only manifested after removing `node_modules` and reinstalling dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development environment configuration for improved build stability and consistency.

---

**Note:** This release contains infrastructure updates only. No user-facing features or functionality changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->