### PR TITLE
refactor(functions): implement wrapper pattern for makeCertificatePublic

### DIFF
--- a/functions/callNodeFunction/lib/cloud-storage.js
+++ b/functions/callNodeFunction/lib/cloud-storage.js
@@ -87,7 +87,10 @@ export const buildCloudStorage = (Storage) => {
         }
       },
       setPublic: async (path, bucketName) => {
-        logger.debug(`[Emulated] Set public: ${bucketName}/${getRelativePath(path)}`);
+        path = getRelativePath(path);
+        logger.debug(`[Emulated] Set public: ${bucketName}/${path}`);
+        const publicUrl = `http://localhost:${process.env.STORAGE_PORT}/${bucketName}/${path}`;
+        return publicUrl;
       },
       setPrivate: async (path, bucketName) => {
         logger.debug(`[Emulated] Set private: ${bucketName}/${getRelativePath(path)}`);
@@ -166,7 +169,19 @@ export const buildCloudStorage = (Storage) => {
         path = getRelativePath(path);
         const bucket = storage.bucket(bucketName);
         const file = bucket.file(path);
-        await file.makePublic();
+        
+        // Check if file already is public
+        const [isPublic] = await file.isPublic();
+        
+        if (!isPublic) {
+          await file.makePublic();
+          logger.debug(`Setting file ${path} to public`);
+        } else {
+          logger.debug(`File ${path} already public`);
+        }
+        
+        const publicUrl = await file.publicUrl();
+        return publicUrl;
       },
       setPrivate: async (path, bucketName) => {
         path = getRelativePath(path);

--- a/functions/callNodeFunction/makeCertificatePublic/index.js
+++ b/functions/callNodeFunction/makeCertificatePublic/index.js
@@ -56,41 +56,17 @@ const makeCertificatePublic = async (req) => {
       };
     }
 
-    // Make the certificate public and get public URL
+    // Make the certificate public and get public URL using the storage wrapper
     const bucketName = req.headers.bucket;
+    const publicUrl = await storage.setPublic(certificatePath, bucketName);
     
-    if (process.env.ENVIRONMENT === "development") {
-      // In development/emulated mode, just return a mock public URL
-      logger.debug(`[Emulated] Making certificate public: ${bucketName}/${certificatePath}`);
-      const publicUrl = `http://localhost:${process.env.STORAGE_PORT}/${bucketName}/${certificatePath}`;
-      return {
-        success: true,
-        messageKey: "CERTIFICATE_MADE_PUBLIC",
-        publicUrl
-      };
-    } else {
-      // In production, use actual Storage API
-      const bucket = storage.bucket(bucketName);
-      const file = bucket.file(certificatePath);
-      
-      // Check if file already is public
-      const [isPublic] = await file.isPublic();
-      
-      if (!isPublic) {
-        await file.makePublic();
-        logger.info("Certificate made public", { certificatePath, userRole, userUUID });
-      } else {
-        logger.debug("Certificate already public", { certificatePath });
-      }
-      
-      const publicUrl = await file.publicUrl();
-      
-      return {
-        success: true,
-        messageKey: "CERTIFICATE_MADE_PUBLIC",
-        publicUrl
-      };
-    }
+    logger.info("Certificate made public", { certificatePath, userRole, userUUID, publicUrl });
+    
+    return {
+      success: true,
+      messageKey: "CERTIFICATE_MADE_PUBLIC",
+      publicUrl
+    };
   } catch (error) {
     logger.error("Error making certificate public", { 
       error: error.message, 


### PR DESCRIPTION
- Update cloud-storage wrapper setPublic method to return public URL
- Refactor makeCertificatePublic to use storage wrapper instead of direct GCS API calls
- Remove environment-specific logic from makeCertificatePublic (handled by wrapper)
- Fixes 'storage.bucket is not a function' error by using proper abstraction