### PR TITLE
fix(frontend): correct order_by type to array in AdminCourseList query

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/index.tsx
@@ -87,7 +87,7 @@ const ManageCoursesContent: FC<IProps> = ({ programs }) => {
   const [filter, setFilter] = useState<AdminCourseListVariables>({
     limit: 100,
     where: { programId: { _eq: defaultProgramId } },
-    order_by: { id: order_by.desc },
+    order_by: [{ id: order_by.desc }],
   });
 
   // Menubar configuration

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseList.ts
@@ -535,5 +535,5 @@ export interface AdminCourseListVariables {
   where: Course_bool_exp;
   limit?: number | null;
   offset?: number | null;
-  order_by?: Course_order_by | null;
+  order_by?: Course_order_by[] | null;
 }

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UsersByLastName.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UsersByLastName.ts
@@ -129,5 +129,5 @@ export interface UsersByLastNameVariables {
   limit?: number | null;
   offset?: number | null;
   filter?: User_bool_exp | null;
-  order_by?: User_order_by | null;
+  order_by?: User_order_by[] | null;
 }

--- a/frontend-nx/apps/edu-hub/queries/courseList.ts
+++ b/frontend-nx/apps/edu-hub/queries/courseList.ts
@@ -38,7 +38,7 @@ export const ADMIN_COURSE_LIST = gql`
     $where: Course_bool_exp! = {}
     $limit: Int = null
     $offset: Int = 0
-    $order_by: Course_order_by = {updated_at: desc}
+    $order_by: [Course_order_by!] = [{updated_at: desc}]
   ) {
     Course(
       order_by: $order_by


### PR DESCRIPTION
Fix GraphQL type mismatch where order_by was declared as single object but Hasura expects an array. Changed Course_order_by to [Course_order_by!] in ADMIN_COURSE_LIST query and updated component usage accordingly.