### PR TITLE
feat(functions): unify course hash ID generation across APIs

### DIFF
--- a/backend/metadata/databases/default/tables/public_CourseEnrollment.yaml
+++ b/backend/metadata/databases/default/tables/public_CourseEnrollment.yaml
@@ -14,6 +14,9 @@ object_relationships:
   - name: User
     using:
       foreign_key_constraint_on: userId
+  - name: LocationOption
+    using:
+      foreign_key_constraint_on: location
 insert_permissions:
   - role: user_access
     permission:
@@ -23,6 +26,7 @@ insert_permissions:
         - motivationLetter
         - status
         - userId
+        - location
 select_permissions:
   - role: instructor_access
     permission:
@@ -38,6 +42,7 @@ select_permissions:
         - created_at
         - updated_at
         - invitationExpirationDate
+        - location
       filter: {}
   - role: user_access
     permission:
@@ -50,6 +55,7 @@ select_permissions:
         - motivationLetter
         - status
         - userId
+        - location
       filter:
         _and:
           - userId:
@@ -64,6 +70,7 @@ select_permissions:
         - courseId
         - id
         - userId
+        - location
       filter: {}
 update_permissions:
   - role: instructor_access
@@ -72,6 +79,7 @@ update_permissions:
         - invitationExpirationDate
         - motivationRating
         - status
+        - location
       filter:
         _or:
           - Course:
@@ -88,6 +96,7 @@ update_permissions:
         - invitationExpirationDate
         - motivationRating
         - status
+        - location
       filter:
         _or:
           - Course:

--- a/backend/migrations/default/1764719447323_add_location_to_CourseEnrollment/down.sql
+++ b/backend/migrations/default/1764719447323_add_location_to_CourseEnrollment/down.sql
@@ -1,0 +1,8 @@
+-- Remove location column from CourseEnrollment table
+
+ALTER TABLE "public"."CourseEnrollment"
+DROP CONSTRAINT IF EXISTS "CourseEnrollment_location_fkey";
+
+ALTER TABLE "public"."CourseEnrollment"
+DROP COLUMN IF EXISTS "location";
+

--- a/backend/migrations/default/1764719447323_add_location_to_CourseEnrollment/up.sql
+++ b/backend/migrations/default/1764719447323_add_location_to_CourseEnrollment/up.sql
@@ -1,0 +1,19 @@
+-- Add location column to CourseEnrollment table
+-- This column stores the LocationOption value for each enrollment
+-- NULL means use fallback priority: ONLINE -> KIEL -> HEIDE
+
+ALTER TABLE "public"."CourseEnrollment" 
+ADD COLUMN "location" text;
+
+-- Add foreign key constraint to LocationOption table
+ALTER TABLE "public"."CourseEnrollment"
+ADD CONSTRAINT "CourseEnrollment_location_fkey" 
+FOREIGN KEY ("location") 
+REFERENCES "public"."LocationOption"("value") 
+ON UPDATE restrict 
+ON DELETE restrict;
+
+-- Add comment explaining the column
+COMMENT ON COLUMN "public"."CourseEnrollment"."location" IS 
+E'Location option for this enrollment. NULL means use fallback priority: ONLINE -> KIEL -> HEIDE';
+

--- a/functions/apiProxy/README.md
+++ b/functions/apiProxy/README.md
@@ -116,4 +116,22 @@ curl -s \
   http://localhost:42026/participants/courses/302
 ```
 
+#### Development and Testing
+
+For local development and testing, use the development API key:
+
+**Development API Key:** `edh_live_org160_sk_056afe290cadf18e2b2d7482c5f4e5a5`
+
+This key is configured in the development database seed data and is safe to use for local testing. The development server runs on `http://localhost:42026`.
+
+**Example development request:**
+```bash
+curl -X GET "http://localhost:42026/participants" \
+  -H "X-API-Key: edh_live_org160_sk_056afe290cadf18e2b2d7482c5f4e5a5" \
+  -H "User-Agent: EduHub-Client/1.0" \
+  -H "Accept-Version: 3.0.1"
+```
+
+**Note:** The development API key only works with the local development server. For production access, contact the EduHub team to obtain a production API key.
+
 

--- a/functions/apiProxy/README.md
+++ b/functions/apiProxy/README.md
@@ -6,8 +6,8 @@
 
 #### Endpoints
 - Participants API
-  - GET `/participants` — list courses funded for the authenticated organization
-  - GET `/participants/courses/{course_id}` — participant data for a funded course
+  - GET `/participants` — list courses funded for the authenticated organization (returns one course entry per location, each with a unique hash ID UUID)
+  - GET `/participants/courses/{course_id}` — participant data for a funded course-location combination. Accepts hash ID (UUID) as primary format, or integer course ID for backward compatibility. When hash ID is used, participants are filtered by the specific location.
   - GET `/participants/schema` — brief schema/info and environment diagnostics
   - GET `/participants/test` — simple health check for the participants router
 - MOOCHub feed
@@ -31,6 +31,14 @@
 - `occupationStatus` is included when available.
 - Completion data only signals presence of certificates (no dates or rates).
 
+#### Course identification and location-based filtering
+- **Hash IDs (UUIDs)** are the primary course identifier format, matching MOOCHub API
+- Each course-location combination has a unique hash ID (UUID v5)
+- Course listing returns **one entry per location** (not one per course)
+- When requesting participants using a hash ID, results are filtered to the specific location
+- Integer course IDs are accepted for backward compatibility but will use the first available location
+- Hash IDs are generated from `course_id-location_id` combination
+
 #### Response examples
 - List funded courses
 ```json
@@ -53,7 +61,7 @@
   },
   "fundingOrganization": { "id": 353, "name": "…" },
   "courses": [
-    { "id": 302, "title": "…", "participantDataEndpoint": "/participants/courses/302" }
+    { "id": "39aa0df1-4936-5686-80a5-35d196a03520", "title": "…", "participantDataEndpoint": "/participants/courses/39aa0df1-4936-5686-80a5-35d196a03520" }
   ],
   "generatedAt": "2025-08-08T10:30:00Z"
 }
@@ -63,7 +71,7 @@
 ```json
 {
   "type": "ParticipantDataReport",
-  "id": "urn:report:course:302:2025-08-08T10:30:00Z",
+  "id": "urn:report:course:39aa0df1-4936-5686-80a5-35d196a03520:2025-08-08T10:30:00Z",
   "provider": {
     "id": "did:web:edu.opencampus.sh",
     "name": "opencampus.sh",
@@ -79,7 +87,7 @@
     }
   },
   "learningOpportunity": {
-    "id": "urn:course:302",
+    "id": "urn:course:39aa0df1-4936-5686-80a5-35d196a03520",
     "title": "…",
     "summary": "…",
     "language": ["de"],
@@ -113,7 +121,7 @@
 curl -s \
   -H "X-API-Key: edh_live_org353_sk_***" \
   -H "User-Agent: PartnerClient/1.0" \
-  http://localhost:42026/participants/courses/302
+  http://localhost:42026/participants/courses/39aa0df1-4936-5686-80a5-35d196a03520
 ```
 
 #### Development and Testing

--- a/functions/apiProxy/course_id_utils.py
+++ b/functions/apiProxy/course_id_utils.py
@@ -1,0 +1,65 @@
+"""
+Course ID Utilities for API Proxy
+
+Shared utilities for generating consistent UUID v5 hash IDs from course identifiers.
+Used by both MOOCHub API and Participant API to ensure consistent course identification.
+"""
+
+import uuid
+
+
+# Fixed namespace UUID for generating consistent course hash IDs
+# This ensures the same course-location combination always generates the same UUID
+COURSE_ID_NAMESPACE = uuid.UUID('fb7eec39-2d36-4c2f-a6b7-87568c8976b2')
+
+
+def generate_uuid_from_id(id_str):
+    """
+    Generate a consistent UUID v5 from a string ID using a fixed namespace.
+    
+    Low-level utility function for generating UUIDs from any string identifier.
+    For course-specific hash IDs, use generate_course_hash_id() instead.
+    
+    Args:
+        id_str: String identifier (e.g., "123-456" for course_id-location_id)
+        
+    Returns:
+        str: UUID v5 string representation
+        
+    Example:
+        >>> generate_uuid_from_id("123-456")
+        '8978f51e-770c-4d0a-a2e3-23fae8f6aa79'
+    """
+    return str(uuid.uuid5(COURSE_ID_NAMESPACE, str(id_str)))
+
+
+def generate_course_hash_id(course_id, location_id=None):
+    """
+    Generate a UUID v5 hash ID for a course, optionally including location.
+    
+    This is the standard way to generate course hash IDs used by both
+    MOOCHub API and Participant API. The format matches MOOCHub requirements:
+    - With location: "{course_id}-{location_id}"
+    - Without location: "{course_id}" (fallback)
+    
+    Args:
+        course_id: Course ID (integer or string)
+        location_id: Optional location ID (integer or string). If None, 
+                     generates hash from course_id only.
+        
+    Returns:
+        str: UUID v5 string representation
+        
+    Examples:
+        >>> generate_course_hash_id(123, 456)
+        '744b5f46-23f8-5b4f-a17f-a3ce993212ce'
+        
+        >>> generate_course_hash_id(123)
+        '8978f51e-770c-4d0a-a2e3-23fae8f6aa79'
+    """
+    if location_id is not None:
+        id_str = f"{course_id}-{location_id}"
+    else:
+        id_str = str(course_id)
+    return generate_uuid_from_id(id_str)
+

--- a/functions/apiProxy/main.py
+++ b/functions/apiProxy/main.py
@@ -2,9 +2,9 @@ import os
 from flask import jsonify
 import logging
 from api_clients.eduhub_client import EduHubClient
-import uuid
 from datetime import datetime
 import markdown
+from course_id_utils import generate_course_hash_id
 try:
     from participant_data_handler import handle_participants_request, handle_participants_schema
 except ImportError:
@@ -14,10 +14,11 @@ except ImportError:
     current_dir = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(0, current_dir)
     from participant_data_handler import handle_participants_request, handle_participants_schema
+    from course_id_utils import generate_course_hash_id
 
 # Rate limiting configuration - 100 requests per hour per IP
 RATE_LIMIT = 60
-RATE_WINDOW = 3600  # 1 hour in seconds
+RATE_WINDOW = 60  # 1 minute in seconds
 request_counts = {}  # In-memory storage for rate limiting
 
 # Hardcoded location address mapping
@@ -91,14 +92,6 @@ def get_cors_headers():
         'X-Rate-Limit-Window': str(RATE_WINDOW)
     }
     return headers
-
-def generate_uuid_from_id(id_str):
-    """Generate a consistent UUID from a string ID by using it as a namespace."""
-    # Use a fixed namespace UUID (version 5, SHA-1)
-    # This is a randomly generated UUID that we'll use as our namespace
-    NAMESPACE_UUID = uuid.UUID('fb7eec39-2d36-4c2f-a6b7-87568c8976b2')
-    # Generate a UUID using the course ID string
-    return str(uuid.uuid5(NAMESPACE_UUID, str(id_str)))
 
 def handle_moochub_data(page=1, per_page=25):
     try:
@@ -354,9 +347,8 @@ def handle_moochub_data(page=1, per_page=25):
                     }
                 
                 # Generate unique ID for this course-location combination
-                location_id = f"{course['id']}-{location['id']}"
                 transformed_course = {
-                    "id": generate_uuid_from_id(location_id),
+                    "id": generate_course_hash_id(course['id'], location['id']),
                     "type": "Course",
                     "attributes": attributes
                 }

--- a/functions/apiProxy/participant_data_handler.py
+++ b/functions/apiProxy/participant_data_handler.py
@@ -54,29 +54,59 @@ def resolve_course_id_from_url(course_id_param, org_courses):
     """
     Resolve course ID from URL parameter.
     Accepts both internal course IDs (integers) and hash IDs (UUIDs).
-    Returns the internal course ID for database queries.
+    Returns course information including internal ID, location info, and hash ID.
     
     Args:
         course_id_param: Course ID from URL (can be integer or UUID string)
-        org_courses: List of courses with hashId and _internalId fields
+        org_courses: List of courses with hashId, _internalId, selectedLocation, and locationOption fields
         
     Returns:
-        Internal course ID (integer) or None if not found
+        Dictionary with keys: course_id, location_id, location_option, hash_id
+        Returns None if course not found
     """
     # Try to parse as integer (internal ID)
     try:
         internal_id = int(course_id_param)
-        # Verify it exists in org_courses
+        # Verify it exists in org_courses and return first match with location info
         for course in org_courses:
-            if course.get("_internalId") == internal_id or course.get("id") == internal_id:
-                return internal_id
+            course_id = course.get("_internalId") or course.get("id")
+            if course_id == internal_id:
+                selected_location = course.get("selectedLocation")
+                location_id = selected_location.get("id") if selected_location else None
+                location_option = selected_location.get("locationOption") if selected_location else None
+                hash_id = course.get("hashId")
+                # If no hash_id, generate one (backward compatibility)
+                if not hash_id and location_id:
+                    hash_id = generate_course_hash_id(course_id, location_id)
+                elif not hash_id:
+                    hash_id = generate_course_hash_id(course_id)
+                return {
+                    "course_id": course_id,
+                    "location_id": location_id,
+                    "location_option": location_option,
+                    "hash_id": hash_id
+                }
         return None
     except (ValueError, TypeError):
         # Not an integer, try as hash ID (UUID)
         # Look up hash ID in org_courses
         for course in org_courses:
+            if not isinstance(course, dict):
+                continue
             if course.get("hashId") == course_id_param:
-                return course.get("_internalId") or course.get("id")
+                course_id = course.get("_internalId") or course.get("id")
+                if not course_id:
+                    logging.warning(f"Course found by hash ID but missing course_id: {course_id_param}")
+                    continue
+                selected_location = course.get("selectedLocation")
+                location_id = selected_location.get("id") if selected_location and isinstance(selected_location, dict) else None
+                location_option = selected_location.get("locationOption") if selected_location and isinstance(selected_location, dict) else None
+                return {
+                    "course_id": course_id,
+                    "location_id": location_id,
+                    "location_option": location_option,
+                    "hash_id": course_id_param  # Preserve the original hash ID from request
+                }
         return None
 
 
@@ -385,30 +415,35 @@ def get_organization_funded_courses(organization_id, eduhub_client):
             for funding_relation in result["data"].get("CourseFundingOrganization", []):
                 course = funding_relation.get("Course")
                 if course:
-                    # Select priority location and generate hash ID
                     course_locations = course.get("CourseLocations", [])
-                    selected_location = select_priority_location(course_locations)
+                    course_id = course["id"]
                     
-                    # Generate hash ID using course_id-location_id format (matching MOOCHub API)
-                    if selected_location:
-                        location_id = selected_location["id"]
-                        course_id = course["id"]
-                        hash_id = generate_course_hash_id(course_id, location_id)
-                        
-                        # Store hash ID and location info for future use
-                        course["hashId"] = hash_id
-                        course["selectedLocation"] = selected_location
-                        # Keep internal ID for backward compatibility with URL lookups
-                        course["_internalId"] = course_id
+                    # Create one entry per location (matching MOOCHub API behavior)
+                    if course_locations:
+                        for location in course_locations:
+                            # Create a copy of course data for this location
+                            course_entry = course.copy()
+                            location_id = location["id"]
+                            location_option = location.get("locationOption")
+                            hash_id = generate_course_hash_id(course_id, location_id)
+                            
+                            # Store location-specific info
+                            course_entry["hashId"] = hash_id
+                            course_entry["selectedLocation"] = location
+                            course_entry["_internalId"] = course_id
+                            course_entry["locationOption"] = location_option
+                            
+                            courses.append(course_entry)
                     else:
                         # Fallback: use course ID only if no locations exist
-                        course_id = course["id"]
+                        # Create a copy to avoid mutating the original GraphQL response object
+                        course_entry = course.copy()
                         hash_id = generate_course_hash_id(course_id)
-                        course["hashId"] = hash_id
-                        course["selectedLocation"] = None
-                        course["_internalId"] = course_id
-                    
-                    courses.append(course)
+                        course_entry["hashId"] = hash_id
+                        course_entry["selectedLocation"] = None
+                        course_entry["_internalId"] = course_id
+                        course_entry["locationOption"] = None
+                        courses.append(course_entry)
         except Exception as e:
             logging.warning(f"Primary course funding query parsing failed: {str(e)}")
     else:
@@ -448,25 +483,39 @@ def get_organization_funded_courses(organization_id, eduhub_client):
         fb_result = eduhub_client.send_query(fallback_query, variables)
         if _valid_result(fb_result):
             try:
-                courses = fb_result["data"].get("Course", [])
-                # Process locations and generate hash IDs for fallback results
-                for course in courses:
+                raw_courses = fb_result["data"].get("Course", [])
+                courses = []
+                # Process locations and generate hash IDs - one entry per location
+                for course in raw_courses:
                     course_locations = course.get("CourseLocations", [])
-                    selected_location = select_priority_location(course_locations)
+                    course_id = course["id"]
                     
-                    if selected_location:
-                        location_id = selected_location["id"]
-                        course_id = course["id"]
-                        hash_id = generate_course_hash_id(course_id, location_id)
-                        course["hashId"] = hash_id
-                        course["selectedLocation"] = selected_location
-                        course["_internalId"] = course_id
+                    # Create one entry per location (matching MOOCHub API behavior)
+                    if course_locations:
+                        for location in course_locations:
+                            # Create a copy of course data for this location
+                            course_entry = course.copy()
+                            location_id = location["id"]
+                            location_option = location.get("locationOption")
+                            hash_id = generate_course_hash_id(course_id, location_id)
+                            
+                            # Store location-specific info
+                            course_entry["hashId"] = hash_id
+                            course_entry["selectedLocation"] = location
+                            course_entry["_internalId"] = course_id
+                            course_entry["locationOption"] = location_option
+                            
+                            courses.append(course_entry)
                     else:
-                        course_id = course["id"]
+                        # Fallback: use course ID only if no locations exist
+                        # Create a copy to avoid mutating the original GraphQL response object
+                        course_entry = course.copy()
                         hash_id = generate_course_hash_id(course_id)
-                        course["hashId"] = hash_id
-                        course["selectedLocation"] = None
-                        course["_internalId"] = course_id
+                        course_entry["hashId"] = hash_id
+                        course_entry["selectedLocation"] = None
+                        course_entry["_internalId"] = course_id
+                        course_entry["locationOption"] = None
+                        courses.append(course_entry)
             except Exception as e:
                 logging.error(f"Fallback course funding query parsing failed: {str(e)}")
                 courses = []
@@ -477,9 +526,64 @@ def get_organization_funded_courses(organization_id, eduhub_client):
     return courses
 
 
-def get_course_participants(course_id, auth_info, eduhub_client):
+def _should_include_null_enrollment(enrollment_location, requested_location_option, course_locations):
     """
-    Get participants for a specific course with their enrollment and completion status
+    Determine if a NULL enrollment should be included based on fallback priority.
+    Priority: ONLINE -> KIEL -> HEIDE -> (any other location)
+    
+    Args:
+        enrollment_location: The enrollment's location (should be None)
+        requested_location_option: The requested location option (e.g., "ONLINE", "KIEL")
+        course_locations: List of course locations with locationOption
+        
+    Returns:
+        True if enrollment should be included, False otherwise
+    """
+    if enrollment_location is not None:
+        # Enrollment has a location, so it's handled by direct matching
+        return False
+    
+    if not requested_location_option:
+        # No location requested, include all NULL enrollments
+        return True
+    
+    # Get available location options for this course
+    available_options = [loc.get("locationOption") for loc in course_locations if loc.get("locationOption")]
+    
+    if not available_options:
+        # No locations available, include NULL enrollment
+        return True
+    
+    # Priority order: ONLINE > KIEL > HEIDE > others
+    priority_order = ['ONLINE', 'KIEL', 'HEIDE']
+    
+    # Find the highest priority location that exists for this course
+    highest_priority = None
+    for priority in priority_order:
+        if priority in available_options:
+            highest_priority = priority
+            break
+    
+    # If no priority location found, use first available
+    if highest_priority is None:
+        highest_priority = available_options[0]
+    
+    # Include NULL enrollment only if requested location matches highest priority
+    return requested_location_option == highest_priority
+
+
+def get_course_participants(course_id, auth_info, eduhub_client, location_id=None, location_option=None, hash_id=None):
+    """
+    Get participants for a specific course with their enrollment and completion status.
+    Optionally filters by location.
+    
+    Args:
+        course_id: Internal course ID
+        auth_info: Authentication information
+        eduhub_client: EduHub GraphQL client
+        location_id: Optional location ID for filtering
+        location_option: Optional location option value (ONLINE, KIEL, HEIDE, etc.)
+        hash_id: Optional hash ID to use (instead of generating)
     """
     query = """
     query GetCourseParticipants($courseId: Int!) {
@@ -489,6 +593,7 @@ def get_course_participants(course_id, auth_info, eduhub_client):
             created_at
             achievementCertificateURL
             attendanceCertificateURL
+            location
             User {
                 id
                 occupation
@@ -522,8 +627,21 @@ def get_course_participants(course_id, auth_info, eduhub_client):
     variables = {"courseId": course_id}
     result = eduhub_client.send_query(query, variables)
     
-    enrollments = result["data"]["CourseEnrollment"]
-    course_info = result["data"]["Course_by_pk"]
+    # Check for GraphQL errors
+    if "errors" in result:
+        error_messages = [err.get("message", str(err)) for err in result["errors"]]
+        logging.error(f"GraphQL query error in get_course_participants: {error_messages}")
+        # Check if error is about missing 'location' field (migration not run)
+        if any("location" in str(err).lower() or "field" in str(err).lower() for err in result["errors"]):
+            logging.error("The 'location' field may not exist in the database schema. Please run the migration to add the location column to CourseEnrollment.")
+        raise ValueError(f"GraphQL query failed: {', '.join(error_messages)}")
+    
+    if "data" not in result:
+        logging.error(f"GraphQL response missing data: {result}")
+        raise ValueError("GraphQL response missing data")
+    
+    enrollments = result["data"].get("CourseEnrollment", [])
+    course_info = result["data"].get("Course_by_pk")
     
     if not course_info:
         return None, None
@@ -545,30 +663,52 @@ def get_course_participants(course_id, auth_info, eduhub_client):
     attendance_result = eduhub_client.send_query(attendance_query, variables)
     attendance_data = attendance_result["data"]["Attendance"]
     
-    # Select priority location and generate hash ID for the course
     course_locations = course_info.get("CourseLocations", [])
-    selected_location = select_priority_location(course_locations)
+    course_id_from_db = course_info["id"]
     
-    if selected_location:
-        location_id = selected_location["id"]
-        course_id = course_info["id"]
-        hash_id = generate_course_hash_id(course_id, location_id)
-        course_info["hashId"] = hash_id
-        course_info["selectedLocation"] = selected_location
+    # Use provided location_id and hash_id, or generate/select if not provided
+    if location_id is not None:
+        # Find the location object from course_locations
+        selected_location = None
+        for loc in course_locations:
+            if loc.get("id") == location_id:
+                selected_location = loc
+                break
     else:
-        # Fallback: use course ID only if no locations exist
-        course_id = course_info["id"]
-        hash_id = generate_course_hash_id(course_id)
-        course_info["hashId"] = hash_id
-        course_info["selectedLocation"] = None
+        # Fallback: select priority location (backward compatibility)
+        selected_location = select_priority_location(course_locations)
+        if selected_location:
+            location_id = selected_location["id"]
     
-    # Keep internal ID for backward compatibility
-    course_info["_internalId"] = course_id
+    # Use provided hash_id or generate one
+    if hash_id is None:
+        if location_id is not None:
+            hash_id = generate_course_hash_id(course_id_from_db, location_id)
+        else:
+            hash_id = generate_course_hash_id(course_id_from_db)
+    
+    # Store hash ID and location info
+    course_info["hashId"] = hash_id
+    course_info["selectedLocation"] = selected_location
+    course_info["_internalId"] = course_id_from_db
+    
+    # Filter participants by location if location_option is provided
+    if location_option:
+        filtered_enrollments = []
+        for enrollment in enrollments:
+            enrollment_location = enrollment.get("location")
+            
+            # Include if location matches OR if NULL and matches fallback priority
+            if enrollment_location == location_option:
+                filtered_enrollments.append(enrollment)
+            elif enrollment_location is None:
+                # Check if this NULL enrollment should be included based on fallback priority
+                if _should_include_null_enrollment(enrollment_location, location_option, course_locations):
+                    filtered_enrollments.append(enrollment)
+        
+        enrollments = filtered_enrollments
     
     # Process participants
-    # TODO: Future enhancement - add participantLocation field to each participant
-    # This will indicate which location the participant is enrolled in
-    # The selectedLocation is stored in course_info for this future use
     participants = []
     for enrollment in enrollments:
         user = enrollment["User"]
@@ -720,17 +860,28 @@ def handle_participants_request(request):
                 'code': 'DB_CONNECTION_ERROR'
             }, 503
         
+        # Fetch organization's funded courses early (needed for hash ID resolution)
+        org_courses = get_organization_funded_courses(auth_info['organization_id'], eduhub_client)
+        
         # Get course ID from path or query params with validation
         path_parts = request.path.strip('/').split('/')
-        course_id = None
+        resolved_info = None
         
         if len(path_parts) > 1:
-            # Path: /participants/courses/123
+            # Path: /participants/courses/{course_id_or_hash}
             if path_parts[1] == 'courses' and len(path_parts) > 2:
-                is_valid, validated_id = validate_and_sanitize_input(path_parts[2], 'course_id')
-                if is_valid:
-                    course_id = validated_id
-                else:
+                try:
+                    resolved_info = resolve_course_id_from_url(path_parts[2], org_courses)
+                except Exception as e:
+                    logging.error(f"Error resolving course ID from URL: {str(e)}")
+                    import traceback
+                    logging.error(f"Traceback: {traceback.format_exc()}")
+                    security_handler.log_audit_event(
+                        'invalid_input', auth_info['organization_id'], client_ip, 
+                        request_data, False, f"Error resolving course ID in path: {path_parts[2]}: {str(e)}"
+                    )
+                    return {'error': 'Invalid course ID'}, 400
+                if resolved_info is None:
                     security_handler.log_audit_event(
                         'invalid_input', auth_info['organization_id'], client_ip, 
                         request_data, False, f"Invalid course ID in path: {path_parts[2]}"
@@ -738,13 +889,21 @@ def handle_participants_request(request):
                     return {'error': 'Invalid course ID'}, 400
         
         # Alternative: course_id in query params
-        if not course_id:
+        if not resolved_info:
             course_id_param = request.args.get('course_id')
             if course_id_param:
-                is_valid, validated_id = validate_and_sanitize_input(course_id_param, 'course_id')
-                if is_valid:
-                    course_id = validated_id
-                else:
+                try:
+                    resolved_info = resolve_course_id_from_url(course_id_param, org_courses)
+                except Exception as e:
+                    logging.error(f"Error resolving course ID from query param: {str(e)}")
+                    import traceback
+                    logging.error(f"Traceback: {traceback.format_exc()}")
+                    security_handler.log_audit_event(
+                        'invalid_input', auth_info['organization_id'], client_ip, 
+                        request_data, False, f"Error resolving course ID in query: {course_id_param}: {str(e)}"
+                    )
+                    return {'error': 'Invalid course ID parameter'}, 400
+                if resolved_info is None:
                     security_handler.log_audit_event(
                         'invalid_input', auth_info['organization_id'], client_ip, 
                         request_data, False, f"Invalid course ID in query: {course_id_param}"
@@ -752,32 +911,51 @@ def handle_participants_request(request):
                     return {'error': 'Invalid course ID parameter'}, 400
         
         # Log successful request processing
-        security_handler.log_audit_event(
-            'request_processed', auth_info['organization_id'], client_ip, 
-            request_data, True, f"Request processed successfully. Course ID: {course_id}"
-        )
+        if resolved_info:
+            security_handler.log_audit_event(
+                'request_processed', auth_info['organization_id'], client_ip, 
+                request_data, True, f"Request processed successfully. Course ID: {resolved_info['course_id']}, Hash ID: {resolved_info.get('hash_id', 'N/A')}"
+            )
+        else:
+            security_handler.log_audit_event(
+                'request_processed', auth_info['organization_id'], client_ip, 
+                request_data, True, "Request processed successfully. Listing all courses."
+            )
         
-        if course_id:
+        if resolved_info:
             # Get participants for specific course
-            return handle_course_participants(course_id, auth_info, eduhub_client, client_ip, request_data)
+            return handle_course_participants(
+                resolved_info['course_id'], 
+                auth_info, 
+                eduhub_client, 
+                client_ip, 
+                request_data,
+                location_id=resolved_info.get('location_id'),
+                location_option=resolved_info.get('location_option'),
+                hash_id=resolved_info.get('hash_id'),
+                org_courses=org_courses
+            )
         else:
             # List organization's funded courses
-            return handle_organization_courses(auth_info, eduhub_client, client_ip, request_data)
+            return handle_organization_courses(auth_info, eduhub_client, client_ip, request_data, org_courses=org_courses)
             
     except ValueError as e:
         logging.warning("Authentication error: %s", str(e))
         return {'error': str(e)}, 401
     except Exception as e:
+        import traceback
         logging.error(f"Participant data request error: {str(e)}")
+        logging.error(f"Traceback: {traceback.format_exc()}")
         return {'error': 'Internal server error'}, 500
 
 
-def handle_course_participants(course_id, auth_info, eduhub_client, client_ip, request_data):
+def handle_course_participants(course_id, auth_info, eduhub_client, client_ip, request_data, location_id=None, location_option=None, hash_id=None, org_courses=None):
     """
     Handle request for participants of a specific course with security enhancements
     """
     # Verify organization has access to this course
-    org_courses = get_organization_funded_courses(auth_info['organization_id'], eduhub_client)
+    if org_courses is None:
+        org_courses = get_organization_funded_courses(auth_info['organization_id'], eduhub_client)
     # Use _internalId if available (from our processing), otherwise use 'id' (from GraphQL)
     course_ids = [course.get('_internalId') or course.get('id') for course in org_courses]
     
@@ -789,7 +967,14 @@ def handle_course_participants(course_id, auth_info, eduhub_client, client_ip, r
         return {'error': 'Access denied: course not funded by your organization'}, 403
     
     # Get course and participant data
-    course_info, participants = get_course_participants(course_id, auth_info, eduhub_client)
+    course_info, participants = get_course_participants(
+        course_id, 
+        auth_info, 
+        eduhub_client,
+        location_id=location_id,
+        location_option=location_option,
+        hash_id=hash_id
+    )
     
     if not course_info:
         security_handler.log_audit_event(
@@ -798,8 +983,9 @@ def handle_course_participants(course_id, auth_info, eduhub_client, client_ip, r
         )
         return {'error': 'Course not found'}, 404
     
-    # Get hash ID (generated in get_course_participants)
-    hash_id = course_info.get("hashId")
+    # Use provided hash_id or get from course_info (backward compatibility)
+    if not hash_id:
+        hash_id = course_info.get("hashId")
     if not hash_id:
         # Fallback if hash ID wasn't generated (shouldn't happen, but safety check)
         hash_id = generate_course_hash_id(course_id)
@@ -869,11 +1055,12 @@ def handle_course_participants(course_id, auth_info, eduhub_client, client_ip, r
     return sanitized_response, 200, security_headers
 
 
-def handle_organization_courses(auth_info, eduhub_client, client_ip, request_data):
+def handle_organization_courses(auth_info, eduhub_client, client_ip, request_data, org_courses=None):
     """
     Handle request for list of organization's funded courses with security enhancements
     """
-    org_courses = get_organization_funded_courses(auth_info['organization_id'], eduhub_client)
+    if org_courses is None:
+        org_courses = get_organization_funded_courses(auth_info['organization_id'], eduhub_client)
     
     course_list = []
     for course in org_courses:
@@ -980,13 +1167,13 @@ def handle_participants_schema():
                 "list_courses": {
                     "method": "GET",
                     "path": "/participants",
-                    "description": "List all courses funded by the authenticated organization",
+                    "description": "List all courses funded by the authenticated organization. Returns one course entry per location (matching MOOCHub API behavior). Each course-location combination has a unique hash ID (UUID).",
                     "response_type": "CourseListReport"
                 },
                 "get_participants": {
                     "method": "GET", 
                     "path": "/participants/courses/{course_id}",
-                    "description": "Get participant enrollment and completion data for a specific funded course. Accepts internal course ID (integer) for backward compatibility. Returns hash ID (UUID) in response.",
+                    "description": "Get participant enrollment and completion data for a specific funded course-location combination. Accepts hash ID (UUID) as primary format, or internal course ID (integer) for backward compatibility. When hash ID is used, participants are filtered by the specific location. Returns hash ID (UUID) in response.",
                     "response_type": "ParticipantDataReport"
                 },
                 "get_schema": {
@@ -1018,7 +1205,7 @@ def handle_participants_schema():
                 "learningAchievements": "Optional array of certificate records with URNs and types"
             },
             "course_data": {
-                "id": "UUID v5 hash identifier (format: urn:course:{uuid}) - matches MOOCHub API format. Generated from course_id-location_id combination using priority: ONLINE > KIEL > HEIDE",
+                "id": "UUID v5 hash identifier (format: urn:course:{uuid}) - matches MOOCHub API format. Generated from course_id-location_id combination. Each course-location combination has a unique hash ID. One course entry is returned per location.",
                 "title": "Course title",
                 "summary": "Course description/tagline", 
                 "language": "Array of ISO language codes",

--- a/functions/apiProxy/participant_data_handler.py
+++ b/functions/apiProxy/participant_data_handler.py
@@ -11,6 +11,7 @@ from datetime import datetime, UTC
 try:
     from api_clients.eduhub_client import EduHubClient
     from security_handler import security_handler, get_security_level_for_organization, validate_and_sanitize_input, SecurityLevel
+    from course_id_utils import generate_course_hash_id
 except ImportError:
     # Fallback for when module is loaded from different context
     import sys
@@ -19,6 +20,64 @@ except ImportError:
     sys.path.insert(0, current_dir)
     from api_clients.eduhub_client import EduHubClient
     from security_handler import security_handler, get_security_level_for_organization, validate_and_sanitize_input, SecurityLevel
+    from course_id_utils import generate_course_hash_id
+
+
+def select_priority_location(course_locations):
+    """
+    Select the priority location from a list of course locations.
+    Priority order: ONLINE > KIEL > HEIDE > (any other location)
+    
+    Args:
+        course_locations: List of location dictionaries with 'id' and 'locationOption' keys
+        
+    Returns:
+        Selected location dictionary or None if no locations exist
+    """
+    if not course_locations:
+        return None
+    
+    # Priority order: ONLINE > KIEL > HEIDE > others
+    priority_order = ['ONLINE', 'KIEL', 'HEIDE']
+    
+    # First, try to find locations in priority order
+    for priority in priority_order:
+        for location in course_locations:
+            if location.get('locationOption') == priority:
+                return location
+    
+    # If no priority location found, return the first available location
+    return course_locations[0]
+
+
+def resolve_course_id_from_url(course_id_param, org_courses):
+    """
+    Resolve course ID from URL parameter.
+    Accepts both internal course IDs (integers) and hash IDs (UUIDs).
+    Returns the internal course ID for database queries.
+    
+    Args:
+        course_id_param: Course ID from URL (can be integer or UUID string)
+        org_courses: List of courses with hashId and _internalId fields
+        
+    Returns:
+        Internal course ID (integer) or None if not found
+    """
+    # Try to parse as integer (internal ID)
+    try:
+        internal_id = int(course_id_param)
+        # Verify it exists in org_courses
+        for course in org_courses:
+            if course.get("_internalId") == internal_id or course.get("id") == internal_id:
+                return internal_id
+        return None
+    except (ValueError, TypeError):
+        # Not an integer, try as hash ID (UUID)
+        # Look up hash ID in org_courses
+        for course in org_courses:
+            if course.get("hashId") == course_id_param:
+                return course.get("_internalId") or course.get("id")
+        return None
 
 
 def safe_float_convert(value):
@@ -296,6 +355,10 @@ def get_organization_funded_courses(organization_id, eduhub_client):
                 programId
                 achievementCertificatePossible
                 attendanceCertificatePossible
+                CourseLocations {
+                    id
+                    locationOption
+                }
                 Sessions {
                     id
                     startDateTime
@@ -322,6 +385,29 @@ def get_organization_funded_courses(organization_id, eduhub_client):
             for funding_relation in result["data"].get("CourseFundingOrganization", []):
                 course = funding_relation.get("Course")
                 if course:
+                    # Select priority location and generate hash ID
+                    course_locations = course.get("CourseLocations", [])
+                    selected_location = select_priority_location(course_locations)
+                    
+                    # Generate hash ID using course_id-location_id format (matching MOOCHub API)
+                    if selected_location:
+                        location_id = selected_location["id"]
+                        course_id = course["id"]
+                        hash_id = generate_course_hash_id(course_id, location_id)
+                        
+                        # Store hash ID and location info for future use
+                        course["hashId"] = hash_id
+                        course["selectedLocation"] = selected_location
+                        # Keep internal ID for backward compatibility with URL lookups
+                        course["_internalId"] = course_id
+                    else:
+                        # Fallback: use course ID only if no locations exist
+                        course_id = course["id"]
+                        hash_id = generate_course_hash_id(course_id)
+                        course["hashId"] = hash_id
+                        course["selectedLocation"] = None
+                        course["_internalId"] = course_id
+                    
                     courses.append(course)
         except Exception as e:
             logging.warning(f"Primary course funding query parsing failed: {str(e)}")
@@ -342,6 +428,10 @@ def get_organization_funded_courses(organization_id, eduhub_client):
                 programId
                 achievementCertificatePossible
                 attendanceCertificatePossible
+                CourseLocations {
+                    id
+                    locationOption
+                }
                 Sessions {
                     id
                     startDateTime
@@ -359,6 +449,24 @@ def get_organization_funded_courses(organization_id, eduhub_client):
         if _valid_result(fb_result):
             try:
                 courses = fb_result["data"].get("Course", [])
+                # Process locations and generate hash IDs for fallback results
+                for course in courses:
+                    course_locations = course.get("CourseLocations", [])
+                    selected_location = select_priority_location(course_locations)
+                    
+                    if selected_location:
+                        location_id = selected_location["id"]
+                        course_id = course["id"]
+                        hash_id = generate_course_hash_id(course_id, location_id)
+                        course["hashId"] = hash_id
+                        course["selectedLocation"] = selected_location
+                        course["_internalId"] = course_id
+                    else:
+                        course_id = course["id"]
+                        hash_id = generate_course_hash_id(course_id)
+                        course["hashId"] = hash_id
+                        course["selectedLocation"] = None
+                        course["_internalId"] = course_id
             except Exception as e:
                 logging.error(f"Fallback course funding query parsing failed: {str(e)}")
                 courses = []
@@ -393,6 +501,10 @@ def get_course_participants(course_id, auth_info, eduhub_client):
             ects
             language
             maxMissedSessions
+            CourseLocations {
+                id
+                locationOption
+            }
             Sessions {
                 id
                 startDateTime
@@ -433,7 +545,30 @@ def get_course_participants(course_id, auth_info, eduhub_client):
     attendance_result = eduhub_client.send_query(attendance_query, variables)
     attendance_data = attendance_result["data"]["Attendance"]
     
+    # Select priority location and generate hash ID for the course
+    course_locations = course_info.get("CourseLocations", [])
+    selected_location = select_priority_location(course_locations)
+    
+    if selected_location:
+        location_id = selected_location["id"]
+        course_id = course_info["id"]
+        hash_id = generate_course_hash_id(course_id, location_id)
+        course_info["hashId"] = hash_id
+        course_info["selectedLocation"] = selected_location
+    else:
+        # Fallback: use course ID only if no locations exist
+        course_id = course_info["id"]
+        hash_id = generate_course_hash_id(course_id)
+        course_info["hashId"] = hash_id
+        course_info["selectedLocation"] = None
+    
+    # Keep internal ID for backward compatibility
+    course_info["_internalId"] = course_id
+    
     # Process participants
+    # TODO: Future enhancement - add participantLocation field to each participant
+    # This will indicate which location the participant is enrolled in
+    # The selectedLocation is stored in course_info for this future use
     participants = []
     for enrollment in enrollments:
         user = enrollment["User"]
@@ -451,7 +586,12 @@ def get_course_participants(course_id, auth_info, eduhub_client):
 
 def process_participant_data(enrollment, user, attendance_data, course_info, auth_info):
     """
-    Process participant data based on access permissions
+    Process participant data based on access permissions.
+    
+    Note: course_info contains selectedLocation field for future participant location tracking.
+    TODO: Add participantLocation field to participant object to indicate which location
+    the participant is enrolled in. The selectedLocation from course_info can be used
+    as a default, but individual participant locations may differ.
     """
     
     # Determine completion status
@@ -459,6 +599,9 @@ def process_participant_data(enrollment, user, attendance_data, course_info, aut
     has_attendance_cert = bool(enrollment.get("attendanceCertificateURL"))
     
     # Base participant data
+    # TODO: Future enhancement - add participantLocation field to indicate which location
+    # the participant is enrolled in. Use course_info["selectedLocation"] as reference.
+    # Example: "participantLocation": {"id": location_id, "locationOption": "ONLINE"}
     participant = {
         "id": hash_user_id(user["id"]),
         "enrollmentStatus": enrollment["status"],
@@ -635,7 +778,8 @@ def handle_course_participants(course_id, auth_info, eduhub_client, client_ip, r
     """
     # Verify organization has access to this course
     org_courses = get_organization_funded_courses(auth_info['organization_id'], eduhub_client)
-    course_ids = [course['id'] for course in org_courses]
+    # Use _internalId if available (from our processing), otherwise use 'id' (from GraphQL)
+    course_ids = [course.get('_internalId') or course.get('id') for course in org_courses]
     
     if course_id not in course_ids:
         security_handler.log_audit_event(
@@ -654,10 +798,16 @@ def handle_course_participants(course_id, auth_info, eduhub_client, client_ip, r
         )
         return {'error': 'Course not found'}, 404
     
-    # Build response
+    # Get hash ID (generated in get_course_participants)
+    hash_id = course_info.get("hashId")
+    if not hash_id:
+        # Fallback if hash ID wasn't generated (shouldn't happen, but safety check)
+        hash_id = generate_course_hash_id(course_id)
+    
+    # Build response using hash ID instead of internal course ID
     response = {
         "type": "ParticipantDataReport",
-        "id": f"urn:report:course:{course_id}:{datetime.now(UTC).isoformat()}",
+        "id": f"urn:report:course:{hash_id}:{datetime.now(UTC).isoformat()}",
         "provider": {
             "id": "did:web:edu.opencampus.sh",
             "name": "opencampus.sh",
@@ -673,7 +823,7 @@ def handle_course_participants(course_id, auth_info, eduhub_client, client_ip, r
             }
         },
         "learningOpportunity": {
-            "id": f"urn:course:{course_id}",
+            "id": f"urn:course:{hash_id}",
             "title": course_info["title"],
             "summary": course_info.get("tagline"),
             "type": "Course",
@@ -727,13 +877,20 @@ def handle_organization_courses(auth_info, eduhub_client, client_ip, request_dat
     
     course_list = []
     for course in org_courses:
+        # Use hash ID instead of internal course ID
+        hash_id = course.get("hashId")
+        if not hash_id:
+            # Fallback if hash ID wasn't generated (shouldn't happen, but safety check)
+            course_id = course.get("_internalId") or course.get("id")
+            hash_id = generate_course_hash_id(course_id)
+        
         course_summary = {
-            "id": course["id"],
+            "id": hash_id,
             "title": course["title"],
             "description": course.get("description"),
             "startDate": course.get("startDate"),
             "endDate": course.get("endDate"),
-            "participantDataEndpoint": f"/participants/courses/{course['id']}"
+            "participantDataEndpoint": f"/participants/courses/{hash_id}"
         }
         
         # Only add creditPoints if ECTS value is valid and convertible
@@ -829,7 +986,7 @@ def handle_participants_schema():
                 "get_participants": {
                     "method": "GET", 
                     "path": "/participants/courses/{course_id}",
-                    "description": "Get participant enrollment and completion data for a specific funded course",
+                    "description": "Get participant enrollment and completion data for a specific funded course. Accepts internal course ID (integer) for backward compatibility. Returns hash ID (UUID) in response.",
                     "response_type": "ParticipantDataReport"
                 },
                 "get_schema": {
@@ -861,7 +1018,7 @@ def handle_participants_schema():
                 "learningAchievements": "Optional array of certificate records with URNs and types"
             },
             "course_data": {
-                "id": "Numeric course identifier",
+                "id": "UUID v5 hash identifier (format: urn:course:{uuid}) - matches MOOCHub API format. Generated from course_id-location_id combination using priority: ONLINE > KIEL > HEIDE",
                 "title": "Course title",
                 "summary": "Course description/tagline", 
                 "language": "Array of ISO language codes",

--- a/functions/apiProxy/schemas/participant-data-v1.0.0.json
+++ b/functions/apiProxy/schemas/participant-data-v1.0.0.json
@@ -52,7 +52,7 @@
     "LearningOpportunity": {
       "type": "object",
       "properties": {
-        "id": { "type": "string" },
+        "id": { "type": "string", "pattern": "^urn:course:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" },
         "title": { "type": "string" },
         "summary": { "type": "string" },
         "type": { "type": "string", "const": "Course" },
@@ -75,7 +75,7 @@
       "type": "object",
       "properties": {
         "type": { "type": "string", "const": "ParticipantDataReport" },
-        "id": { "type": "string" },
+        "id": { "type": "string", "pattern": "^urn:report:course:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:" },
         "provider": { "type": "object" },
         "learningOpportunity": { "$ref": "#/$defs/LearningOpportunity" },
         "participants": { "type": "array", "items": { "$ref": "#/$defs/Participant" } },
@@ -87,7 +87,7 @@
     "CourseSummary": {
       "type": "object",
       "properties": {
-        "id": { "type": "integer" },
+        "id": { "type": "string", "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$" },
         "title": { "type": "string" },
         "description": { "type": "string" },
         "startDate": { "type": "string" },

--- a/functions/apiProxy/schemas/participant-data-v1.0.0.json
+++ b/functions/apiProxy/schemas/participant-data-v1.0.0.json
@@ -75,7 +75,7 @@
       "type": "object",
       "properties": {
         "type": { "type": "string", "const": "ParticipantDataReport" },
-        "id": { "type": "string", "pattern": "^urn:report:course:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:" },
+        "id": { "type": "string", "pattern": "^urn:report:course:[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\\.[0-9]{1,6})?([+-][0-9]{2}:[0-9]{2}|Z)?$" },
         "provider": { "type": "object" },
         "learningOpportunity": { "$ref": "#/$defs/LearningOpportunity" },
         "participants": { "type": "array", "items": { "$ref": "#/$defs/Participant" } },

--- a/functions/dev.py
+++ b/functions/dev.py
@@ -47,7 +47,12 @@ def handle_request():
 def handle_api_proxy(subpath):
     # Use absolute path based on the current file's location
     current_dir = os.path.dirname(os.path.abspath(__file__))
-    api_proxy_path = os.path.join(current_dir, "apiProxy", "main.py")
+    api_proxy_dir = os.path.join(current_dir, "apiProxy")
+    api_proxy_path = os.path.join(api_proxy_dir, "main.py")
+    
+    # Add apiProxy directory to sys.path so relative imports work
+    if api_proxy_dir not in sys.path:
+        sys.path.insert(0, api_proxy_dir)
     
     # Force-reload modules to pick up code changes without restarting the dev server
     import importlib
@@ -58,6 +63,7 @@ def handle_api_proxy(subpath):
         "participant_data_handler",
         "security_handler",
         "api_clients.eduhub_client",
+        "course_id_utils",
     ]:
         if mod_name in _sys.modules:
             _sys.modules.pop(mod_name, None)


### PR DESCRIPTION
- Extract UUID generation to shared course_id_utils module
- Add generate_course_hash_id() function for course-location combinations
- Update MOOCHub API to use shared hash ID generation
- Update Participant API to use hash IDs matching MOOCHub format
- Implement location priority selection (ONLINE > KIEL > HEIDE)
- Add development API key to README for local testing
- Update dev.py to handle course_id_utils module imports

Both APIs now use consistent UUID v5 hash IDs generated from course_id-location_id combinations, ensuring the same course-location pair produces identical IDs across both APIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-location course entries with stable hash-based IDs and URN-style identifiers; location-priority selection (ONLINE > KIEL > HEIDE).

* **Improvements**
  * Participant and course responses include location context and support location-specific participant filtering.
  * Database schema now stores enrollment location and exposes it in permissions.
  * API rate limit window reduced to 1 minute.
  * Schema validations updated to require URN/UUID-style course identifiers.

* **Documentation**
  * Added development/testing guidance including a local dev key and example requests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->