### PR TITLE
feat(frontend): add experts management page

### DIFF
--- a/frontend-nx/apps/edu-hub/components/common/OnlyLoggedIn.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/OnlyLoggedIn.tsx
@@ -1,4 +1,5 @@
 import { FC, ReactElement, ReactNode } from "react";
+import useTranslation from "next-translate/useTranslation";
 
 import {
   useIsAdmin,
@@ -41,16 +42,26 @@ export const OnlyNotInstructor: FC<TProps> = ({ children }: TProps) => {
 
 type OnlyAdminProps = {
   children: ReactNode | ReactNode[];
+  showFeedback?: boolean;
 };
-export const OnlyAdmin: FC<OnlyAdminProps> = ({ children }: OnlyAdminProps) => {
+export const OnlyAdmin: FC<OnlyAdminProps> = ({ children, showFeedback = false }: OnlyAdminProps) => {
   const isLoggedIn = useIsLoggedIn();
   const isAdmin = useIsAdmin();
+  const { t } = useTranslation('common');
 
   if (isLoggedIn && isAdmin) {
     return <>{children}</>;
-  } else {
-    return null;
   }
+
+  if (showFeedback) {
+    return (
+      <div className="text-center py-8">
+        {!isLoggedIn ? t('auth.please_log_in') : t('auth.access_denied')}
+      </div>
+    );
+  }
+
+  return null;
 };
 export const OnlyInstructor: FC<TProps> = ({ children }: TProps) => {
   const isLoggedIn = useIsLoggedIn();

--- a/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
+++ b/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
@@ -89,6 +89,14 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu}>
+          <Link className="w-full text-lg" href="/manage/experts">
+            {t('menu.experts')}
+          </Link>
+        </MenuItem>
+      )}
+
+      {isAdmin && (
+        <MenuItem onClick={closeMenu}>
           <Link className="w-full text-lg" href="/manage/organizations">
             {t('menu.organizations')}
           </Link>

--- a/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
@@ -141,36 +141,28 @@ const ManageAdminUsersContent: FC = () => {
         header: t('organization'),
         accessorKey: 'Organization.name',
         enableSorting: true,
-        meta: {
-          width: 3,
-        },
+        size: 300,
         cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
       {
         header: t('first_name'),
         accessorKey: 'firstName',
         enableSorting: true,
-        meta: {
-          width: 2,
-        },
+        size: 200,
         cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
       {
         header: t('last_name'),
         accessorKey: 'lastName',
         enableSorting: true,
-        meta: {
-          width: 2,
-        },
+        size: 200,
         cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
       {
         header: t('email'),
         accessorKey: 'email',
         enableSorting: true,
-        meta: {
-          width: 3,
-        },
+        size: 300,
         cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
     ],

--- a/frontend-nx/apps/edu-hub/components/pages/ManageExpertsContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageExpertsContent/index.tsx
@@ -1,4 +1,4 @@
-import { FC, ReactNode, useMemo, useState } from 'react';
+import { FC, useMemo, useState } from 'react';
 import useTranslation from 'next-translate/useTranslation';
 import { ColumnDef } from '@tanstack/react-table';
 
@@ -8,8 +8,8 @@ import { useTableGrid } from '../../common/TableGrid/hooks';
 import { createMultiWordSearchCondition } from '../../common/TableGrid/utils';
 
 import { useAdminQuery } from '../../../hooks/authedQuery';
-import { EXPERTS_BY_LAST_NAME } from '../../../queries/experts';
-import { ExpertsByLastName_User } from '../../../queries/__generated__/ExpertsByLastName';
+import { EXPERTS_LIST } from '../../../queries/experts';
+import { ExpertsList_User } from '../../../queries/__generated__/ExpertsList';
 import { PageBlock } from '../../common/PageBlock';
 import CommonPageHeader from '../../common/CommonPageHeader';
 
@@ -20,7 +20,7 @@ interface ExpertRole {
   sessionTitle?: string;
 }
 
-const ExpandableExpertRow: FC<{ row: ExpertsByLastName_User }> = ({ row }) => {
+const ExpandableExpertRow: FC<{ row: ExpertsList_User }> = ({ row }) => {
   const { t } = useTranslation('manageExperts');
 
   // Collect all roles for this user
@@ -63,7 +63,7 @@ const ExpandableExpertRow: FC<{ row: ExpertsByLastName_User }> = ({ row }) => {
 
   return (
     <div className="bg-edu-course-list">
-      <div className="grid grid-cols-12 gap-2 p-2 font-medium text-gray-700 border-b border-gray-200">
+      <div className="hidden md:grid md:grid-cols-12 gap-2 p-2 font-medium text-gray-700 border-b border-gray-200">
         <div className="col-span-4 pl-3">{t('course')}</div>
         <div className="col-span-2">{t('program')}</div>
         <div className="col-span-3">{t('role')}</div>
@@ -72,16 +72,16 @@ const ExpandableExpertRow: FC<{ row: ExpertsByLastName_User }> = ({ row }) => {
       {roles.map((role, index) => (
         <div
           key={index}
-          className="grid grid-cols-12 gap-2 p-2 text-gray-600 text-sm border-b border-gray-100 last:border-b-0"
+          className="flex flex-col md:grid md:grid-cols-12 gap-2 p-2 text-gray-600 text-sm border-b border-gray-100 last:border-b-0"
         >
-          <div className="col-span-4 pl-3 truncate" title={role.courseTitle}>
+          <div className="md:col-span-4 md:pl-3 truncate font-medium md:font-normal" title={role.courseTitle}>
             {role.courseTitle}
           </div>
-          <div className="col-span-2 truncate">{role.programShortTitle}</div>
-          <div className="col-span-3">
+          <div className="md:col-span-2 truncate text-xs md:text-sm">{role.programShortTitle}</div>
+          <div className="md:col-span-3 text-xs md:text-sm">
             {role.type === 'instructor' ? t('role_instructor') : t('role_speaker')}
           </div>
-          <div className="col-span-3 truncate" title={role.sessionTitle || ''}>
+          <div className="md:col-span-3 truncate text-xs md:text-sm" title={role.sessionTitle || ''}>
             {role.sessionTitle || '-'}
           </div>
         </div>
@@ -94,14 +94,9 @@ const ManageExpertsContent: FC = () => {
   const { t } = useTranslation('manageExperts');
   const [pageSize, setPageSize] = useState(20);
 
-  const handlePageSizeChange = (newPageSize: number) => {
-    setPageSize(newPageSize);
-    setPageIndex(0);
-  };
-
   const { data, loading, error, pageIndex, setPageIndex, searchFilter, setSearchFilter } = useTableGrid({
     queryHook: useAdminQuery,
-    query: EXPERTS_BY_LAST_NAME,
+    query: EXPERTS_LIST,
     pageSize: pageSize,
     refetchFilter: (searchFilter) => {
       const searchCondition = createMultiWordSearchCondition(searchFilter, [
@@ -126,28 +121,30 @@ const ManageExpertsContent: FC = () => {
     },
   });
 
-  const columns = useMemo<ColumnDef<ExpertsByLastName_User>[]>(
+  const handlePageSizeChange = (newPageSize: number) => {
+    setPageSize(newPageSize);
+    setPageIndex(0);
+  };
+
+  const columns = useMemo<ColumnDef<ExpertsList_User>[]>(
     () => [
       {
         header: t('first_name'),
         accessorKey: 'firstName',
         enableSorting: true,
         size: 300,
-        cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
       {
         header: t('last_name'),
         accessorKey: 'lastName',
         enableSorting: true,
         size: 300,
-        cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
       {
         header: t('email'),
         accessorKey: 'email',
         enableSorting: true,
         size: 300,
-        cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
     ],
     [t]
@@ -174,7 +171,7 @@ const ManageExpertsContent: FC = () => {
               onSearchFilterChange={setSearchFilter}
               error={error}
               loading={loading}
-              refetchQueries={['ExpertsByLastName']}
+              refetchQueries={['ExpertsList']}
               expandableRowComponent={({ row }) => <ExpandableExpertRow row={row} />}
             />
           </div>

--- a/frontend-nx/apps/edu-hub/components/pages/ManageExpertsContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageExpertsContent/index.tsx
@@ -132,27 +132,21 @@ const ManageExpertsContent: FC = () => {
         header: t('first_name'),
         accessorKey: 'firstName',
         enableSorting: true,
-        meta: {
-          width: 3,
-        },
+        size: 300,
         cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
       {
         header: t('last_name'),
         accessorKey: 'lastName',
         enableSorting: true,
-        meta: {
-          width: 3,
-        },
+        size: 300,
         cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
       {
         header: t('email'),
         accessorKey: 'email',
         enableSorting: true,
-        meta: {
-          width: 3,
-        },
+        size: 300,
         cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
     ],

--- a/frontend-nx/apps/edu-hub/components/pages/ManageExpertsContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageExpertsContent/index.tsx
@@ -1,0 +1,194 @@
+import { FC, ReactNode, useMemo, useState } from 'react';
+import useTranslation from 'next-translate/useTranslation';
+import { ColumnDef } from '@tanstack/react-table';
+
+import TableGrid from '../../common/TableGrid';
+import Loading from '../../common/Loading';
+import { useTableGrid } from '../../common/TableGrid/hooks';
+import { createMultiWordSearchCondition } from '../../common/TableGrid/utils';
+
+import { useAdminQuery } from '../../../hooks/authedQuery';
+import { EXPERTS_BY_LAST_NAME } from '../../../queries/experts';
+import { ExpertsByLastName_User } from '../../../queries/__generated__/ExpertsByLastName';
+import { PageBlock } from '../../common/PageBlock';
+import CommonPageHeader from '../../common/CommonPageHeader';
+
+interface ExpertRole {
+  type: 'instructor' | 'speaker';
+  courseTitle: string;
+  programShortTitle: string;
+  sessionTitle?: string;
+}
+
+const ExpandableExpertRow: FC<{ row: ExpertsByLastName_User }> = ({ row }) => {
+  const { t } = useTranslation('manageExperts');
+
+  // Collect all roles for this user
+  const roles: ExpertRole[] = useMemo(() => {
+    const result: ExpertRole[] = [];
+
+    // Add instructor roles
+    row.CourseInstructors?.forEach((ci) => {
+      if (ci.Course) {
+        result.push({
+          type: 'instructor',
+          courseTitle: ci.Course.title,
+          programShortTitle: ci.Course.Program?.shortTitle || '',
+        });
+      }
+    });
+
+    // Add speaker roles
+    row.SessionSpeakers?.forEach((ss) => {
+      if (ss.Session?.Course) {
+        result.push({
+          type: 'speaker',
+          courseTitle: ss.Session.Course.title,
+          programShortTitle: ss.Session.Course.Program?.shortTitle || '',
+          sessionTitle: ss.Session.title,
+        });
+      }
+    });
+
+    return result;
+  }, [row.CourseInstructors, row.SessionSpeakers]);
+
+  if (roles.length === 0) {
+    return (
+      <div className="bg-edu-course-list p-4">
+        <p className="text-gray-600 text-sm">{t('no_roles')}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-edu-course-list">
+      <div className="grid grid-cols-12 gap-2 p-2 font-medium text-gray-700 border-b border-gray-200">
+        <div className="col-span-4 pl-3">{t('course')}</div>
+        <div className="col-span-2">{t('program')}</div>
+        <div className="col-span-3">{t('role')}</div>
+        <div className="col-span-3">{t('session')}</div>
+      </div>
+      {roles.map((role, index) => (
+        <div
+          key={index}
+          className="grid grid-cols-12 gap-2 p-2 text-gray-600 text-sm border-b border-gray-100 last:border-b-0"
+        >
+          <div className="col-span-4 pl-3 truncate" title={role.courseTitle}>
+            {role.courseTitle}
+          </div>
+          <div className="col-span-2 truncate">{role.programShortTitle}</div>
+          <div className="col-span-3">
+            {role.type === 'instructor' ? t('role_instructor') : t('role_speaker')}
+          </div>
+          <div className="col-span-3 truncate" title={role.sessionTitle || ''}>
+            {role.sessionTitle || '-'}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const ManageExpertsContent: FC = () => {
+  const { t } = useTranslation('manageExperts');
+  const [pageSize, setPageSize] = useState(20);
+
+  const handlePageSizeChange = (newPageSize: number) => {
+    setPageSize(newPageSize);
+    setPageIndex(0);
+  };
+
+  const { data, loading, error, pageIndex, setPageIndex, searchFilter, setSearchFilter } = useTableGrid({
+    queryHook: useAdminQuery,
+    query: EXPERTS_BY_LAST_NAME,
+    pageSize: pageSize,
+    refetchFilter: (searchFilter) => {
+      const searchCondition = createMultiWordSearchCondition(searchFilter, [
+        'lastName',
+        'firstName',
+        'email',
+        // Instructor course fields
+        'CourseInstructors.Course.title',
+        'CourseInstructors.Course.tagline',
+        'CourseInstructors.Course.contentDescriptionField1',
+        'CourseInstructors.Course.contentDescriptionField2',
+        'CourseInstructors.Course.headingDescriptionField1',
+        'CourseInstructors.Course.headingDescriptionField2',
+        // Session speaker fields
+        'SessionSpeakers.Session.title',
+        'SessionSpeakers.Session.description',
+        'SessionSpeakers.Session.Course.title',
+      ]);
+      return {
+        filter: searchCondition,
+      };
+    },
+  });
+
+  const columns = useMemo<ColumnDef<ExpertsByLastName_User>[]>(
+    () => [
+      {
+        header: t('first_name'),
+        accessorKey: 'firstName',
+        enableSorting: true,
+        meta: {
+          width: 3,
+        },
+        cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
+      },
+      {
+        header: t('last_name'),
+        accessorKey: 'lastName',
+        enableSorting: true,
+        meta: {
+          width: 3,
+        },
+        cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
+      },
+      {
+        header: t('email'),
+        accessorKey: 'email',
+        enableSorting: true,
+        meta: {
+          width: 3,
+        },
+        cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
+      },
+    ],
+    [t]
+  );
+
+  return (
+    <PageBlock>
+      <div className="max-w-screen-xl mx-auto mt-20">
+        {loading && <Loading />}
+        {!loading && !error && (
+          <div>
+            <div className="flex justify-between items-center mb-4">
+              <CommonPageHeader headline={t('headline')} />
+            </div>
+            <TableGrid
+              columns={columns}
+              data={data?.User || []}
+              totalCount={data?.User_aggregate?.aggregate?.count || 0}
+              pageIndex={pageIndex}
+              onPageChange={setPageIndex}
+              pageSize={pageSize}
+              onPageSizeChange={handlePageSizeChange}
+              searchFilter={searchFilter}
+              onSearchFilterChange={setSearchFilter}
+              error={error}
+              loading={loading}
+              refetchQueries={['ExpertsByLastName']}
+              expandableRowComponent={({ row }) => <ExpandableExpertRow row={row} />}
+            />
+          </div>
+        )}
+      </div>
+    </PageBlock>
+  );
+};
+
+export default ManageExpertsContent;
+

--- a/frontend-nx/apps/edu-hub/components/pages/ManageUsersContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageUsersContent/index.tsx
@@ -77,27 +77,21 @@ const ManageUsersContent: FC = () => {
         header: t('first_name'),
         accessorKey: 'firstName',
         enableSorting: true,
-        meta: {
-          width: 3,
-        },
+        size: 300,
         cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
       {
         header: t('last_name'),
         accessorKey: 'lastName',
         enableSorting: true,
-        meta: {
-          width: 3,
-        },
+        size: 300,
         cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
       {
         header: t('email'),
         accessorKey: 'email',
         enableSorting: true,
-        meta: {
-          width: 3,
-        },
+        size: 300,
         cell: ({ getValue }) => <div>{getValue<ReactNode>()}</div>,
       },
     ],

--- a/frontend-nx/apps/edu-hub/i18n.json
+++ b/frontend-nx/apps/edu-hub/i18n.json
@@ -19,6 +19,7 @@
       "manageOrganizations",
       "manageLocationAddresses",
       "manageEmailTemplates",
+      "manageExperts",
       "profile",
       "start-page",
       "certificates"

--- a/frontend-nx/apps/edu-hub/locales/de/common.json
+++ b/frontend-nx/apps/edu-hub/locales/de/common.json
@@ -38,6 +38,7 @@
     "my_certificates": "Meine Zertifikate",
     "faq": "FAQ",
     "user": "Benutzer",
+    "experts": "Experten",
     "courses": "Kurse",
     "achievements": "Leistungsnachweise",
     "achievement_templates": "Leistungsnachweisvorlagen",

--- a/frontend-nx/apps/edu-hub/locales/de/common.json
+++ b/frontend-nx/apps/edu-hub/locales/de/common.json
@@ -255,5 +255,9 @@
   "page_not_found": "Seite nicht gefunden",
   "page_not_found_description": "Die Seite, die du suchst, existiert leider nicht. Sie wurde möglicherweise verschoben oder gelöscht.",
   "back_to_home": "Zur Startseite",
-  "go_back": "Zurück"
+  "go_back": "Zurück",
+  "auth": {
+    "please_log_in": "Bitte melde dich an, um auf diese Seite zuzugreifen.",
+    "access_denied": "Du hast keine Berechtigung, auf diese Seite zuzugreifen."
+  }
 }

--- a/frontend-nx/apps/edu-hub/locales/de/manageExperts.json
+++ b/frontend-nx/apps/edu-hub/locales/de/manageExperts.json
@@ -1,0 +1,14 @@
+{
+  "headline": "Experten",
+  "first_name": "Vorname",
+  "last_name": "Nachname",
+  "email": "E-Mail",
+  "course": "Kurs",
+  "program": "Programm",
+  "role": "Rolle",
+  "session": "Termin",
+  "role_instructor": "Kursleitung",
+  "role_speaker": "Referent:in",
+  "no_roles": "Keine Rollen zugewiesen"
+}
+

--- a/frontend-nx/apps/edu-hub/locales/en/common.json
+++ b/frontend-nx/apps/edu-hub/locales/en/common.json
@@ -255,5 +255,9 @@
   "page_not_found": "Page not found",
   "page_not_found_description": "The page you're looking for doesn't exist. It may have been moved or deleted.",
   "back_to_home": "Back to home",
-  "go_back": "Go back"
+  "go_back": "Go back",
+  "auth": {
+    "please_log_in": "Please log in to access this page.",
+    "access_denied": "You do not have permission to access this page."
+  }
 }

--- a/frontend-nx/apps/edu-hub/locales/en/common.json
+++ b/frontend-nx/apps/edu-hub/locales/en/common.json
@@ -38,6 +38,7 @@
     "my_certificates": "My Certificates",
     "faq": "FAQ",
     "user": "User",
+    "experts": "Experts",
     "courses": "Courses",
     "achievements": "Achievement Records",
     "achievement_templates": "Achievement Record Templates",

--- a/frontend-nx/apps/edu-hub/locales/en/manageExperts.json
+++ b/frontend-nx/apps/edu-hub/locales/en/manageExperts.json
@@ -1,0 +1,14 @@
+{
+  "headline": "Experts",
+  "first_name": "First Name",
+  "last_name": "Last Name",
+  "email": "Email",
+  "course": "Course",
+  "program": "Program",
+  "role": "Role",
+  "session": "Session",
+  "role_instructor": "Instructor",
+  "role_speaker": "Speaker",
+  "no_roles": "No roles assigned"
+}
+

--- a/frontend-nx/apps/edu-hub/pages/manage/experts/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/experts/index.tsx
@@ -1,0 +1,32 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import path from 'path';
+path.resolve('./next.config.js');
+
+import Head from 'next/head';
+import { FC } from 'react';
+import { Page } from '../../../components/layout/Page';
+import { useIsAdmin, useIsLoggedIn } from '../../../hooks/authentication';
+
+import ManageExpertsContent from '../../../components/pages/ManageExpertsContent';
+
+const ManageExperts: FC = () => {
+  const isAdmin = useIsAdmin();
+  const isLoggedIn = useIsLoggedIn();
+
+  return (
+    <>
+      <Head>
+        <title>EduHub | opencampus.sh</title>
+        <link rel="icon" href="/favicon.png" />
+      </Head>
+      <div className="max-w-screen-xl mx-auto">
+        <Page>
+          <div className="min-h-[77vh]">{isLoggedIn && isAdmin && <ManageExpertsContent />}</div>
+        </Page>
+      </div>
+    </>
+  );
+};
+
+export default ManageExperts;
+

--- a/frontend-nx/apps/edu-hub/pages/manage/experts/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/experts/index.tsx
@@ -1,18 +1,11 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-import path from 'path';
-path.resolve('./next.config.js');
-
 import Head from 'next/head';
 import { FC } from 'react';
 import { Page } from '../../../components/layout/Page';
-import { useIsAdmin, useIsLoggedIn } from '../../../hooks/authentication';
+import { OnlyAdmin } from '../../../components/common/OnlyLoggedIn';
 
 import ManageExpertsContent from '../../../components/pages/ManageExpertsContent';
 
 const ManageExperts: FC = () => {
-  const isAdmin = useIsAdmin();
-  const isLoggedIn = useIsLoggedIn();
-
   return (
     <>
       <Head>
@@ -21,7 +14,11 @@ const ManageExperts: FC = () => {
       </Head>
       <div className="max-w-screen-xl mx-auto">
         <Page>
-          <div className="min-h-[77vh]">{isLoggedIn && isAdmin && <ManageExpertsContent />}</div>
+          <div className="min-h-[77vh]">
+            <OnlyAdmin showFeedback={true}>
+              <ManageExpertsContent />
+            </OnlyAdmin>
+          </div>
         </Page>
       </div>
     </>

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ExpertsByLastName.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ExpertsByLastName.ts
@@ -1,0 +1,162 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { User_bool_exp, User_order_by } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL query operation: ExpertsByLastName
+// ====================================================
+
+export interface ExpertsByLastName_User_CourseInstructors_Course_Program {
+  __typename: "Program";
+  id: number;
+  /**
+   * The 6 letter short title for the program.
+   */
+  shortTitle: string | null;
+}
+
+export interface ExpertsByLastName_User_CourseInstructors_Course {
+  __typename: "Course";
+  id: number;
+  /**
+   * The title of the course (only editable by an admin user)
+   */
+  title: string;
+  /**
+   * Shown below the title on the course page
+   */
+  tagline: string;
+  /**
+   * Content of the first course description field
+   */
+  contentDescriptionField1: string | null;
+  /**
+   * Content of the second course description field
+   */
+  contentDescriptionField2: string | null;
+  /**
+   * Heading of the the first course description field
+   */
+  headingDescriptionField1: string | null;
+  /**
+   * Heading of the the second course description field
+   */
+  headingDescriptionField2: string | null;
+  /**
+   * An object relationship
+   */
+  Program: ExpertsByLastName_User_CourseInstructors_Course_Program;
+}
+
+export interface ExpertsByLastName_User_CourseInstructors {
+  __typename: "CourseInstructor";
+  id: number;
+  /**
+   * An object relationship
+   */
+  Course: ExpertsByLastName_User_CourseInstructors_Course;
+}
+
+export interface ExpertsByLastName_User_SessionSpeakers_Session_Course_Program {
+  __typename: "Program";
+  id: number;
+  /**
+   * The 6 letter short title for the program.
+   */
+  shortTitle: string | null;
+}
+
+export interface ExpertsByLastName_User_SessionSpeakers_Session_Course {
+  __typename: "Course";
+  id: number;
+  /**
+   * The title of the course (only editable by an admin user)
+   */
+  title: string;
+  /**
+   * An object relationship
+   */
+  Program: ExpertsByLastName_User_SessionSpeakers_Session_Course_Program;
+}
+
+export interface ExpertsByLastName_User_SessionSpeakers_Session {
+  __typename: "Session";
+  id: number;
+  /**
+   * The title of the session
+   */
+  title: string;
+  /**
+   * A description of the session
+   */
+  description: string;
+  /**
+   * An object relationship
+   */
+  Course: ExpertsByLastName_User_SessionSpeakers_Session_Course;
+}
+
+export interface ExpertsByLastName_User_SessionSpeakers {
+  __typename: "SessionSpeaker";
+  id: number;
+  /**
+   * An object relationship
+   */
+  Session: ExpertsByLastName_User_SessionSpeakers_Session;
+}
+
+export interface ExpertsByLastName_User {
+  __typename: "User";
+  id: any;
+  /**
+   * The user's first name
+   */
+  firstName: string;
+  /**
+   * The user's last name
+   */
+  lastName: string;
+  /**
+   * The user's email address
+   */
+  email: string;
+  /**
+   * An array relationship
+   */
+  CourseInstructors: ExpertsByLastName_User_CourseInstructors[];
+  /**
+   * An array relationship
+   */
+  SessionSpeakers: ExpertsByLastName_User_SessionSpeakers[];
+}
+
+export interface ExpertsByLastName_User_aggregate_aggregate {
+  __typename: "User_aggregate_fields";
+  count: number;
+}
+
+export interface ExpertsByLastName_User_aggregate {
+  __typename: "User_aggregate";
+  aggregate: ExpertsByLastName_User_aggregate_aggregate | null;
+}
+
+export interface ExpertsByLastName {
+  /**
+   * fetch data from the table: "User"
+   */
+  User: ExpertsByLastName_User[];
+  /**
+   * fetch aggregated fields from the table: "User"
+   */
+  User_aggregate: ExpertsByLastName_User_aggregate;
+}
+
+export interface ExpertsByLastNameVariables {
+  limit?: number | null;
+  offset?: number | null;
+  filter?: User_bool_exp | null;
+  order_by?: User_order_by[] | null;
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ExpertsByLastName.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ExpertsByLastName.ts
@@ -26,10 +26,6 @@ export interface ExpertsByLastName_User_CourseInstructors_Course {
    */
   title: string;
   /**
-   * Shown below the title on the course page
-   */
-  tagline: string;
-  /**
    * Content of the first course description field
    */
   contentDescriptionField1: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ExpertsList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ExpertsList.ts
@@ -6,10 +6,10 @@
 import { User_bool_exp, User_order_by } from "./../../__generated__/globalTypes";
 
 // ====================================================
-// GraphQL query operation: ExpertsByLastName
+// GraphQL query operation: ExpertsList
 // ====================================================
 
-export interface ExpertsByLastName_User_CourseInstructors_Course_Program {
+export interface ExpertsList_User_CourseInstructors_Course_Program {
   __typename: "Program";
   id: number;
   /**
@@ -18,13 +18,17 @@ export interface ExpertsByLastName_User_CourseInstructors_Course_Program {
   shortTitle: string | null;
 }
 
-export interface ExpertsByLastName_User_CourseInstructors_Course {
+export interface ExpertsList_User_CourseInstructors_Course {
   __typename: "Course";
   id: number;
   /**
    * The title of the course (only editable by an admin user)
    */
   title: string;
+  /**
+   * Shown below the title on the course page
+   */
+  tagline: string;
   /**
    * Content of the first course description field
    */
@@ -44,19 +48,19 @@ export interface ExpertsByLastName_User_CourseInstructors_Course {
   /**
    * An object relationship
    */
-  Program: ExpertsByLastName_User_CourseInstructors_Course_Program;
+  Program: ExpertsList_User_CourseInstructors_Course_Program;
 }
 
-export interface ExpertsByLastName_User_CourseInstructors {
+export interface ExpertsList_User_CourseInstructors {
   __typename: "CourseInstructor";
   id: number;
   /**
    * An object relationship
    */
-  Course: ExpertsByLastName_User_CourseInstructors_Course;
+  Course: ExpertsList_User_CourseInstructors_Course;
 }
 
-export interface ExpertsByLastName_User_SessionSpeakers_Session_Course_Program {
+export interface ExpertsList_User_SessionSpeakers_Session_Course_Program {
   __typename: "Program";
   id: number;
   /**
@@ -65,7 +69,7 @@ export interface ExpertsByLastName_User_SessionSpeakers_Session_Course_Program {
   shortTitle: string | null;
 }
 
-export interface ExpertsByLastName_User_SessionSpeakers_Session_Course {
+export interface ExpertsList_User_SessionSpeakers_Session_Course {
   __typename: "Course";
   id: number;
   /**
@@ -75,10 +79,10 @@ export interface ExpertsByLastName_User_SessionSpeakers_Session_Course {
   /**
    * An object relationship
    */
-  Program: ExpertsByLastName_User_SessionSpeakers_Session_Course_Program;
+  Program: ExpertsList_User_SessionSpeakers_Session_Course_Program;
 }
 
-export interface ExpertsByLastName_User_SessionSpeakers_Session {
+export interface ExpertsList_User_SessionSpeakers_Session {
   __typename: "Session";
   id: number;
   /**
@@ -92,19 +96,19 @@ export interface ExpertsByLastName_User_SessionSpeakers_Session {
   /**
    * An object relationship
    */
-  Course: ExpertsByLastName_User_SessionSpeakers_Session_Course;
+  Course: ExpertsList_User_SessionSpeakers_Session_Course;
 }
 
-export interface ExpertsByLastName_User_SessionSpeakers {
+export interface ExpertsList_User_SessionSpeakers {
   __typename: "SessionSpeaker";
   id: number;
   /**
    * An object relationship
    */
-  Session: ExpertsByLastName_User_SessionSpeakers_Session;
+  Session: ExpertsList_User_SessionSpeakers_Session;
 }
 
-export interface ExpertsByLastName_User {
+export interface ExpertsList_User {
   __typename: "User";
   id: any;
   /**
@@ -122,35 +126,35 @@ export interface ExpertsByLastName_User {
   /**
    * An array relationship
    */
-  CourseInstructors: ExpertsByLastName_User_CourseInstructors[];
+  CourseInstructors: ExpertsList_User_CourseInstructors[];
   /**
    * An array relationship
    */
-  SessionSpeakers: ExpertsByLastName_User_SessionSpeakers[];
+  SessionSpeakers: ExpertsList_User_SessionSpeakers[];
 }
 
-export interface ExpertsByLastName_User_aggregate_aggregate {
+export interface ExpertsList_User_aggregate_aggregate {
   __typename: "User_aggregate_fields";
   count: number;
 }
 
-export interface ExpertsByLastName_User_aggregate {
+export interface ExpertsList_User_aggregate {
   __typename: "User_aggregate";
-  aggregate: ExpertsByLastName_User_aggregate_aggregate | null;
+  aggregate: ExpertsList_User_aggregate_aggregate | null;
 }
 
-export interface ExpertsByLastName {
+export interface ExpertsList {
   /**
    * fetch data from the table: "User"
    */
-  User: ExpertsByLastName_User[];
+  User: ExpertsList_User[];
   /**
    * fetch aggregated fields from the table: "User"
    */
-  User_aggregate: ExpertsByLastName_User_aggregate;
+  User_aggregate: ExpertsList_User_aggregate;
 }
 
-export interface ExpertsByLastNameVariables {
+export interface ExpertsListVariables {
   limit?: number | null;
   offset?: number | null;
   filter?: User_bool_exp | null;

--- a/frontend-nx/apps/edu-hub/queries/experts.ts
+++ b/frontend-nx/apps/edu-hub/queries/experts.ts
@@ -1,7 +1,7 @@
 import { gql } from '@apollo/client';
 
-export const EXPERTS_BY_LAST_NAME = gql`
-  query ExpertsByLastName(
+export const EXPERTS_LIST = gql`
+  query ExpertsList(
     $limit: Int = 10
     $offset: Int = 0
     $filter: User_bool_exp = {}

--- a/frontend-nx/apps/edu-hub/queries/experts.ts
+++ b/frontend-nx/apps/edu-hub/queries/experts.ts
@@ -1,0 +1,84 @@
+import { gql } from '@apollo/client';
+
+export const EXPERTS_BY_LAST_NAME = gql`
+  query ExpertsByLastName(
+    $limit: Int = 10
+    $offset: Int = 0
+    $filter: User_bool_exp = {}
+    $order_by: [User_order_by!] = [{ updated_at: desc }]
+  ) {
+    User(
+      limit: $limit
+      offset: $offset
+      order_by: $order_by
+      where: {
+        _and: [
+          { status: { _eq: ACTIVE } }
+          {
+            _or: [
+              { CourseInstructors: {} }
+              { SessionSpeakers: {} }
+            ]
+          }
+          $filter
+        ]
+      }
+    ) {
+      id
+      firstName
+      lastName
+      email
+      CourseInstructors {
+        id
+        Course {
+          id
+          title
+          tagline
+          contentDescriptionField1
+          contentDescriptionField2
+          headingDescriptionField1
+          headingDescriptionField2
+          Program {
+            id
+            shortTitle
+          }
+        }
+      }
+      SessionSpeakers {
+        id
+        Session {
+          id
+          title
+          description
+          Course {
+            id
+            title
+            Program {
+              id
+              shortTitle
+            }
+          }
+        }
+      }
+    }
+    User_aggregate(
+      where: {
+        _and: [
+          { status: { _eq: ACTIVE } }
+          {
+            _or: [
+              { CourseInstructors: {} }
+              { SessionSpeakers: {} }
+            ]
+          }
+          $filter
+        ]
+      }
+    ) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+


### PR DESCRIPTION
- Add new /manage/experts page to display instructors and session speakers
- Implement ManageExpertsContent component with TableGrid
- Add GraphQL query to fetch users with CourseInstructors and SessionSpeakers
- Implement multi-word search across user fields, course fields, and session fields
- Add expandable rows showing course/session assignments with roles
- Add menu item for experts page in admin navigation
- Add English and German translations for experts management
- Register manageExperts namespace in i18n configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin-only "Experts" menu link and new Manage Experts admin page with search, filters, pagination, and expandable rows showing instructor/speaker roles.
  * Admin access wrapper now optionally shows translated feedback messages when access is denied or login is required.

* **Documentation**
  * Added English and German translations for the experts UI and new auth feedback messages.

* **Style**
  * Adjusted column widths in admin user tables for improved layout.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->