### PR TITLE
Migration deployment issue investigation

### DIFF
--- a/infrastructure/application/06_cloud-functions.tf
+++ b/infrastructure/application/06_cloud-functions.tf
@@ -342,12 +342,33 @@ resource "google_cloudfunctions2_function" "call_node_function" {
   }
 }
 
-# Make sure the Cloud Function's service account can access Formbricks secret
+# Make sure the Cloud Function's service account can access all required secrets
 resource "google_secret_manager_secret_iam_member" "call_node_function_formbricks_api_key" {
   secret_id  = google_secret_manager_secret.formbricks_api_key.id
   role       = "roles/secretmanager.secretAccessor"
   member     = "serviceAccount:${google_service_account.custom_cloud_function_account.email}"
   depends_on = [google_secret_manager_secret.formbricks_api_key]
+}
+
+resource "google_secret_manager_secret_iam_member" "call_node_function_keycloak_pw" {
+  secret_id  = google_secret_manager_secret.keycloak_pw.id
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:${google_service_account.custom_cloud_function_account.email}"
+  depends_on = [google_secret_manager_secret.keycloak_pw]
+}
+
+resource "google_secret_manager_secret_iam_member" "call_node_function_cloud_function_secret" {
+  secret_id  = google_secret_manager_secret.cloud_function.id
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:${google_service_account.custom_cloud_function_account.email}"
+  depends_on = [google_secret_manager_secret.cloud_function]
+}
+
+resource "google_secret_manager_secret_iam_member" "call_node_function_hasura_admin_key" {
+  secret_id  = google_secret_manager_secret.hasura_graphql_admin_key.id
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:${google_service_account.custom_cloud_function_account.email}"
+  depends_on = [google_secret_manager_secret.hasura_graphql_admin_key]
 }
 
 


### PR DESCRIPTION
Add missing IAM bindings for `call_node_function` to access existing secrets.

A previous PR switched the `call_node_function` to use a custom service account but only granted it access to the new `formbricks-api-key` secret. This caused deployment failures as the function lost access to previously used secrets like `keycloak-pw`, `cloud-function`, and `hasura-graphql-admin-key`. This PR restores the necessary permissions.

---
<a href="https://cursor.com/background-agent?bcId=bc-e804b9e2-d4af-481f-938a-8f22ed3edd20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e804b9e2-d4af-481f-938a-8f22ed3edd20"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced cloud infrastructure security by configuring proper access permissions for service accounts to access required secrets.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->