### PR TITLE
fix: reset page index when search filter changes in SessionsTab

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/SessionsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/SessionsTab/index.tsx
@@ -192,6 +192,11 @@ export const SessionsTab: FC<IProps> = ({ course, qResult }) => {
     setPageIndex(0);
   }, []);
 
+  const handleSearchFilterChange = useCallback((value: string) => {
+    setSearchFilter(value);
+    setPageIndex(0);
+  }, []);
+
   const lectureStart = course.Program?.lectureStart;
   const lectureEnd = course.Program?.lectureEnd;
 
@@ -326,7 +331,7 @@ export const SessionsTab: FC<IProps> = ({ course, qResult }) => {
         pageSize={pageSize}
         onPageSizeChange={handlePageSizeChange}
         searchFilter={searchFilter}
-        onSearchFilterChange={setSearchFilter}
+        onSearchFilterChange={handleSearchFilterChange}
         refetchQueries={['ManagedCourse']}
         onAddButtonClick={insertSession}
         addButtonText={t('add_session')}


### PR DESCRIPTION
Resets page index to 0 when the search filter changes in the Sessions tab, so users on later pages see matching results immediately instead of an empty table.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search filtering in course content management. When applying a new search filter, pagination now automatically resets to the first page of results, ensuring users start from the beginning when filtering sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->