### PR TITLE
feat: add funding organizations component and footer translations

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/FundingOrganizations.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/FundingOrganizations.tsx
@@ -1,0 +1,67 @@
+import { FC } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { getPublicImageUrl } from '../../../helpers/filehandling';
+
+interface FundingOrganization {
+  id: number;
+  Organization: {
+    id: number;
+    name: string;
+    logo: string | null;
+  };
+}
+
+interface IProps {
+  courseFundingOrganizations: FundingOrganization[];
+}
+
+const LOGO_SIZE = 512;
+const LOGO_HEIGHT = 80;
+const LOGO_WIDTH = 400;
+
+export const FundingOrganizations: FC<IProps> = ({ courseFundingOrganizations }) => {
+  const t = useTranslations('course');
+
+  const organizationsWithLogos = courseFundingOrganizations.filter(
+    (cfo) => cfo.Organization?.logo
+  );
+
+  if (organizationsWithLogos.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mt-10 bg-edu-course-invited text-label-primary light rounded-2xl p-4 mx-6 xl:mx-0">
+      <span className="text-sm font-medium tracking-wide mb-4 block text-label-primary">
+        {t('funded_by')}
+      </span>
+      <div className="flex flex-col sm:flex-row flex-wrap items-center gap-6 sm:gap-8">
+        {organizationsWithLogos.map((cfo) => {
+          const logo = cfo.Organization.logo;
+          if (!logo) return null;
+          const logoUrl = getPublicImageUrl(logo, LOGO_SIZE);
+          if (!logoUrl) {
+            return null;
+          }
+          return (
+            <div
+              key={cfo.id}
+              className="flex shrink-0 items-center justify-center"
+              style={{ width: LOGO_WIDTH, height: LOGO_HEIGHT }}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={logoUrl}
+                alt={cfo.Organization.name}
+                width={LOGO_WIDTH}
+                height={LOGO_HEIGHT}
+                className="max-h-full max-w-full object-contain"
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/index.tsx
@@ -15,6 +15,7 @@ import { getCourseEnrollment } from '../../../helpers/util';
 import { ContentRow } from '../../common/ContentRow';
 import { PageBlock } from '../../common/PageBlock';
 import { DescriptionFields } from './DescriptionFields';
+import { FundingOrganizations } from './FundingOrganizations';
 import { InfoPanel } from './InfoPanel';
 import { useWeekdayStartAndEndString } from '../../../helpers/dateTimeHelpers';
 import { LearningGoals } from './LearningGoals';
@@ -50,7 +51,7 @@ const CourseContent: FC<{ id: number }> = ({ id }) => {
       userId,
     },
     fetchPolicy: 'cache-and-network',
-    async onCompleted(data) {
+    onCompleted(data) {
       // Check if user has been invited to the course and the invitation has not expired
       const courseEnrollment = getCourseEnrollment(data?.Course_by_pk, userId);
       const enrollmentStatus = courseEnrollment?.status;
@@ -198,18 +199,16 @@ const CourseContent: FC<{ id: number }> = ({ id }) => {
                 (course.achievementCertificatePossible || course.attendanceCertificatePossible) && (
                   <ContentRow className="my-24 text-label-primary bg-fill-primary light px-8 py-8">
                     {!isDegreeCourse && (
-                      <>
-                        <div className="flex flex-col md:flex-row gap-12 md:gap-24 w-full">
-                          <Attendances course={course} />
-                          {!courseEnrollment?.achievementCertificateURL && (
-                            <AchievementRecord
-                              courseId={course.id}
-                              achievementRecordUploadDeadline={course.Program.achievementRecordUploadDeadline}
-                              courseTitle={course.title}
-                            />
-                          )}
-                        </div>
-                      </>
+                      <div className="flex flex-col md:flex-row gap-12 md:gap-24 w-full">
+                        <Attendances course={course} />
+                        {!courseEnrollment?.achievementCertificateURL && (
+                          <AchievementRecord
+                            courseId={course.id}
+                            achievementRecordUploadDeadline={course.Program.achievementRecordUploadDeadline}
+                            courseTitle={course.title}
+                          />
+                        )}
+                      </div>
                     )}
                     {isDegreeCourse && <CompletedDegreeCourses degreeCourseId={course.id} />}
                     <CertificateDownload courseEnrollment={courseEnrollment} />
@@ -227,7 +226,7 @@ const CourseContent: FC<{ id: number }> = ({ id }) => {
                   ) : (
                     <CurrentDegreeCourses degreeCourses={course.DegreeCourses} />
                   )}
-                  {requiresPayment && (course.basePrice || course.basePrice === 0 || course.basePrice === null || addonItems.length > 0) && (
+                  {!!(requiresPayment && (course.basePrice || course.basePrice === 0 || course.basePrice === null || addonItems.length > 0)) && (
                     <div className="mt-24">
                       <span className="text-3xl font-semibold block mb-6">{tCoursePage('pricing_section_title')}</span>
                       <PricingSummary
@@ -246,6 +245,7 @@ const CourseContent: FC<{ id: number }> = ({ id }) => {
                 </div>
               </ContentRow>
               <DescriptionFields course={course} />
+              <FundingOrganizations courseFundingOrganizations={course.CourseFundingOrganizations ?? []} />
             </div>
           </div>
         </div>

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -327,6 +327,7 @@
       "current_degree_elements": "Aktuelle Angebote im Rahmen des Degrees",
       "no_degree_elements_available": "Aktuell gibt es keine laufenden Angebote zu diesem Degree."
     },
+    "funded_by": "Gefördert durch:",
     "learning": {
       "you_will_learn": "Du wirst lernen",
       "general_achievement_certificate_conditions": "**Online-Teilnahme:**\nWenn eine Online-Teilnahme möglich ist, wird die Teilnahme nur dann als anwesend gewertet, wenn die Kamera eingeschaltet ist.\n\n**Semester Opening:**\nWir laden euch zum kursübergreifenden Semester Opening am 16. Oktober 2025 im COBL (Legienstraße 40, Kiel) ein! 💛\nHier bekommt ihr Einblicke hinter die Kulissen unserer OC-Community, lernt Kursleitungen und andere Kursteilnehmer:innen kennen und könnt in inspirierenden Sessions die Kieler Unternehmenslandschaft entdecken.\nZu allen Infos und zur Anmeldung geht es [HIER](https://forms.office.com/e/2TrRyRTCS5)."
@@ -1642,5 +1643,12 @@
     "no_pricing": "Keine Preise konfiguriert.",
     "synced": "Synchronisiert",
     "not_synced": "Nicht synchronisiert"
+  },
+  "footer": {
+    "imprint": "Impressum",
+    "privacy": "Datenschutz",
+    "faq": "FAQ",
+    "newsletter": "Newsletter",
+    "sponsored_by": "Gefördert durch:"
   }
 }

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -327,6 +327,7 @@
       "current_degree_elements": "Current Offerings that are Part of the Degree",
       "no_degree_elements_available": "Currently there are no ongoing offerings for this Degree."
     },
+    "funded_by": "Funded by:",
     "learning": {
       "you_will_learn": "You will learn",
       "general_achievement_certificate_conditions": "**Online Participation:**\nIf online participation is possible, attendances are only counted as present if the camera is continuously turned on!\n\n**Semester Opening:**\nWe invite you to the Semester Opening for all courses on October 16, 2025, at the COBL (Legienstraße 40, Kiel)! 💛\nHere you can get a glimpse behind the scenes of our OC community, get to know course instructors and other course participants and discover Kiel's corporate landscape in inspiring sessions.\nClick here for all information and to register: [HERE](https://forms.office.com/e/2TrRyRTCS5)."
@@ -1645,5 +1646,12 @@
     "no_pricing": "No pricing configured.",
     "synced": "Synced",
     "not_synced": "Not synced"
+  },
+  "footer": {
+    "imprint": "Imprint",
+    "privacy": "Privacy",
+    "faq": "FAQ",
+    "newsletter": "Newsletter",
+    "sponsored_by": "Sponsored by:"
   }
 }


### PR DESCRIPTION
Add FundingOrganizations component to display funding organizations on
the course content page. Include footer-related i18n keys (imprint,
privacy, FAQ, newsletter, sponsored_by) and minor cleanup in
CourseContent (remove unnecessary fragment, fix boolean coercion).

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added funding organization logos display on course content pages to show organizations providing support, featuring a "Funded by" section label.

* **Translations**
  * Extended English and German translation files with new funding organization labels for course pages and new footer navigation links including imprint, privacy policy, FAQ, newsletter signup, and sponsorship information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->