### PR TITLE
fix(moochub): correct date fields and add contentLocation fallback for onsite courses

### DIFF
--- a/docs/MOOCHUB_FEED_DOCUMENTATION.md
+++ b/docs/MOOCHUB_FEED_DOCUMENTATION.md
@@ -90,6 +90,10 @@ curl "https://api.edu.opencampus.sh/moochub?page=1&per_page=10"
         },
         "courseMode": ["online"],
         "inLanguage": ["en"],
+        "startDate": ["2024-03-15T09:00:00Z"],
+        "endDate": ["2024-06-20T17:00:00Z"],
+        "applicationStartDate": "2024-01-15T00:00:00Z",
+        "applicationDeadline": "2024-03-10T00:00:00Z",
         "url": "https://edu.opencampus.sh/course/123?source=moochub&provider=opencampus-sh&feed_version=3.0.1",
         "description": "<p>Course description in HTML</p>",
         "publisher": {
@@ -206,6 +210,21 @@ for location in course["CourseLocations"]:
 # Determine courseMode based on location
 course_mode = ["online"] if location["locationOption"] == "ONLINE" else ["onsite"]
 ```
+
+### Date Field Mapping
+
+The feed maps EduHub date fields to MOOCHub schema v3.0.1 as follows:
+
+| MOOCHub Field | Type | EduHub Source |
+|---------------|------|---------------|
+| `startDate` | DateTimeSeries (array) | First `Session.startDateTime` (sessions ordered by startDateTime asc) |
+| `endDate` | DateTimeSeries (array) | Last `Session.endDateTime` (sessions ordered by startDateTime asc) |
+| `applicationStartDate` | NullableDateTime (single) | `Program.applicationStart` |
+| `applicationDeadline` | NullableDateTime (single) | `Course.applicationEnd` |
+
+- **startDate** and **endDate**: Derived from the course's sessions. If a course has no sessions, both are `null`.
+- **applicationStartDate**: When the application/enrollment period begins (from the course's program).
+- **applicationDeadline**: When the application/enrollment period ends (last day applications are accepted).
 
 ### Metadata Tag Collection
 

--- a/functions/apiProxy/main.py
+++ b/functions/apiProxy/main.py
@@ -127,6 +127,11 @@ def handle_moochub_data(page=1, per_page=25):
                 Program {
                     id
                     shortTitle
+                    applicationStart
+                }
+                Sessions(order_by: { startDateTime: asc }) {
+                    startDateTime
+                    endDateTime
                 }
                 CourseLocations {
                     id
@@ -234,7 +239,22 @@ def handle_moochub_data(page=1, per_page=25):
                             break
                     if has_dlc_funding:
                         break
-            
+
+            # Compute course start/end dates from first and last session
+            sessions = course.get("Sessions", [])
+            first_session_start = sessions[0]["startDateTime"] if sessions else None
+            last_session_end = sessions[-1]["endDateTime"] if sessions else None
+
+            # Format application dates for MOOCHub (date-only fields need time suffix)
+            application_start = course.get("Program", {}).get("applicationStart")
+            application_deadline = course.get("applicationEnd")
+            application_start_date = (
+                f"{application_start}T00:00:00Z" if application_start else None
+            )
+            application_deadline_str = (
+                f"{application_deadline}T00:00:00Z" if application_deadline else None
+            )
+
             # Create one entry per course location
             for location in course["CourseLocations"]:
                 # Determine courseMode based on location
@@ -251,7 +271,10 @@ def handle_moochub_data(page=1, per_page=25):
                     },
                     "courseMode": course_mode,
                     "inLanguage": [course["language"].lower()],
-                    "startDate": [f"{course['applicationEnd']}T00:00:00Z"] if course["applicationEnd"] else None,
+                    "startDate": [first_session_start] if first_session_start else None,
+                    "endDate": [last_session_end] if last_session_end else None,
+                    "applicationStartDate": application_start_date,
+                    "applicationDeadline": application_deadline_str,
                     "description": "".join(description_parts),
                     "publisher": {
                         "name": "opencampus.sh",
@@ -278,10 +301,11 @@ def handle_moochub_data(page=1, per_page=25):
                 moochub_params = "source=moochub&provider=opencampus-sh&feed_version=3.0.1"
                 attributes["url"] = f"{api_base_url}/course/{course['id']}?{moochub_params}"
                 
-                # Add contentLocation for onsite courses with valid defaultSessionAddressId
-                if location["locationOption"] != "ONLINE" and location.get("defaultSessionAddressId"):
-                    address_id = location["defaultSessionAddressId"]
-                    if address_id in LOCATION_ADDRESS_MAPPING:
+                # Add contentLocation for onsite courses
+                if location["locationOption"] != "ONLINE":
+                    address_id = location.get("defaultSessionAddressId")
+                    default_addr = location.get("DefaultSessionAddress") or {}
+                    if address_id and address_id in LOCATION_ADDRESS_MAPPING:
                         location_data = LOCATION_ADDRESS_MAPPING[address_id]
                         attributes["contentLocation"] = {
                             "name": location_data["name"],
@@ -291,6 +315,17 @@ def handle_moochub_data(page=1, per_page=25):
                                 "description": location_data["description"]
                             }
                         }
+                    else:
+                        content_location = {"name": default_addr.get("shortLabel")}
+                        address_block = {
+                            "city": (location.get("locationOption") or "").title()
+                        }
+                        if default_addr.get("address"):
+                            address_block["streetAddress"] = default_addr["address"]
+                        if default_addr.get("description"):
+                            address_block["description"] = default_addr["description"]
+                        content_location["address"] = address_block
+                        attributes["contentLocation"] = content_location
                 
                 # Note: metadata_tags are collected but not included in the feed
                 # They are used internally for determining funding and other custom attributes

--- a/functions/apiProxy/main.py
+++ b/functions/apiProxy/main.py
@@ -316,7 +316,9 @@ def handle_moochub_data(page=1, per_page=25):
                             }
                         }
                     else:
-                        content_location = {"name": default_addr.get("shortLabel")}
+                        safe_name = default_addr.get("shortLabel") or (
+                            location.get("locationOption") or ""
+                        ).title()
                         address_block = {
                             "city": (location.get("locationOption") or "").title()
                         }
@@ -324,8 +326,11 @@ def handle_moochub_data(page=1, per_page=25):
                             address_block["streetAddress"] = default_addr["address"]
                         if default_addr.get("description"):
                             address_block["description"] = default_addr["description"]
-                        content_location["address"] = address_block
-                        attributes["contentLocation"] = content_location
+                        if safe_name or address_block.get("streetAddress") or address_block.get(
+                            "description"
+                        ) or address_block.get("city"):
+                            content_location = {"name": safe_name, "address": address_block}
+                            attributes["contentLocation"] = content_location
                 
                 # Note: metadata_tags are collected but not included in the feed
                 # They are used internally for determining funding and other custom attributes


### PR DESCRIPTION
- startDate: use first session startDateTime instead of applicationEnd
- endDate: add from last session endDateTime
- applicationStartDate: add from Program.applicationStart
- applicationDeadline: add from Course.applicationEnd
- contentLocation: fallback to DefaultSessionAddress for unmapped onsite
  addresses; title-case locationOption for city

Co-authored-by: Cursor <cursoragent@cursor.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Date Field Mapping section describing startDate, endDate, applicationStartDate, and applicationDeadline and their mappings to MOOCHub schema v3.0.1.
  * Updated feed example to include new date fields and guidance when session dates are absent.

* **New Features**
  * Feeds now include application start and deadline dates.
  * Course entries expose course start/end dates derived from session dates.
  * Improved in-person course location and address details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->