### PR TITLE
fix(metadata): allow CourseEnrollments_aggregate for instructor role

### DIFF
--- a/backend/metadata/databases/default/tables/public_CourseEnrollment.yaml
+++ b/backend/metadata/databases/default/tables/public_CourseEnrollment.yaml
@@ -66,6 +66,7 @@ select_permissions:
         - location
         - termsAcceptedAt
       filter: {}
+      allow_aggregations: true
   - role: user_access
     permission:
       columns:


### PR DESCRIPTION
Add allow_aggregations: true to instructor_access select permission on CourseEnrollment table so instructors can access the aggregate field needed for the Teilnahmen & Leistungen tab.