### PR TITLE
fix: send all session dates in MOOCHub feed as irregular series

### DIFF
--- a/functions/apiProxy/main.py
+++ b/functions/apiProxy/main.py
@@ -240,10 +240,10 @@ def handle_moochub_data(page=1, per_page=25):
                     if has_dlc_funding:
                         break
 
-            # Compute course start/end dates from first and last session
+            # Build start/end date arrays from all sessions (irregular series per MOOCHub schema)
             sessions = course.get("Sessions", [])
-            first_session_start = sessions[0]["startDateTime"] if sessions else None
-            last_session_end = sessions[-1]["endDateTime"] if sessions else None
+            start_dates = [s["startDateTime"] for s in sessions] if sessions else None
+            end_dates = [s["endDateTime"] for s in sessions] if sessions else None
 
             # Format application dates for MOOCHub (date-only fields need time suffix)
             application_start = course.get("Program", {}).get("applicationStart")
@@ -271,8 +271,8 @@ def handle_moochub_data(page=1, per_page=25):
                     },
                     "courseMode": course_mode,
                     "inLanguage": [course["language"].lower()],
-                    "startDate": [first_session_start] if first_session_start else None,
-                    "endDate": [last_session_end] if last_session_end else None,
+                    "startDate": start_dates,
+                    "endDate": end_dates,
                     "applicationStartDate": application_start_date,
                     "applicationDeadline": application_deadline_str,
                     "description": "".join(description_parts),


### PR DESCRIPTION
Replace first/last session only with full session arrays for startDate
and endDate. DLC and other consumers can only display concrete dates,
not date ranges - sending all sessions fixes incorrect interpretation
as 2 sessions when first and last span different days.

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved course date calculation to accurately represent all session schedules instead of only first and last sessions, providing better visibility into courses with irregular session patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->