### PR TITLE
fix: skip sign-in for external link registration

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
@@ -237,6 +237,7 @@ export const useRegistrationHandler = ({
     config,
     handleLogin,
     handleRegistration,
+    handleExternalRegistration,
     submitRegistration,
     retryPayment,
     retryEnrollmentId,

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/index.tsx
@@ -81,14 +81,20 @@ export const Registration: FC<RegistrationProps> = ({ course, courseEnrollment, 
     );
   }
 
-  // If not logged in, show login prompt
+  // If not logged in: for external link registration, open link directly; otherwise prompt login
   if (!isLoggedIn) {
+    const isExternalWithLink =
+      registrationHandler.config.isExternal && course.externalRegistrationLink;
     return (
       <div className="w-full">
         <RegistrationButton
           course={course}
           registrationType={course.registrationType || CourseRegistrationType_enum.APPROVAL_WITH_INPUT}
-          onClick={registrationHandler.handleLogin}
+          onClick={
+            isExternalWithLink
+              ? registrationHandler.handleExternalRegistration
+              : registrationHandler.handleLogin
+          }
         />
       </div>
     );


### PR DESCRIPTION
When registration type is external link, anonymous users are now directly linked to the external page in a new tab instead of being prompted to sign in first.

## Changes
- Expose `handleExternalRegistration` from `useRegistrationHandler` hook
- In Registration component: when not logged in and course has external registration with a link, open the external URL directly instead of triggering sign-in

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for external registration links. Courses configured with external registration now direct unauthenticated users directly to the external registration page instead of the standard login flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->