### PR TITLE
fix: download documentation, query stability, auth refactor

### DIFF
--- a/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
+++ b/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
@@ -1799,6 +1799,7 @@ export enum User_select_column {
   integerId = "integerId",
   lastName = "lastName",
   matriculationNumber = "matriculationNumber",
+  matrixUserHandle = "matrixUserHandle",
   newsletterRegistration = "newsletterRegistration",
   occupation = "occupation",
   organizationId = "organizationId",
@@ -1839,6 +1840,7 @@ export enum User_update_column {
   integerId = "integerId",
   lastName = "lastName",
   matriculationNumber = "matriculationNumber",
+  matrixUserHandle = "matrixUserHandle",
   newsletterRegistration = "newsletterRegistration",
   occupation = "occupation",
   organizationId = "organizationId",
@@ -9205,6 +9207,7 @@ export interface User_bool_exp {
   integerId?: Int_comparison_exp | null;
   lastName?: String_comparison_exp | null;
   matriculationNumber?: String_comparison_exp | null;
+  matrixUserHandle?: String_comparison_exp | null;
   newsletterRegistration?: Boolean_comparison_exp | null;
   occupation?: UserOccupation_enum_comparison_exp | null;
   organizationId?: Int_comparison_exp | null;
@@ -9242,6 +9245,7 @@ export interface User_insert_input {
   integerId?: number | null;
   lastName?: string | null;
   matriculationNumber?: string | null;
+  matrixUserHandle?: string | null;
   newsletterRegistration?: boolean | null;
   occupation?: UserOccupation_enum | null;
   organizationId?: number | null;
@@ -9268,6 +9272,7 @@ export interface User_max_order_by {
   integerId?: order_by | null;
   lastName?: order_by | null;
   matriculationNumber?: order_by | null;
+  matrixUserHandle?: order_by | null;
   organizationId?: order_by | null;
   picture?: order_by | null;
   updated_at?: order_by | null;
@@ -9291,6 +9296,7 @@ export interface User_min_order_by {
   integerId?: order_by | null;
   lastName?: order_by | null;
   matriculationNumber?: order_by | null;
+  matrixUserHandle?: order_by | null;
   organizationId?: order_by | null;
   picture?: order_by | null;
   updated_at?: order_by | null;
@@ -9342,6 +9348,7 @@ export interface User_order_by {
   integerId?: order_by | null;
   lastName?: order_by | null;
   matriculationNumber?: order_by | null;
+  matrixUserHandle?: order_by | null;
   newsletterRegistration?: order_by | null;
   occupation?: order_by | null;
   organizationId?: order_by | null;

--- a/frontend-nx/apps/edu-hub/components/AuthStoreUpdater.tsx
+++ b/frontend-nx/apps/edu-hub/components/AuthStoreUpdater.tsx
@@ -1,0 +1,26 @@
+import { useSession } from 'next-auth/react';
+import { useCurrentRole } from '../hooks/authentication';
+import { setAuthState } from '../config/authStore';
+
+/**
+ * Updates the module-level auth store used by the Apollo auth link.
+ * Must be rendered inside SessionProvider so useSession has access.
+ * Runs during render so the store is current before any child queries execute.
+ *
+ * When status is 'loading' (e.g. token refresh, window focus), we keep the
+ * previous auth to avoid clearing it and causing 401s on in-flight requests.
+ */
+export function AuthStoreUpdater(): null {
+  const { data, status } = useSession();
+  const currentRole = useCurrentRole();
+
+  if (status !== 'loading') {
+    setAuthState({
+      accessToken: data?.accessToken ?? null,
+      role: currentRole,
+    });
+  }
+  // else: keep previous auth state to avoid 401s during brief loading
+
+  return null;
+}

--- a/frontend-nx/apps/edu-hub/components/common/TableGrid/hooks.ts
+++ b/frontend-nx/apps/edu-hub/components/common/TableGrid/hooks.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from 'react';
-import { useDebouncedCallback } from 'use-debounce';
+import { useDebounce } from 'use-debounce';
 import { SortingState } from '@tanstack/react-table';
 import { BaseRow, BulkAction, UseTableGridProps } from './types';
 import { mergeSortDirection } from './utils';
@@ -98,30 +98,33 @@ export function useTableGrid<V>({
     return userSort.length > 0 ? userSort : (stableDefaultSort || []);
   }, [sorting, stableDefaultSort]);
 
-  const queryResult = queryHook(query, {
-    variables: {
-      offset: pageIndex * pageSize,
-      limit: pageSize,
-      ...stableQueryVariables,
-      order_by: orderBy,
-    },
-  });
+  const [debouncedSearchFilter] = useDebounce(searchFilter, debounceMs);
 
-  const { data, loading, error, refetch } = queryResult;
-
-  const debouncedRefetch = useDebouncedCallback(refetch, debounceMs);
-
-  useEffect(() => {
-    const currentFilter = refetchFilterRef.current;
-    const refetchVariables = currentFilter ? currentFilter(searchFilter) : {};
-    debouncedRefetch({
+  const rawVariables = useMemo(() => {
+    const refetchVariables = refetchFilterRef.current
+      ? refetchFilterRef.current(debouncedSearchFilter)
+      : {};
+    return {
       offset: pageIndex * pageSize,
       limit: pageSize,
       ...stableQueryVariables,
       ...refetchVariables,
       order_by: orderBy,
-    });
-  }, [pageIndex, debouncedRefetch, searchFilter, stableQueryVariables, pageSize, orderBy]);
+    };
+  }, [pageIndex, pageSize, stableQueryVariables, debouncedSearchFilter, orderBy]);
+
+  const effectiveVariables = useStableValue(rawVariables);
+
+  const queryOptions = useMemo(
+    () => ({
+      variables: effectiveVariables,
+    }),
+    [effectiveVariables]
+  );
+
+  const queryResult = queryHook(query, queryOptions);
+
+  const { data, loading, error, refetch } = queryResult;
 
   const handleSetSearchFilter = useCallback((value: string) => {
     setSearchFilter(value);
@@ -141,7 +144,7 @@ export function useTableGrid<V>({
     data,
     loading,
     error,
-    refetch: debouncedRefetch,
+    refetch,
     searchFilter,
     pageIndex,
     setSearchFilter: handleSetSearchFilter,

--- a/frontend-nx/apps/edu-hub/components/common/TableGrid/hooks.ts
+++ b/frontend-nx/apps/edu-hub/components/common/TableGrid/hooks.ts
@@ -111,7 +111,14 @@ export function useTableGrid<V>({
       ...refetchVariables,
       order_by: orderBy,
     };
-  }, [pageIndex, pageSize, stableQueryVariables, debouncedSearchFilter, orderBy]);
+  }, [
+    pageIndex,
+    pageSize,
+    stableQueryVariables,
+    debouncedSearchFilter,
+    orderBy,
+    refetchFilter,
+  ]);
 
   const effectiveVariables = useStableValue(rawVariables);
 

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
@@ -847,26 +847,20 @@ function ExpandableRowContent({
       if (!docPath) return;
 
       setDownloadError(null);
-      let signedUrl = docResult.data?.getSignedUrl?.link;
-
-      if (!signedUrl) {
-        try {
-          const result = await getDoc({ variables: { path: docPath } });
-          signedUrl = result.data?.getSignedUrl?.link;
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err);
-          setDownloadError(t('download_documentation_error') || msg);
-          return;
+      try {
+        const result = await getDoc({ variables: { path: docPath } });
+        const signedUrl = result.data?.getSignedUrl?.link;
+        if (signedUrl) {
+          window.open(signedUrl, '_blank', 'noopener,noreferrer');
+        } else {
+          setDownloadError(t('download_documentation_error') || 'Failed to get download URL');
         }
-      }
-
-      if (signedUrl) {
-        window.open(signedUrl, '_blank', 'noopener,noreferrer');
-      } else {
-        setDownloadError(t('download_documentation_error') || 'Failed to get download URL');
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        setDownloadError(t('download_documentation_error') || msg);
       }
     },
-    [enrollment.mostRecentRecord?.documentationUrl, docResult.data?.getSignedUrl?.link, getDoc, t]
+    [enrollment.mostRecentRecord?.documentationUrl, getDoc, t]
   );
 
   const onSetRating = useCallback(

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
@@ -829,23 +829,45 @@ function ExpandableRowContent({
   t: (key: string) => string;
   locale: string;
 }) {
-  const [docUrlLoaded, setDocUrlLoaded] = useState(false);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
   const [getDoc, docResult] = useLazyRoleQuery<GetSignedUrl, GetSignedUrlVariables>(GET_SIGNED_URL);
   const [setAchievementRecord] = useRoleMutation<
     UpdateAchievementRecordByPk,
     UpdateAchievementRecordByPkVariables
   >(UPDATE_AN_ACHIEVEMENT_RECORD);
 
-  const loadDoc = useCallback(() => {
-    if (
-      enrollment.mostRecentRecord?.documentationUrl &&
-      enrollment.mostRecentRecord.documentationUrl !== 'pending_upload' &&
-      !docUrlLoaded
-    ) {
-      getDoc({ variables: { path: enrollment.mostRecentRecord.documentationUrl } });
-      setDocUrlLoaded(true);
-    }
-  }, [enrollment.mostRecentRecord, docUrlLoaded, getDoc]);
+  const handleDownloadClick = useCallback(
+    async (e: React.MouseEvent) => {
+      e.preventDefault();
+      const docPath =
+        enrollment.mostRecentRecord?.documentationUrl &&
+        enrollment.mostRecentRecord.documentationUrl !== 'pending_upload'
+          ? enrollment.mostRecentRecord.documentationUrl
+          : null;
+      if (!docPath) return;
+
+      setDownloadError(null);
+      let signedUrl = docResult.data?.getSignedUrl?.link;
+
+      if (!signedUrl) {
+        try {
+          const result = await getDoc({ variables: { path: docPath } });
+          signedUrl = result.data?.getSignedUrl?.link;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          setDownloadError(t('download_documentation_error') || msg);
+          return;
+        }
+      }
+
+      if (signedUrl) {
+        window.open(signedUrl, '_blank', 'noopener,noreferrer');
+      } else {
+        setDownloadError(t('download_documentation_error') || 'Failed to get download URL');
+      }
+    },
+    [enrollment.mostRecentRecord?.documentationUrl, docResult.data?.getSignedUrl?.link, getDoc, t]
+  );
 
   const onSetRating = useCallback(
     async (rating: AchievementRecordRating_enum) => {
@@ -954,10 +976,11 @@ function ExpandableRowContent({
               </div>
             </div>
             <Button
-              as="a"
+              as="button"
+              type="button"
               filled
-              href={docResult.loading ? '#' : docResult.data?.getSignedUrl?.link ?? '#'}
-              onClick={loadDoc}
+              disabled={docResult.loading}
+              onClick={handleDownloadClick}
             >
               {docResult.loading ? (
                 <CircularProgress size={20} />
@@ -965,6 +988,13 @@ function ExpandableRowContent({
                 t('download_documentation')
               )}
             </Button>
+            {downloadError && (
+              <ErrorMessageDialog
+                errorMessage={downloadError}
+                open={!!downloadError}
+                onClose={() => setDownloadError(null)}
+              />
+            )}
           </Card>
           );
         })()}

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/index.tsx
@@ -74,12 +74,19 @@ const getNextCourseStatus = (course: ManagedCourse_Course_by_pk) => {
  */
 export const ManageCourseContent: FC<Props> = ({ courseId }) => {
   const t = useTranslations('manageCourse');
+  const managedCourseQueryOptions = useMemo(
+    () => ({
+      variables: {
+        id: courseId,
+      },
+    }),
+    [courseId]
+  );
 
-  const qResult = useRoleQuery<ManagedCourse, ManagedCourseVariables>(MANAGED_COURSE, {
-    variables: {
-      id: courseId,
-    },
-  });
+  const qResult = useRoleQuery<ManagedCourse, ManagedCourseVariables>(
+    MANAGED_COURSE,
+    managedCourseQueryOptions
+  );
 
   const isAdmin = useIsAdmin();
   const instructorIds = qResult?.data?.Course_by_pk?.CourseInstructors.map((ci) => ci.User.id);

--- a/frontend-nx/apps/edu-hub/config/apollo.ts
+++ b/frontend-nx/apps/edu-hub/config/apollo.ts
@@ -1,13 +1,35 @@
-import { ApolloClient, InMemoryCache, createHttpLink } from '@apollo/client';
+import { ApolloClient, ApolloLink, InMemoryCache, createHttpLink } from '@apollo/client';
+import { AuthRoles } from '../types/enums';
+import { getAuthState } from './authStore';
 
 const httpLink = createHttpLink({
   uri: process.env.NEXT_PUBLIC_API_URL,
   credentials: 'include',
 });
 
+const authLink = new ApolloLink((operation, forward) => {
+  const { accessToken, role } = getAuthState();
+  const roleOverride = operation.getContext().role as AuthRoles | undefined;
+  const effectiveRole = roleOverride ?? role;
+  const willAddAuth = !!(accessToken && effectiveRole !== AuthRoles.anonymous);
+
+  if (willAddAuth) {
+    operation.setContext((prev: Record<string, unknown>) => ({
+      ...prev,
+      headers: {
+        ...prev.headers,
+        'x-hasura-role': effectiveRole,
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }));
+  }
+
+  return forward(operation);
+});
+
 export const client = new ApolloClient({
   uri: process.env.NEXT_PUBLIC_API_URL,
-  link: httpLink,
+  link: ApolloLink.from([authLink, httpLink]),
   cache: new InMemoryCache({
     typePolicies: {
       Query: {
@@ -39,6 +61,29 @@ export const client = new ApolloClient({
           CourseEnrollments: {
             merge: (_, incoming) => incoming,
           },
+          // Prevent refetch loop: MANAGED_COURSE and COURSE_PARTICIPATIONS both write
+          // Course.Sessions and AchievementOptionCourses. Returning existing when refs
+          // match avoids cache broadcast that triggers refetch.
+          AchievementOptionCourses: {
+            merge(existing: unknown[] | undefined, incoming: unknown[] | undefined) {
+              if (!incoming?.length) return existing ?? incoming;
+              if (!existing?.length) return incoming;
+              const existingRefs = (existing as { __ref?: string }[]).map((e) => e?.__ref).join(',');
+              const incomingRefs = (incoming as { __ref?: string }[]).map((i) => i?.__ref).join(',');
+              if (existingRefs === incomingRefs) return existing;
+              return incoming;
+            },
+          },
+          Sessions: {
+            merge(existing: unknown[] | undefined, incoming: unknown[] | undefined) {
+              if (!incoming?.length) return existing ?? incoming;
+              if (!existing?.length) return incoming;
+              const existingRefs = (existing as { __ref?: string }[]).map((e) => e?.__ref).join(',');
+              const incomingRefs = (incoming as { __ref?: string }[]).map((i) => i?.__ref).join(',');
+              if (existingRefs === incomingRefs) return existing;
+              return incoming;
+            },
+          },
         },
       },
       AchievementOption: {
@@ -67,9 +112,7 @@ export const client = new ApolloClient({
         fields: {
           applicationStart: {
             merge: (_, applicationStart) => {
-              return applicationStart != null
-                ? new Date(applicationStart)
-                : null;
+              return applicationStart != null ? new Date(applicationStart) : null;
             },
           },
           applicationEnd: {

--- a/frontend-nx/apps/edu-hub/config/apollo.ts
+++ b/frontend-nx/apps/edu-hub/config/apollo.ts
@@ -14,14 +14,20 @@ const authLink = new ApolloLink((operation, forward) => {
   const willAddAuth = !!(accessToken && effectiveRole !== AuthRoles.anonymous);
 
   if (willAddAuth) {
-    operation.setContext((prev: Record<string, unknown>) => ({
-      ...prev,
-      headers: {
-        ...prev.headers,
-        'x-hasura-role': effectiveRole,
-        Authorization: `Bearer ${accessToken}`,
-      },
-    }));
+    operation.setContext((prev: Record<string, unknown>) => {
+      const existingHeaders =
+        prev.headers && typeof prev.headers === 'object'
+          ? (prev.headers as Record<string, string>)
+          : {};
+      return {
+        ...prev,
+        headers: {
+          ...existingHeaders,
+          'x-hasura-role': effectiveRole,
+          Authorization: `Bearer ${accessToken}`,
+        },
+      };
+    });
   }
 
   return forward(operation);
@@ -66,7 +72,7 @@ export const client = new ApolloClient({
           // match avoids cache broadcast that triggers refetch.
           AchievementOptionCourses: {
             merge(existing: unknown[] | undefined, incoming: unknown[] | undefined) {
-              if (!incoming?.length) return existing ?? incoming;
+              if (incoming == null) return existing ?? incoming;
               if (!existing?.length) return incoming;
               const existingRefs = (existing as { __ref?: string }[]).map((e) => e?.__ref).join(',');
               const incomingRefs = (incoming as { __ref?: string }[]).map((i) => i?.__ref).join(',');
@@ -76,7 +82,7 @@ export const client = new ApolloClient({
           },
           Sessions: {
             merge(existing: unknown[] | undefined, incoming: unknown[] | undefined) {
-              if (!incoming?.length) return existing ?? incoming;
+              if (incoming == null) return existing ?? incoming;
               if (!existing?.length) return incoming;
               const existingRefs = (existing as { __ref?: string }[]).map((e) => e?.__ref).join(',');
               const incomingRefs = (incoming as { __ref?: string }[]).map((i) => i?.__ref).join(',');

--- a/frontend-nx/apps/edu-hub/config/authStore.ts
+++ b/frontend-nx/apps/edu-hub/config/authStore.ts
@@ -1,0 +1,21 @@
+/**
+ * Module-level auth state for Apollo Link. Updated by AuthStoreUpdater from React.
+ * This allows the Apollo link to add auth headers at request time without passing
+ * context through useQuery options, which can trigger refetches when context changes.
+ */
+import { AuthRoles } from '../types/enums';
+
+export type AuthState = {
+  accessToken: string | null;
+  role: AuthRoles;
+};
+
+let authState: AuthState = { accessToken: null, role: AuthRoles.anonymous };
+
+export function getAuthState(): AuthState {
+  return authState;
+}
+
+export function setAuthState(state: AuthState): void {
+  authState = state;
+}

--- a/frontend-nx/apps/edu-hub/contexts/AppSettingsContext.tsx
+++ b/frontend-nx/apps/edu-hub/contexts/AppSettingsContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, ReactNode } from 'react';
+import React, { createContext, useContext, ReactNode, useMemo } from 'react';
 import { useRoleQuery } from '../hooks/authedQuery';
 import { APP_SETTINGS } from '../queries/appSettings';
 import { AppSettings } from '../queries/__generated__/AppSettings';
@@ -29,17 +29,20 @@ const defaultSettings: AppSettingsContextType = {
 
 const AppSettingsContext = createContext<AppSettingsContextType>(defaultSettings);
 
-export const AppSettingsProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
-  const { data, loading, error } = useRoleQuery<AppSettings>(APP_SETTINGS, {
-    variables: { appName: 'edu' },
-  });
+const APP_SETTINGS_OPTIONS = { variables: { appName: 'edu' } };
 
-  const settings: AppSettingsContextType = {
-    ...defaultSettings,
-    ...(data?.AppSettings[0] || {}),
-    loading,
-    error,
-  };
+export const AppSettingsProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const { data, loading, error } = useRoleQuery<AppSettings>(APP_SETTINGS, APP_SETTINGS_OPTIONS);
+
+  const settings = useMemo<AppSettingsContextType>(
+    () => ({
+      ...defaultSettings,
+      ...(data?.AppSettings[0] ?? undefined),
+      loading,
+      error,
+    }),
+    [data, loading, error]
+  );
 
   return <AppSettingsContext.Provider value={settings}>{children}</AppSettingsContext.Provider>;
 };

--- a/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
+++ b/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
@@ -1,7 +1,7 @@
 import { ApolloError, useQuery, useLazyQuery } from '@apollo/client';
 import { useSession, signOut } from 'next-auth/react';
 import { useTranslations } from 'next-intl';
-import { useCallback, useMemo, useRef } from 'react';
+import { useCallback, useRef } from 'react';
 
 import { useCurrentRole } from './authentication';
 import { useAuthError } from '../contexts/AuthErrorContext';
@@ -13,7 +13,6 @@ const useErrorHandler = () => {
   const { showAuthError } = useAuthError();
 
   return useCallback((error: { message?: string }) => {
-    console.log('error handler error: ', error);
     if (error?.message?.includes('JWTExpired') || error?.message?.includes('JWSInvalidSignature')) {
       // For expired sessions, redirect immediately to login without showing a blocking dialog
       console.info('Session expired, redirecting to login...');
@@ -21,6 +20,9 @@ const useErrorHandler = () => {
         callbackUrl: '/?sessionExpired=true',
         redirect: true 
       });
+    } else if (error?.message?.includes('NetworkError') || error?.message?.includes('Failed to fetch')) {
+      // NetworkError (e.g. aborted on page refresh, offline) — don't show auth dialog; log only
+      console.warn('GraphQL network error (may be transient):', error?.message);
     } else {
       // Show error dialog for other authentication errors (without signing out)
       showAuthError(t("common.authed_query.authentication_error") + ": " + (error?.message ?? ''), false);
@@ -29,34 +31,11 @@ const useErrorHandler = () => {
 };
 
 export const useRoleQuery: typeof useQuery = (query, passedOptions) => {
-  const { data } = useSession();
-  const accessToken = data?.accessToken;
-  const currentRole = useCurrentRole();
+  // Auth headers are added by the Apollo auth link (reads from authStore).
+  // We do NOT pass context with auth here — context changes trigger refetches
+  // (Apollo issue #11835). Only pass role override when caller needs it.
+  const roleOverride = passedOptions?.context?.role as AuthRoles | undefined;
 
-  // Keep a ref to passedOptions so the auth-context memo below doesn't need it
-  // as a dependency. Callers that pass inline option objects (new reference every
-  // render) would otherwise invalidate the memo on every render and send new
-  // options objects to Apollo, triggering unnecessary setOptions calls.
-  const passedOptionsRef = useRef(passedOptions);
-  passedOptionsRef.current = passedOptions;
-
-  // Auth context: only rebuilt when the token or role actually changes.
-  const authContext = useMemo(() => {
-    const opts = passedOptionsRef.current;
-    const passedRole = opts?.context?.role as AuthRoles | undefined;
-    if (!accessToken || currentRole === AuthRoles.anonymous) {
-      return opts?.context;
-    }
-    return {
-      ...opts?.context,
-      headers: {
-        'x-hasura-role': passedRole ?? currentRole,
-        Authorization: `Bearer ${accessToken}`,
-      },
-    };
-  }, [accessToken, currentRole]); // passedOptions intentionally NOT here
-
-  // onError: stable via refs so it never causes Apollo to see new options.
   const errorHandler = useErrorHandler();
   const errorHandlerRef = useRef(errorHandler);
   errorHandlerRef.current = errorHandler;
@@ -68,18 +47,13 @@ export const useRoleQuery: typeof useQuery = (query, passedOptions) => {
     callerOnErrorRef.current?.(error);
   }, []);
 
-  // Merge stable auth context into passedOptions without making passedOptions a
-  // memo dependency — Apollo's own deep-equality check handles variable changes.
-  const queryOptions = useMemo(
-    () => ({
-      ...passedOptionsRef.current,
-      context: authContext,
-      onError,
-    }),
-    [authContext, onError]
-  );
-
-  return useQuery(query, queryOptions);
+  return useQuery(query, {
+    ...passedOptions,
+    context: roleOverride ? { role: roleOverride } : undefined,
+    onError,
+    fetchPolicy: passedOptions?.fetchPolicy ?? 'cache-first',
+    nextFetchPolicy: passedOptions?.nextFetchPolicy ?? 'cache-first',
+  });
 };
 
 export const useLazyRoleQuery: typeof useLazyQuery = (query, passedOptions) => {

--- a/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
+++ b/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
@@ -1,5 +1,5 @@
 import { ApolloError, useQuery, useLazyQuery } from '@apollo/client';
-import { useSession, signOut } from 'next-auth/react';
+import { signOut } from 'next-auth/react';
 import { useTranslations } from 'next-intl';
 import { useCallback, useRef } from 'react';
 
@@ -57,157 +57,109 @@ export const useRoleQuery: typeof useQuery = (query, passedOptions) => {
 };
 
 export const useLazyRoleQuery: typeof useLazyQuery = (query, passedOptions) => {
-  const { data } = useSession();
-  const accessToken = data?.accessToken;
   const currentRole = useCurrentRole();
+  const passedRole = passedOptions?.context?.role as AuthRoles | undefined;
 
-  const passedRole: AuthRoles = passedOptions?.context?.role;
-
-  const options = accessToken
-    ? {
-        ...passedOptions,
-        context: {
-          ...passedOptions?.context,
-          headers: {
-            ...(currentRole !== AuthRoles.anonymous && {
-              'x-hasura-role': passedRole ?? currentRole,
-            }),
-            ...(currentRole !== AuthRoles.anonymous && {
-              Authorization: `Bearer ${accessToken}`,
-            }),
-          },
-        },
-      }
-    : passedOptions;
+  const options = {
+    ...passedOptions,
+    context: {
+      ...passedOptions?.context,
+      role: passedRole ?? currentRole,
+    },
+  };
 
   const errorHandler = useErrorHandler();
   const callerOnError = passedOptions?.onError;
 
-  return useLazyQuery(query, { 
-    ...options, 
+  return useLazyQuery(query, {
+    ...options,
     onError: (error) => {
       errorHandler(error);
       callerOnError?.(error);
-    }
+    },
   });
 };
 
 export const useAdminQuery: typeof useQuery = (query, passedOptions) => {
-  const { data } = useSession();
-  const accessToken = data?.accessToken;
-
-  const options = accessToken
-    ? {
-        ...passedOptions,
-        context: {
-          ...passedOptions?.context,
-          headers: {
-            ...passedOptions?.context?.headers,
-            'x-hasura-role': AuthRoles.admin,
-            Authorization: `Bearer ${accessToken}`,
-          },
-        },
-      }
-    : passedOptions;
+  const options = {
+    ...passedOptions,
+    context: {
+      ...passedOptions?.context,
+      role: AuthRoles.admin,
+    },
+  };
 
   const errorHandler = useErrorHandler();
   const callerOnError = passedOptions?.onError;
 
-  return useQuery(query, { 
-    ...options, 
+  return useQuery(query, {
+    ...options,
     onError: (error) => {
       errorHandler(error);
       callerOnError?.(error);
-    }
+    },
   });
 };
 
 export const useAdminLazyQuery: typeof useLazyQuery = (query, passedOptions) => {
-  const { data } = useSession();
-  const accessToken = data?.accessToken;
-
-  const options = accessToken
-    ? {
-        ...passedOptions,
-        context: {
-          ...passedOptions?.context,
-          headers: {
-            ...passedOptions?.context?.headers,
-            'x-hasura-role': AuthRoles.admin,
-            Authorization: `Bearer ${accessToken}`,
-          },
-        },
-      }
-    : passedOptions;
+  const options = {
+    ...passedOptions,
+    context: {
+      ...passedOptions?.context,
+      role: AuthRoles.admin,
+    },
+  };
 
   const errorHandler = useErrorHandler();
   const callerOnError = passedOptions?.onError;
 
-  return useLazyQuery(query, { 
-    ...options, 
+  return useLazyQuery(query, {
+    ...options,
     onError: (error) => {
       errorHandler(error);
       callerOnError?.(error);
-    }
+    },
   });
 };
 
 export const useInstructorQuery: typeof useQuery = (query, passedOptions) => {
-  const { data } = useSession();
-  const accessToken = data?.accessToken;
-
-  const options = accessToken
-    ? {
-        ...passedOptions,
-        context: {
-          ...passedOptions?.context,
-          headers: {
-            ...passedOptions?.context?.headers,
-            'x-hasura-role': AuthRoles.instructor,
-            Authorization: `Bearer ${accessToken}`,
-          },
-        },
-      }
-    : passedOptions;
+  const options = {
+    ...passedOptions,
+    context: {
+      ...passedOptions?.context,
+      role: AuthRoles.instructor,
+    },
+  };
 
   const errorHandler = useErrorHandler();
   const callerOnError = passedOptions?.onError;
 
-  return useQuery(query, { 
-    ...options, 
+  return useQuery(query, {
+    ...options,
     onError: (error) => {
       errorHandler(error);
       callerOnError?.(error);
-    }
+    },
   });
 };
 
 export const useAuthedQuery: typeof useQuery = (query, passedOptions) => {
-  const { data } = useSession();
-  const accessToken = data?.accessToken;
-
-  const options = accessToken
-    ? {
-        ...passedOptions,
-        context: {
-          ...passedOptions?.context,
-          headers: {
-            ...passedOptions?.context?.headers,
-            'x-hasura-role': AuthRoles.user,
-            Authorization: `Bearer ${accessToken}`,
-          },
-        },
-      }
-    : passedOptions;
+  const options = {
+    ...passedOptions,
+    context: {
+      ...passedOptions?.context,
+      role: AuthRoles.user,
+    },
+  };
 
   const errorHandler = useErrorHandler();
   const callerOnError = passedOptions?.onError;
 
-  return useQuery(query, { 
-    ...options, 
+  return useQuery(query, {
+    ...options,
     onError: (error) => {
       errorHandler(error);
       callerOnError?.(error);
-    }
+    },
   });
 };

--- a/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
+++ b/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
@@ -60,13 +60,15 @@ export const useLazyRoleQuery: typeof useLazyQuery = (query, passedOptions) => {
   const currentRole = useCurrentRole();
   const passedRole = passedOptions?.context?.role as AuthRoles | undefined;
 
-  const options = {
-    ...passedOptions,
-    context: {
-      ...passedOptions?.context,
-      role: passedRole ?? currentRole,
-    },
-  };
+  const options = passedOptions
+    ? {
+        ...passedOptions,
+        context: {
+          ...passedOptions.context,
+          role: passedRole ?? currentRole,
+        },
+      }
+    : passedOptions;
 
   const errorHandler = useErrorHandler();
   const callerOnError = passedOptions?.onError;

--- a/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
+++ b/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
@@ -1,6 +1,7 @@
-import { useQuery, useLazyQuery } from '@apollo/client';
+import { ApolloError, useQuery, useLazyQuery } from '@apollo/client';
 import { useSession, signOut } from 'next-auth/react';
 import { useTranslations } from 'next-intl';
+import { useCallback, useMemo, useRef } from 'react';
 
 import { useCurrentRole } from './authentication';
 import { useAuthError } from '../contexts/AuthErrorContext';
@@ -11,7 +12,7 @@ const useErrorHandler = () => {
   const t = useTranslations();
   const { showAuthError } = useAuthError();
 
-  return (error: { message?: string }) => {
+  return useCallback((error: { message?: string }) => {
     console.log('error handler error: ', error);
     if (error?.message?.includes('JWTExpired') || error?.message?.includes('JWSInvalidSignature')) {
       // For expired sessions, redirect immediately to login without showing a blocking dialog
@@ -24,7 +25,7 @@ const useErrorHandler = () => {
       // Show error dialog for other authentication errors (without signing out)
       showAuthError(t("common.authed_query.authentication_error") + ": " + (error?.message ?? ''), false);
     }
-  };
+  }, [showAuthError, t]);
 };
 
 export const useRoleQuery: typeof useQuery = (query, passedOptions) => {
@@ -32,35 +33,53 @@ export const useRoleQuery: typeof useQuery = (query, passedOptions) => {
   const accessToken = data?.accessToken;
   const currentRole = useCurrentRole();
 
-  const passedRole: AuthRoles = passedOptions?.context?.role;
+  // Keep a ref to passedOptions so the auth-context memo below doesn't need it
+  // as a dependency. Callers that pass inline option objects (new reference every
+  // render) would otherwise invalidate the memo on every render and send new
+  // options objects to Apollo, triggering unnecessary setOptions calls.
+  const passedOptionsRef = useRef(passedOptions);
+  passedOptionsRef.current = passedOptions;
 
-  const options = accessToken
-    ? {
-        ...passedOptions,
-        context: {
-          ...passedOptions?.context,
-          headers: {
-            ...(currentRole !== AuthRoles.anonymous && {
-              'x-hasura-role': passedRole ? passedRole : currentRole,
-            }),
-            ...(currentRole !== AuthRoles.anonymous && {
-              Authorization: `Bearer ${accessToken}`,
-            }),
-          },
-        },
-      }
-    : passedOptions;
-
-  const errorHandler = useErrorHandler();
-  const callerOnError = passedOptions?.onError;
-      
-  return useQuery(query, { 
-    ...options, 
-    onError: (error) => {
-      errorHandler(error);
-      callerOnError?.(error);
+  // Auth context: only rebuilt when the token or role actually changes.
+  const authContext = useMemo(() => {
+    const opts = passedOptionsRef.current;
+    const passedRole = opts?.context?.role as AuthRoles | undefined;
+    if (!accessToken || currentRole === AuthRoles.anonymous) {
+      return opts?.context;
     }
-  });
+    return {
+      ...opts?.context,
+      headers: {
+        'x-hasura-role': passedRole ?? currentRole,
+        Authorization: `Bearer ${accessToken}`,
+      },
+    };
+  }, [accessToken, currentRole]); // passedOptions intentionally NOT here
+
+  // onError: stable via refs so it never causes Apollo to see new options.
+  const errorHandler = useErrorHandler();
+  const errorHandlerRef = useRef(errorHandler);
+  errorHandlerRef.current = errorHandler;
+  const callerOnErrorRef = useRef(passedOptions?.onError);
+  callerOnErrorRef.current = passedOptions?.onError;
+
+  const onError = useCallback((error: ApolloError) => {
+    errorHandlerRef.current(error);
+    callerOnErrorRef.current?.(error);
+  }, []);
+
+  // Merge stable auth context into passedOptions without making passedOptions a
+  // memo dependency — Apollo's own deep-equality check handles variable changes.
+  const queryOptions = useMemo(
+    () => ({
+      ...passedOptionsRef.current,
+      context: authContext,
+      onError,
+    }),
+    [authContext, onError]
+  );
+
+  return useQuery(query, queryOptions);
 };
 
 export const useLazyRoleQuery: typeof useLazyQuery = (query, passedOptions) => {
@@ -77,7 +96,7 @@ export const useLazyRoleQuery: typeof useLazyQuery = (query, passedOptions) => {
           ...passedOptions?.context,
           headers: {
             ...(currentRole !== AuthRoles.anonymous && {
-              'x-hasura-role': passedRole ? passedRole : currentRole,
+              'x-hasura-role': passedRole ?? currentRole,
             }),
             ...(currentRole !== AuthRoles.anonymous && {
               Authorization: `Bearer ${accessToken}`,

--- a/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
+++ b/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
@@ -1,31 +1,51 @@
 import { ApolloError, useQuery, useLazyQuery } from '@apollo/client';
 import { signOut } from 'next-auth/react';
 import { useTranslations } from 'next-intl';
-import { useCallback, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 
 import { useCurrentRole } from './authentication';
 import { useAuthError } from '../contexts/AuthErrorContext';
 
 import { AuthRoles } from '../types/enums';
 
+const getErrorMessage = (error: unknown): string | undefined => {
+  if (!error) {
+    return undefined;
+  }
+
+  if (typeof error === 'string') {
+    return error;
+  }
+
+  if (typeof error === 'object' && 'message' in error) {
+    const message = (error as { message?: unknown }).message;
+    return typeof message === 'string' ? message : undefined;
+  }
+
+  return undefined;
+};
+
 const useErrorHandler = () => {
   const t = useTranslations();
   const { showAuthError } = useAuthError();
 
-  return useCallback((error: { message?: string }) => {
-    if (error?.message?.includes('JWTExpired') || error?.message?.includes('JWSInvalidSignature')) {
+  return useCallback((error: unknown) => {
+    const message = getErrorMessage(error);
+
+    if (message?.includes('JWTExpired') || message?.includes('JWSInvalidSignature')) {
       // For expired sessions, redirect immediately to login without showing a blocking dialog
       console.info('Session expired, redirecting to login...');
-      signOut({ 
+      signOut({
         callbackUrl: '/?sessionExpired=true',
-        redirect: true 
+        redirect: true,
       });
-    } else if (error?.message?.includes('NetworkError') || error?.message?.includes('Failed to fetch')) {
+    } else if (message?.includes('NetworkError') || message?.includes('Failed to fetch')) {
       // NetworkError (e.g. aborted on page refresh, offline) — don't show auth dialog; log only
-      console.warn('GraphQL network error (may be transient):', error?.message);
+      console.warn('GraphQL network error (may be transient):', error);
     } else {
-      // Show error dialog for other authentication errors (without signing out)
-      showAuthError(t("common.authed_query.authentication_error") + ": " + (error?.message ?? ''), false);
+      console.error('Authentication error in query hook:', error);
+      // Show a generic user-facing auth dialog; internal details stay in logs only.
+      showAuthError(t('common.authed_query.authentication_error'), false);
     }
   }, [showAuthError, t]);
 };
@@ -35,6 +55,21 @@ export const useRoleQuery: typeof useQuery = (query, passedOptions) => {
   // We do NOT pass context with auth here — context changes trigger refetches
   // (Apollo issue #11835). Only pass role override when caller needs it.
   const roleOverride = passedOptions?.context?.role as AuthRoles | undefined;
+  const mergedContext = useMemo(() => {
+    const currentContext = passedOptions?.context;
+    if (!currentContext) {
+      return undefined;
+    }
+
+    if (!roleOverride) {
+      return currentContext;
+    }
+
+    return {
+      ...currentContext,
+      role: roleOverride,
+    };
+  }, [passedOptions?.context, roleOverride]);
 
   const errorHandler = useErrorHandler();
   const errorHandlerRef = useRef(errorHandler);
@@ -47,121 +82,160 @@ export const useRoleQuery: typeof useQuery = (query, passedOptions) => {
     callerOnErrorRef.current?.(error);
   }, []);
 
-  return useQuery(query, {
-    ...passedOptions,
-    context: roleOverride ? { role: roleOverride } : undefined,
-    onError,
-    fetchPolicy: passedOptions?.fetchPolicy ?? 'cache-first',
-    nextFetchPolicy: passedOptions?.nextFetchPolicy ?? 'cache-first',
-  });
+  const options = useMemo(
+    () => ({
+      ...passedOptions,
+      context: mergedContext,
+      onError,
+      fetchPolicy: passedOptions?.fetchPolicy ?? 'cache-first',
+      nextFetchPolicy: passedOptions?.nextFetchPolicy ?? 'cache-first',
+    }),
+    [passedOptions, mergedContext, onError]
+  );
+
+  return useQuery(query, options);
 };
 
 export const useLazyRoleQuery: typeof useLazyQuery = (query, passedOptions) => {
   const currentRole = useCurrentRole();
   const passedRole = passedOptions?.context?.role as AuthRoles | undefined;
+  const mergedContext = useMemo(() => {
+    if (!passedOptions?.context) {
+      return passedOptions?.context;
+    }
 
-  const options = passedOptions
-    ? {
-        ...passedOptions,
-        context: {
-          ...passedOptions.context,
-          role: passedRole ?? currentRole,
-        },
-      }
-    : passedOptions;
+    return {
+      ...passedOptions.context,
+      role: passedRole ?? currentRole,
+    };
+  }, [passedOptions?.context, passedRole, currentRole]);
 
   const errorHandler = useErrorHandler();
-  const callerOnError = passedOptions?.onError;
+  const errorHandlerRef = useRef(errorHandler);
+  errorHandlerRef.current = errorHandler;
+  const callerOnErrorRef = useRef(passedOptions?.onError);
+  callerOnErrorRef.current = passedOptions?.onError;
 
-  return useLazyQuery(query, {
-    ...options,
-    onError: (error) => {
-      errorHandler(error);
-      callerOnError?.(error);
-    },
-  });
+  const onError = useCallback((error: ApolloError) => {
+    errorHandlerRef.current(error);
+    callerOnErrorRef.current?.(error);
+  }, []);
+
+  const options = useMemo(
+    () =>
+      passedOptions
+        ? {
+            ...passedOptions,
+            context: mergedContext,
+            onError,
+          }
+        : passedOptions,
+    [passedOptions, mergedContext, onError]
+  );
+
+  return useLazyQuery(query, options);
 };
 
 export const useAdminQuery: typeof useQuery = (query, passedOptions) => {
-  const options = {
-    ...passedOptions,
-    context: {
+  const mergedContext = useMemo(
+    () => ({
       ...passedOptions?.context,
       role: AuthRoles.admin,
-    },
-  };
+    }),
+    [passedOptions?.context]
+  );
 
   const errorHandler = useErrorHandler();
-  const callerOnError = passedOptions?.onError;
+  const errorHandlerRef = useRef(errorHandler);
+  errorHandlerRef.current = errorHandler;
+  const callerOnErrorRef = useRef(passedOptions?.onError);
+  callerOnErrorRef.current = passedOptions?.onError;
 
-  return useQuery(query, {
-    ...options,
-    onError: (error) => {
-      errorHandler(error);
-      callerOnError?.(error);
-    },
-  });
+  const onError = useCallback((error: ApolloError) => {
+    errorHandlerRef.current(error);
+    callerOnErrorRef.current?.(error);
+  }, []);
+
+  const options = useMemo(
+    () => ({
+      ...passedOptions,
+      context: mergedContext,
+      onError,
+    }),
+    [passedOptions, mergedContext, onError]
+  );
+
+  return useQuery(query, options);
 };
 
 export const useAdminLazyQuery: typeof useLazyQuery = (query, passedOptions) => {
-  const options = {
-    ...passedOptions,
-    context: {
+  const mergedContext = useMemo(
+    () => ({
       ...passedOptions?.context,
       role: AuthRoles.admin,
-    },
-  };
+    }),
+    [passedOptions?.context]
+  );
 
   const errorHandler = useErrorHandler();
-  const callerOnError = passedOptions?.onError;
+  const errorHandlerRef = useRef(errorHandler);
+  errorHandlerRef.current = errorHandler;
+  const callerOnErrorRef = useRef(passedOptions?.onError);
+  callerOnErrorRef.current = passedOptions?.onError;
 
-  return useLazyQuery(query, {
-    ...options,
-    onError: (error) => {
-      errorHandler(error);
-      callerOnError?.(error);
-    },
-  });
+  const onError = useCallback((error: ApolloError) => {
+    errorHandlerRef.current(error);
+    callerOnErrorRef.current?.(error);
+  }, []);
+
+  const options = useMemo(
+    () => ({
+      ...passedOptions,
+      context: mergedContext,
+      onError,
+    }),
+    [passedOptions, mergedContext, onError]
+  );
+
+  return useLazyQuery(query, options);
 };
 
 export const useInstructorQuery: typeof useQuery = (query, passedOptions) => {
-  const options = {
-    ...passedOptions,
-    context: {
+  const mergedContext = useMemo(
+    () => ({
       ...passedOptions?.context,
       role: AuthRoles.instructor,
-    },
-  };
+    }),
+    [passedOptions?.context]
+  );
 
   const errorHandler = useErrorHandler();
-  const callerOnError = passedOptions?.onError;
+  const errorHandlerRef = useRef(errorHandler);
+  errorHandlerRef.current = errorHandler;
+  const callerOnErrorRef = useRef(passedOptions?.onError);
+  callerOnErrorRef.current = passedOptions?.onError;
 
-  return useQuery(query, {
-    ...options,
-    onError: (error) => {
-      errorHandler(error);
-      callerOnError?.(error);
-    },
-  });
+  const onError = useCallback((error: ApolloError) => {
+    errorHandlerRef.current(error);
+    callerOnErrorRef.current?.(error);
+  }, []);
+
+  const options = useMemo(
+    () => ({
+      ...passedOptions,
+      context: mergedContext,
+      onError,
+    }),
+    [passedOptions, mergedContext, onError]
+  );
+
+  return useQuery(query, options);
 };
 
+/**
+ * @deprecated Use useRoleQuery instead.
+ * This alias exists for backward compatibility and no longer forces role=user.
+ */
 export const useAuthedQuery: typeof useQuery = (query, passedOptions) => {
-  const options = {
-    ...passedOptions,
-    context: {
-      ...passedOptions?.context,
-      role: AuthRoles.user,
-    },
-  };
-
-  const errorHandler = useErrorHandler();
-  const callerOnError = passedOptions?.onError;
-
-  return useQuery(query, {
-    ...options,
-    onError: (error) => {
-      errorHandler(error);
-      callerOnError?.(error);
-    },
-  });
+  return useRoleQuery(query, passedOptions);
 };

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -977,7 +977,7 @@
     "attendance_cert_col": "Teilnahme-Zert.",
     "achievement_cert_col": "Leistungs-Zert.",
     "no_applications_present": "Keine Bewerbungen vorhanden",
-    "add_participants": "Teilnehmende bearbeiten",
+    "add_participants": "Teilnehmende hinzufügen/bearbeiten",
     "selected_users": "Ausgewählte User",
     "name_or_email": "Name oder E-Mail",
     "add_as_confirmed": "als bestätigt hinzufügen oder ändern",

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1060,6 +1060,7 @@
     "uploaded_by": "Hochgeladen von",
     "co_authors": "Co-Autoren",
     "download_documentation": "Dokumentation herunterladen",
+    "download_documentation_error": "Projektdokumentation konnte nicht geladen werden. Bitte versuche es erneut.",
     "generate_achievement_certificates": "Leistungsnachweise generieren",
     "delete_achievement_certificates": "Leistungsnachweise löschen",
     "no_certificates_deleted": "Es wurden keine Zertifikate gelöscht",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1076,6 +1076,7 @@
     "uploaded_by": "Uploaded by",
     "co_authors": "Co-authors",
     "download_documentation": "Download Documentation",
+    "download_documentation_error": "Failed to load project documentation. Please try again.",
     "generate_achievement_certificates": "Generate Achievement Certificates",
     "delete_achievement_certificates": "Delete Achievement Certificates",
     "no_certificates_deleted": "No certificates were deleted",

--- a/frontend-nx/apps/edu-hub/pages/_app.tsx
+++ b/frontend-nx/apps/edu-hub/pages/_app.tsx
@@ -16,6 +16,7 @@ import { enUS } from 'date-fns/locale/en-US';
 
 import { AppSettingsProvider } from '../contexts/AppSettingsContext';
 import { AuthErrorProvider } from '../contexts/AuthErrorContext';
+import { AuthStoreUpdater } from '../components/AuthStoreUpdater';
 
 // Import locale messages
 import deMessages from '../locales/de.json';
@@ -76,6 +77,7 @@ const MyApp: FC<AppProps & InitialProps> & {
   return (
     <NextIntlClientProvider locale={locale} messages={messages[locale]} timeZone="Europe/Berlin">
       <SessionProvider session={pageProps.session}>
+        <AuthStoreUpdater />
         <ApolloProvider client={client}>
           <AppCacheProvider {...pageProps}>
             <ThemeProvider theme={theme}>

--- a/frontend-nx/apps/edu-hub/pages/manage/course/[courseId].tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/course/[courseId].tsx
@@ -13,10 +13,14 @@ const ManageCoursePage: FC = () => {
   // Parse courseId only once it has been hydrated by the router
   const courseIdNumber = courseId ? Number(courseId) : null;
 
-  // Keep ManageCourseContent mounted once authenticated — it handles its own
-  // access-control check (admin vs. instructor-of-course). Gating on role here
-  // caused mount/unmount cycles during session transitions that re-fired queries.
-  if (status === 'loading' || !courseIdNumber || Number.isNaN(courseIdNumber)) {
+  // Keep ManageCourseContent mounted only when authenticated — it handles its own
+  // access-control check (admin vs. instructor-of-course). Blocking unauthenticated
+  // prevents MANAGED_COURSE from firing and triggering auth-error behavior.
+  if (
+    status !== 'authenticated' ||
+    !courseIdNumber ||
+    Number.isNaN(courseIdNumber)
+  ) {
     return (
       <>
         <Head>

--- a/frontend-nx/apps/edu-hub/pages/manage/course/[courseId].tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/course/[courseId].tsx
@@ -2,13 +2,33 @@ import Head from 'next/head';
 import { FC } from 'react';
 import { Page } from '../../../components/layout/Page';
 import { useRouter } from 'next/router';
-import { useIsInstructor } from '../../../hooks/authentication';
+import { useSession } from 'next-auth/react';
 import { ManageCourseContent } from '../../../components/pages/ManageCourseContent';
 
 const ManageCoursePage: FC = () => {
   const router = useRouter();
   const { courseId } = router.query;
-  const isInstructor = useIsInstructor();
+  const { status } = useSession();
+
+  // Parse courseId only once it has been hydrated by the router
+  const courseIdNumber = courseId ? Number(courseId) : null;
+
+  // Keep ManageCourseContent mounted once authenticated — it handles its own
+  // access-control check (admin vs. instructor-of-course). Gating on role here
+  // caused mount/unmount cycles during session transitions that re-fired queries.
+  if (status === 'loading' || !courseIdNumber || Number.isNaN(courseIdNumber)) {
+    return (
+      <>
+        <Head>
+          <title>EduHub | opencampus.sh</title>
+          <link rel="icon" href="/favicon.png" />
+        </Head>
+        <Page>
+          <div>Waiting for authentication!</div>
+        </Page>
+      </>
+    );
+  }
 
   return (
     <>
@@ -17,7 +37,7 @@ const ManageCoursePage: FC = () => {
         <link rel="icon" href="/favicon.png" />
       </Head>
       <Page>
-        {isInstructor ? <ManageCourseContent courseId={Number(courseId)} /> : <div>Waiting for authentication!</div>}
+        <ManageCourseContent courseId={courseIdNumber} />
       </Page>
     </>
   );


### PR DESCRIPTION
## Summary

- **fix**: Improve download documentation error handling in CourseParticipationsTab
- **fix**: Add error dialog for failed documentation downloads
- **refactor**: TableGrid uses debounced variables instead of refetch
- **refactor**: Stabilize authedQuery options to prevent unnecessary Apollo re-renders
- **fix**: Course page mount/unmount cycles during session transitions
- **refactor**: Move auth headers to Apollo Link via auth store
- **chore(i18n)**: Update add_participants label (DE)

## Commits

- fix: improve download documentation error handling and query stability
- refactor: move auth headers to Apollo Link via auth store
- chore(i18n): update add_participants label to include add action

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background session synchronizer to keep authentication state current during app use

* **Improvements**
  * More reliable auth/session handling and wait-state UI while authentication or routing resolves
  * Memoized query options to reduce unnecessary data fetches
  * Enhanced error handling for auth and network errors (including automatic handling of expired sessions)

* **Bug Fixes**
  * Explicit download button flow with loading state and error dialog for documentation downloads

* **Localization**
  * Updated participant button text and added documentation-download error translations
<!-- end of auto-generated comment: release notes by coderabbit.ai -->