### PR TITLE
Authed query options logic

### DIFF
--- a/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
+++ b/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
@@ -88,7 +88,9 @@ export const useRoleQuery: typeof useQuery = (query, passedOptions) => {
       context: mergedContext,
       onError,
       fetchPolicy: passedOptions?.fetchPolicy ?? 'cache-first',
-      nextFetchPolicy: passedOptions?.nextFetchPolicy ?? 'cache-first',
+      ...(passedOptions?.nextFetchPolicy !== undefined
+        ? { nextFetchPolicy: passedOptions.nextFetchPolicy }
+        : {}),
     }),
     [passedOptions, mergedContext, onError]
   );
@@ -129,7 +131,10 @@ export const useLazyRoleQuery: typeof useLazyQuery = (query, passedOptions) => {
             context: mergedContext,
             onError,
           }
-        : passedOptions,
+        : {
+            context: mergedContext,
+            onError,
+          },
     [passedOptions, mergedContext, onError]
   );
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Remove forced `nextFetchPolicy` in `useRoleQuery` and ensure `useLazyRoleQuery` always includes shared `onError` handler.

The forced `nextFetchPolicy: 'cache-first'` in `useRoleQuery` was overriding explicit policies from callers, breaking their intended semantics. `useLazyRoleQuery` was skipping the centralized error handling when no options were provided, leading to inconsistent error management.

---
<p><a href="https://cursor.com/agents/bc-83701e35-b2d2-466e-84a2-f7c765beee07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83701e35-b2d2-466e-84a2-f7c765beee07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query option handling to ensure proper default behavior when fetch policies are not explicitly specified.
  * Enhanced default option configuration for role-based query operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->