### PR TITLE
Course slider tile background

### DIFF
--- a/frontend-nx/apps/edu-hub/styles/widget.css
+++ b/frontend-nx/apps/edu-hub/styles/widget.css
@@ -20,7 +20,7 @@ body.widget-page.bg-edu-bg-gray {
 }
 
 /* Ensure all container divs are transparent on widget pages */
-body.widget-page div[class*="bg-"]:not([class*="bg-white"]):not([class*="bg-transparent"]) {
+body.widget-page div[class*="bg-"]:not([class*="bg-white"]):not([class*="bg-transparent"]):not(.bg-fill-primary) {
   background-color: transparent !important;
 }
 

--- a/frontend-nx/apps/edu-hub/styles/widget.css
+++ b/frontend-nx/apps/edu-hub/styles/widget.css
@@ -74,3 +74,8 @@ body.widget-page .swiper-slide a div.rounded-2xl {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.1) !important;
 }
 
+/* Keep tile info section opaque; only outer widget background stays transparent */
+body.widget-page .swiper-slide a div.bg-fill-primary {
+  background-color: var(--eduhub-fill-primary) !important;
+}
+


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Restore opaque background to the lower info panel of course slider tiles in the exported widget.

A broad CSS rule was incorrectly making the `bg-fill-primary` section of the tiles transparent, which should only apply to the outer widget area.

<div><a href="https://cursor.com/agents/bc-187d770e-28b8-48f4-92e0-3371f3667297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-187d770e-28b8-48f4-92e0-3371f3667297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Fixed widget styling so certain elements retain their primary background color (kept opaque) while generic transparent backgrounds still apply to outer areas—improves readability of tile information without altering intended outer transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->