### PR TITLE
chore: merge staging into production

### DIFF
--- a/frontend-nx/apps/edu-hub/styles/widget.css
+++ b/frontend-nx/apps/edu-hub/styles/widget.css
@@ -20,7 +20,7 @@ body.widget-page.bg-edu-bg-gray {
 }
 
 /* Ensure all container divs are transparent on widget pages */
-body.widget-page div[class*="bg-"]:not([class*="bg-white"]):not([class*="bg-transparent"]) {
+body.widget-page div[class*="bg-"]:not([class*="bg-white"]):not([class*="bg-transparent"]):not(.bg-fill-primary) {
   background-color: transparent !important;
 }
 

--- a/frontend-nx/apps/edu-hub/styles/widget.css
+++ b/frontend-nx/apps/edu-hub/styles/widget.css
@@ -74,3 +74,8 @@ body.widget-page .swiper-slide a div.rounded-2xl {
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.1) !important;
 }
 
+/* Keep tile info section opaque; only outer widget background stays transparent */
+body.widget-page .swiper-slide a div.bg-fill-primary {
+  background-color: var(--eduhub-fill-primary) !important;
+}
+


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: limited to scoped CSS changes for widget pages and should only affect visual styling of widget tiles/backgrounds.
> 
> **Overview**
> Fixes widget-page styling so the global “make all `bg-*` containers transparent” override no longer clears `.bg-fill-primary` sections.
> 
> Adds an explicit rule to keep `.bg-fill-primary` tile info areas opaque (using `--eduhub-fill-primary`) while preserving transparent outer widget backgrounds.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f1bc92ee1384f9dd48fe8fb19dbbd4781d9f5e37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->