### PR TITLE
fix(manage-courses): participant chat card, i18n cleanup, matrix dial…

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/CreateMatrixRoomDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/CreateMatrixRoomDialog.tsx
@@ -160,7 +160,9 @@ const CreateMatrixRoomDialog: FC<CreateMatrixRoomDialogProps> = ({ open, course,
         <Button onClick={onClose}>{t("manageCourses.cancel")}</Button>
         {!hasCourseRoom && (
           <Button filled onClick={handleCreate} disabled={!canSubmit}>
-            {loading ? t("manageCourses.common.saving") : t("manageCourses.matrix_room.button_create")}
+            {loading
+              ? t("manageCourses.matrix_room.button_creating")
+              : t("manageCourses.matrix_room.button_create")}
           </Button>
         )}
       </DialogActions>

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/ExpandableCourseRow.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/ExpandableCourseRow.tsx
@@ -647,7 +647,24 @@ const ExpandableCourseRow: FC<ExpandableCourseRowProps> = ({
       ? `${matrixElementClientUrl}/#/room/${matrixRoomId}`
       : `https://matrix.to/#/${matrixRoomId}`;
   }
-  const matrixRoomLink = derivedMatrixLink || course.chatLink || '';
+  const legacyChatUrl = course.chatLink?.trim() ? course.chatLink.trim() : '';
+  const openParticipantChatHref = derivedMatrixLink || legacyChatUrl || '';
+
+  const isLikelyMattermostChatUrl = (url: string) => {
+    try {
+      const host = new URL(url).hostname.toLowerCase();
+      return host.includes('mattermost') || host.includes('chat.opencampus');
+    } catch {
+      return false;
+    }
+  };
+
+  let participantChatButtonKey = 'manageCourses.participant_chat.button_open_chat';
+  if (matrixRoomId) {
+    participantChatButtonKey = 'manageCourses.participant_chat.button_open_element';
+  } else if (legacyChatUrl && isLikelyMattermostChatUrl(legacyChatUrl)) {
+    participantChatButtonKey = 'manageCourses.participant_chat.button_open_mattermost';
+  }
 
   return (
     <div className="w-full flex-1 min-w-0 light">
@@ -840,37 +857,33 @@ const ExpandableCourseRow: FC<ExpandableCourseRowProps> = ({
               />
             </div>
 
-            {/* 4. Chat / Matrix Room - Card Container */}
+            {/* 4. Participant chat (Matrix / legacy channel) */}
             <div className="bg-fill-primary border border-border-primary rounded-lg p-4 space-y-4">
-              {matrixRoomLink ? (
-                <div>
-                  <h4 className="text-sm font-medium text-label-primary mb-2">
-                    {t('manageCourses.chat_link.label')}
-                  </h4>
-                  <a
-                    href={matrixRoomLink}
+              <h4 className="text-sm font-medium text-label-primary">
+                {t('manageCourses.participant_chat.title')}
+              </h4>
+              <div className="flex items-center gap-3 flex-wrap">
+                {openParticipantChatHref ? (
+                  <Button
+                    as="a"
+                    href={openParticipantChatHref}
                     target="_blank"
                     rel="noreferrer"
-                    className="text-sm underline text-blue-600 hover:text-blue-800 break-all"
+                    filled
                   >
-                    {matrixRoomLink}
-                  </a>
-                </div>
-              ) : null}
-
-              <div className="flex items-center gap-3">
-                <Button
-                  onClick={() => setMatrixDialogOpen(true)}
-                  filled={Boolean(matrixRoomId)}
-                  disabled={Boolean(matrixRoomId)}
-                >
-                  <span className="inline-flex items-center gap-2">
-                    <MdForum className="w-4 h-4" />
-                    {matrixRoomId
-                      ? t('manageCourses.matrix_room.button_room_exists')
-                      : t('manageCourses.matrix_room.button_create')}
-                  </span>
-                </Button>
+                    <span className="inline-flex items-center gap-2">
+                      <MdForum className="w-4 h-4" />
+                      {t(participantChatButtonKey)}
+                    </span>
+                  </Button>
+                ) : (
+                  <Button onClick={() => setMatrixDialogOpen(true)}>
+                    <span className="inline-flex items-center gap-2">
+                      <MdForum className="w-4 h-4" />
+                      {t('manageCourses.matrix_room.button_create')}
+                    </span>
+                  </Button>
+                )}
               </div>
             </div>
 

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -912,12 +912,15 @@
       "label": "Externe Anmeldung Link",
       "help_text": "URL wo sich Teilnehmer extern anmelden können"
     },
-    "chat_link": {
-      "label": "Kurs-Chat Link",
-      "help_text": "Link zum Kurs-Chat oder zur Kommunikationsplattform"
+    "participant_chat": {
+      "title": "Teilnehmer-Chat",
+      "button_open_element": "Zum Element-Raum",
+      "button_open_mattermost": "Zum Mattermost-Channel",
+      "button_open_chat": "Zum Chat"
     },
     "matrix_room": {
       "button_create": "Matrix-Raum erstellen",
+      "button_creating": "Matrix-Raum wird erstellt …",
       "button_room_exists": "Matrix-Raum vorhanden",
       "dialog_title": "Matrix-Raum erstellen",
       "room_name_label": "Raumname",
@@ -933,7 +936,6 @@
     },
     "email_templates": {
       "label": "E-Mail-Vorlagen",
-      "manage_button": "E-Mail-Vorlagen verwalten",
       "create_button": "E-Mail-Vorlagen erstellen",
       "edit_button": "E-Mail-Vorlagen bearbeiten",
       "external_registration_note": "E-Mail-Vorlagen sind für externe Anmeldungen nicht verfügbar."

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -928,12 +928,15 @@
       "label": "External Registration Link",
       "help_text": "URL where participants can register externally"
     },
-    "chat_link": {
-      "label": "Course Chat Link",
-      "help_text": "Link to the course chat or communication platform"
+    "participant_chat": {
+      "title": "Participant chat",
+      "button_open_element": "To Element room",
+      "button_open_mattermost": "To Mattermost channel",
+      "button_open_chat": "Open chat"
     },
     "matrix_room": {
       "button_create": "Create Matrix Room",
+      "button_creating": "Creating Matrix room …",
       "button_room_exists": "Matrix Room Exists",
       "dialog_title": "Create Matrix Room",
       "room_name_label": "Room Name",
@@ -949,7 +952,6 @@
     },
     "email_templates": {
       "label": "Email Templates",
-      "manage_button": "Manage Email Templates",
       "create_button": "Create Email Templates",
       "edit_button": "Edit Email Templates",
       "external_registration_note": "Email templates are not available for external registration courses."


### PR DESCRIPTION
…og loading label

- Single action button for Element/Mattermost/legacy chat; card title Teilnehmer-Chat
- Remove unused manageCourses.chat_link and email_templates.manage_button
- Fix Matrix create dialog: use matrix_room.button_creating (was missing manageCourses.common.saving)
- DE: Mattermost-Channel label

Made-with: Cursor