### PR TITLE
fix(manage-courses): Matrix room dialog, Element links, env docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,8 +13,25 @@
 NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL=
 
 # Same base URL for serverless functions (createMatrixRoom, etc.). Often matches
-# NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL. Used when docker-compose passes env to node_functions.
+# NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL. Passed to node_functions via docker-compose.
 MATRIX_ELEMENT_CLIENT_URL=
+
+# --- createMatrixRoom (node_functions) — required for “Create Matrix room” in Manage Courses ---
+# Client API base URL of your Matrix homeserver (Synapse). Example: https://matrix.example.org
+MATRIX_HOMESERVER_URL=
+
+# Matrix server name (domain part of room/user IDs), e.g. example.org. Optional if derivable
+# from MATRIX_MAIN_SPACE_ID or MATRIX_ADMIN_USER_ID (see functions/callNodeFunction/createMatrixRoom).
+MATRIX_SERVER_NAME=
+
+# Room ID of the top-level Space under which program spaces are linked (m.space.child).
+MATRIX_MAIN_SPACE_ID=
+
+# Full Matrix user ID of the admin account used for power levels, e.g. @admin:example.org
+MATRIX_ADMIN_USER_ID=
+
+# Access token for that admin user (keep secret; never commit real values).
+MATRIX_ADMIN_ACCESS_TOKEN=
 
 # =============================================================================
 # Formbricks Integration

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/CreateMatrixRoomDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/CreateMatrixRoomDialog.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useMemo, useState } from "react";
+import { FC, useEffect, useState } from "react";
 import { Alert, Box, Dialog, DialogActions, DialogContent, DialogTitle, TextField, Typography } from "@mui/material";
 import { useTranslations } from "next-intl";
 
@@ -29,6 +29,10 @@ const buildElementLink = (roomId: string | null | undefined) => {
   return `${elementBaseUrl}/#/room/${roomId}`;
 };
 
+/**
+ * Create flow only: parent (`ExpandableCourseRow`) opens this when the course has no Matrix room
+ * and no legacy chat link. There is no “room already exists” state in this dialog.
+ */
 const CreateMatrixRoomDialog: FC<CreateMatrixRoomDialogProps> = ({ open, course, onClose }) => {
   const t = useTranslations();
   const [roomName, setRoomName] = useState("");
@@ -40,13 +44,12 @@ const CreateMatrixRoomDialog: FC<CreateMatrixRoomDialogProps> = ({ open, course,
   const [createMatrixRoom, { loading }] = useRoleMutation(CREATE_MATRIX_ROOM);
 
   const hasProgramSpace = Boolean((course.Program as any)?.matrixSpaceId);
-  const hasCourseRoom = Boolean((course as any).matrixRoomId);
+  const courseMatrixRoomId = (course as any).matrixRoomId as string | null | undefined;
 
-  const existingRoomLink = useMemo(() => {
-    const matrixLink = buildElementLink((course as any).matrixRoomId);
-    if (matrixLink) return matrixLink;
-    return course.chatLink || "";
-  }, [course]);
+  /** Hide inputs only after we show success; refetch may set matrixRoomId a tick before successLink. */
+  const showForm = !successLink;
+  /** Hide after refetch sets matrixRoomId (brief gap before successLink); keep visible while loading. */
+  const showCreateButton = showForm && !courseMatrixRoomId;
 
   useEffect(() => {
     if (!open) return;
@@ -67,7 +70,7 @@ const CreateMatrixRoomDialog: FC<CreateMatrixRoomDialogProps> = ({ open, course,
           courseId: course.id,
           roomName: roomName.trim(),
           topic: topic.trim() || null,
-          spaceName: hasProgramSpace ? null : (spaceName.trim() || null),
+          spaceName: hasProgramSpace ? null : spaceName.trim() || null,
         },
         refetchQueries: ["AdminCourseList"],
         awaitRefetchQueries: true,
@@ -87,32 +90,18 @@ const CreateMatrixRoomDialog: FC<CreateMatrixRoomDialogProps> = ({ open, course,
   };
 
   const canSubmit =
-    roomName.trim().length > 0 && (hasProgramSpace || spaceName.trim().length > 0) && !loading;
+    showCreateButton && roomName.trim().length > 0 && (hasProgramSpace || spaceName.trim().length > 0) && !loading;
 
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
       <DialogTitle className="light">{t("manageCourses.matrix_room.dialog_title")}</DialogTitle>
       <DialogContent className="light">
         <Box sx={{ display: "flex", flexDirection: "column", gap: 2, pt: 1 }}>
-          {hasCourseRoom && (
-            <Alert severity="info">
-              {t("manageCourses.matrix_room.button_room_exists")}
-              {existingRoomLink ? (
-                <>
-                  {" "}
-                  <a href={existingRoomLink} target="_blank" rel="noreferrer" className="underline">
-                    {t("manageCourses.matrix_room.open_in_element")}
-                  </a>
-                </>
-              ) : null}
-            </Alert>
-          )}
-
-          {!hasCourseRoom && !hasProgramSpace && (
+          {showForm && !hasProgramSpace && (
             <Alert severity="info">{t("manageCourses.matrix_room.space_will_be_created_hint")}</Alert>
           )}
 
-          {!hasCourseRoom && !hasProgramSpace && (
+          {showForm && !hasProgramSpace && (
             <TextField
               label={t("manageCourses.matrix_room.space_name_label")}
               value={spaceName}
@@ -122,7 +111,7 @@ const CreateMatrixRoomDialog: FC<CreateMatrixRoomDialogProps> = ({ open, course,
             />
           )}
 
-          {!hasCourseRoom && (
+          {showForm && (
             <>
               <TextField
                 label={t("manageCourses.matrix_room.room_name_label")}
@@ -158,7 +147,7 @@ const CreateMatrixRoomDialog: FC<CreateMatrixRoomDialogProps> = ({ open, course,
       </DialogContent>
       <DialogActions className="light">
         <Button onClick={onClose}>{t("manageCourses.cancel")}</Button>
-        {!hasCourseRoom && (
+        {showCreateButton && (
           <Button filled onClick={handleCreate} disabled={!canSubmit}>
             {loading
               ? t("manageCourses.matrix_room.button_creating")

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/ExpandableCourseRow.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/ExpandableCourseRow.tsx
@@ -640,13 +640,9 @@ const ExpandableCourseRow: FC<ExpandableCourseRowProps> = ({
   }));
 
   const matrixRoomId = (course as any).matrixRoomId as string | undefined;
-  const matrixElementClientUrl = process.env.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL?.replace(/\/+$/, '');
-  let derivedMatrixLink = '';
-  if (matrixRoomId) {
-    derivedMatrixLink = matrixElementClientUrl
-      ? `${matrixElementClientUrl}/#/room/${matrixRoomId}`
-      : `https://matrix.to/#/${matrixRoomId}`;
-  }
+  const elementBaseUrl = process.env.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL?.replace(/\/+$/, '');
+  const derivedMatrixLink =
+    matrixRoomId && elementBaseUrl ? `${elementBaseUrl}/#/room/${matrixRoomId}` : '';
   const legacyChatUrl = course.chatLink?.trim() ? course.chatLink.trim() : '';
   const openParticipantChatHref = derivedMatrixLink || legacyChatUrl || '';
 

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -921,7 +921,6 @@
     "matrix_room": {
       "button_create": "Matrix-Raum erstellen",
       "button_creating": "Matrix-Raum wird erstellt …",
-      "button_room_exists": "Matrix-Raum vorhanden",
       "dialog_title": "Matrix-Raum erstellen",
       "room_name_label": "Raumname",
       "description_label": "Thema / Beschreibung",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -937,8 +937,9 @@
     "matrix_room": {
       "button_create": "Create Matrix Room",
       "button_creating": "Creating Matrix room …",
-      "button_room_exists": "Matrix Room Exists",
+      "button_open_details": "Matrix room details",
       "dialog_title": "Create Matrix Room",
+      "dialog_title_existing": "Matrix room",
       "room_name_label": "Room Name",
       "description_label": "Topic / Description",
       "space_name_label": "Program Space Name",


### PR DESCRIPTION
- CreateMatrixRoomDialog: creation-only flow (no room-exists state)\n- ExpandableCourseRow: Element URL matches dialog; remove matrix.to fallback\n- locales: remove unused matrix_room.button_room_exists\n- .env.example: document MATRIX_* vars for node_functions createMatrixRoom

Made-with: Cursor