### PR TITLE
fix(ci): pass NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL into frontend Doc…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,9 @@
 # =============================================================================
 # Public URL of the Element web client (used by the Next.js app for room links).
 # No trailing slash required. Example: https://element-chat.example.org
+# Staging/production: set the same value as GitHub Actions env var
+# NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL on the staging/production environment so
+# the frontend Docker image build inlines it (Cloud Run runtime env alone is not enough).
 NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL=
 
 # Same base URL for serverless functions (createMatrixRoom, etc.). Often matches
@@ -32,6 +35,14 @@ MATRIX_ADMIN_USER_ID=
 
 # Access token for that admin user (keep secret; never commit real values).
 MATRIX_ADMIN_ACCESS_TOKEN=
+#
+# For existing program subspaces (matrixSpaceId already set), createMatrixRoom joins that
+# space as this user before linking course rooms. Join uses room id domain, MATRIX_SERVER_NAME,
+# and the hostname of MATRIX_HOMESERVER_URL (Synapse strips duplicate “self” server_name).
+# The room must allow join (e.g. public) or you must invite this user into the program space once.
+#
+# One course room still triggers several Client API calls (join + createRoom + state). If you see
+# “Too Many Requests” / HTTP 429, relax Synapse rc_* limits or proxy rate limits for this user/IP.
 
 # =============================================================================
 # Formbricks Integration

--- a/.github/workflows/build-and-store-docker-image.yml
+++ b/.github/workflows/build-and-store-docker-image.yml
@@ -35,6 +35,10 @@ on:
       NEXT_PUBLIC_STORAGE_BUCKET_URL:
         required: false
         type: string
+      # Element web client URL — must be set at docker build time for Next.js client bundle
+      NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL:
+        required: false
+        type: string
       # SHA of the folder for the given application
       SHA:
         required: true
@@ -54,6 +58,7 @@ jobs:
       NEXT_PUBLIC_AUTH_URL: ${{ inputs.NEXT_PUBLIC_AUTH_URL }}
       NEXT_PUBLIC_HELP_DOCS_URL: ${{ inputs.NEXT_PUBLIC_HELP_DOCS_URL }}
       NEXT_PUBLIC_STORAGE_BUCKET_URL: ${{ inputs.NEXT_PUBLIC_STORAGE_BUCKET_URL }}
+      NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL: ${{ inputs.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL }}
 
     steps:
       - name: Check Out the Repository Branch
@@ -66,7 +71,7 @@ jobs:
           project_id: ${{ inputs.PROJECT_ID }}
       - name: Build Docker image
         id: build_image
-        run: docker build ./${{ inputs.DOCKERFILE_FOLDER }} --file ./${{ inputs.DOCKERFILE_FOLDER }}/${{ inputs.DOCKERFILE_NAME }} --tag ${{ inputs.IMAGE_NAME }} --label "runnumber=${GITHUB_RUN_ID}" --build-arg NEXT_PUBLIC_API_URL=${{ inputs.NEXT_PUBLIC_API_URL }} --build-arg NEXT_PUBLIC_AUTH_URL=${{ inputs.NEXT_PUBLIC_AUTH_URL }} --build-arg NEXT_PUBLIC_HELP_DOCS_URL=${{ inputs.NEXT_PUBLIC_HELP_DOCS_URL }} --build-arg NEXT_PUBLIC_STORAGE_BUCKET_URL=${{ inputs.NEXT_PUBLIC_STORAGE_BUCKET_URL }}
+        run: docker build ./${{ inputs.DOCKERFILE_FOLDER }} --file ./${{ inputs.DOCKERFILE_FOLDER }}/${{ inputs.DOCKERFILE_NAME }} --tag ${{ inputs.IMAGE_NAME }} --label "runnumber=${GITHUB_RUN_ID}" --build-arg NEXT_PUBLIC_API_URL=${{ inputs.NEXT_PUBLIC_API_URL }} --build-arg NEXT_PUBLIC_AUTH_URL=${{ inputs.NEXT_PUBLIC_AUTH_URL }} --build-arg NEXT_PUBLIC_HELP_DOCS_URL=${{ inputs.NEXT_PUBLIC_HELP_DOCS_URL }} --build-arg NEXT_PUBLIC_STORAGE_BUCKET_URL=${{ inputs.NEXT_PUBLIC_STORAGE_BUCKET_URL }} --build-arg NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL=${{ inputs.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL }}
       - name: Authenticate with Google Cloud Artifact Registry
         id: auth_gcloud
         run: gcloud auth configure-docker ${{ secrets.GCP_REGION }}-docker.pkg.dev --quiet

--- a/.github/workflows/build-production-infrastructure.yml
+++ b/.github/workflows/build-production-infrastructure.yml
@@ -26,6 +26,7 @@ jobs:
       NEXT_PUBLIC_API_URL: ${{ steps.define_output_variables.outputs.NEXT_PUBLIC_API_URL }}
       NEXT_PUBLIC_HELP_DOCS_URL: ${{ steps.define_output_variables.outputs.NEXT_PUBLIC_HELP_DOCS_URL }}
       NEXT_PUBLIC_STORAGE_BUCKET_URL: ${{ steps.define_output_variables.outputs.NEXT_PUBLIC_STORAGE_BUCKET_URL }}
+      NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL: ${{ steps.define_output_variables.outputs.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL }}
 
     steps:
       - name: Define env variables as output variables
@@ -36,6 +37,7 @@ jobs:
           echo "NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL }}" >> $GITHUB_OUTPUT
           echo "NEXT_PUBLIC_HELP_DOCS_URL=${{ vars.NEXT_PUBLIC_HELP_DOCS_URL }}" >> $GITHUB_OUTPUT
           echo "NEXT_PUBLIC_STORAGE_BUCKET_URL=${{ vars.NEXT_PUBLIC_STORAGE_BUCKET_URL }}" >> $GITHUB_OUTPUT
+          echo "NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL=${{ vars.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL }}" >> $GITHUB_OUTPUT
 
   check_folder_changes:
     name: Check for changes in specific folders
@@ -180,6 +182,7 @@ jobs:
       NEXT_PUBLIC_AUTH_URL: ${{ needs.prepare_environment.outputs.NEXT_PUBLIC_AUTH_URL }}
       NEXT_PUBLIC_HELP_DOCS_URL: ${{ needs.prepare_environment.outputs.NEXT_PUBLIC_HELP_DOCS_URL }}
       NEXT_PUBLIC_STORAGE_BUCKET_URL: ${{ needs.prepare_environment.outputs.NEXT_PUBLIC_STORAGE_BUCKET_URL }}
+      NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL: ${{ needs.prepare_environment.outputs.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL }}
       SHA: ${{ needs.check_folder_changes.outputs.frontend_sha }}
     secrets:
       GCP_REGION: ${{ secrets.GCP_REGION }}

--- a/.github/workflows/build-staging-infrastructure.yml
+++ b/.github/workflows/build-staging-infrastructure.yml
@@ -26,6 +26,7 @@ jobs:
       NEXT_PUBLIC_API_URL: ${{ steps.define_output_variables.outputs.NEXT_PUBLIC_API_URL }}
       NEXT_PUBLIC_HELP_DOCS_URL: ${{ steps.define_output_variables.outputs.NEXT_PUBLIC_HELP_DOCS_URL }}
       NEXT_PUBLIC_STORAGE_BUCKET_URL: ${{ steps.define_output_variables.outputs.NEXT_PUBLIC_STORAGE_BUCKET_URL }}
+      NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL: ${{ steps.define_output_variables.outputs.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL }}
     steps:
       - name: Define env variables as output variables
         id: define_output_variables
@@ -35,6 +36,7 @@ jobs:
           echo "NEXT_PUBLIC_API_URL=${{ vars.NEXT_PUBLIC_API_URL }}" >> $GITHUB_OUTPUT
           echo "NEXT_PUBLIC_HELP_DOCS_URL=${{ vars.NEXT_PUBLIC_HELP_DOCS_URL }}" >> $GITHUB_OUTPUT
           echo "NEXT_PUBLIC_STORAGE_BUCKET_URL=${{ vars.NEXT_PUBLIC_STORAGE_BUCKET_URL }}" >> $GITHUB_OUTPUT
+          echo "NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL=${{ vars.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL }}" >> $GITHUB_OUTPUT
 
   check_folder_changes:
     name: Check for changes in specific folders
@@ -166,6 +168,7 @@ jobs:
       NEXT_PUBLIC_AUTH_URL: ${{ needs.prepare_environment.outputs.NEXT_PUBLIC_AUTH_URL }}
       NEXT_PUBLIC_HELP_DOCS_URL: ${{ needs.prepare_environment.outputs.NEXT_PUBLIC_HELP_DOCS_URL }}
       NEXT_PUBLIC_STORAGE_BUCKET_URL: ${{ needs.prepare_environment.outputs.NEXT_PUBLIC_STORAGE_BUCKET_URL }}
+      NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL: ${{ needs.prepare_environment.outputs.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL }}
       SHA: ${{ needs.check_folder_changes.outputs.frontend_sha }}
     secrets:
       GCP_REGION: ${{ secrets.GCP_REGION }}

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -913,7 +913,7 @@
       "help_text": "URL wo sich Teilnehmer extern anmelden können"
     },
     "participant_chat": {
-      "title": "Teilnehmer-Chat",
+      "title": "Teilnehmenden-Chat",
       "button_open_element": "Zum Element-Raum",
       "button_open_mattermost": "Zum Mattermost-Channel",
       "button_open_chat": "Zum Chat"


### PR DESCRIPTION
…ker build

- Add workflow input and docker build-arg so Next.js inlines Element client URL\n- Wire GitHub vars through staging/production infrastructure workflows\n- Document build-time requirement and Matrix admin notes in .env.example\n- de: rename participant chat title to Teilnehmenden-Chat

Made-with: Cursor