### PR TITLE
fix(functions): Harden Keycloak user PUT merge for custom attributes

### DIFF
--- a/.github/workflows/build-staging-infrastructure.yml
+++ b/.github/workflows/build-staging-infrastructure.yml
@@ -102,8 +102,10 @@ jobs:
             echo $sha
           }
 
-          hasura_sha=$(calculate_sha "backend")
-          keycloak_sha=$(calculate_sha "keycloak")
+          # Same pattern as production: content hash plus timestamp so Terraform sees a new
+          # value each pipeline run and Cloud Run can roll out fresh :latest images when needed.
+          hasura_sha=$(calculate_sha "backend")-$(date +%s)
+          keycloak_sha=$(calculate_sha "keycloak")-$(date +%s)
           frontend_sha=$(calculate_sha "frontend-nx")
           functions_sha=$(calculate_sha "functions")
 

--- a/functions/shared_libs/node/keycloakUserMerge.cjs
+++ b/functions/shared_libs/node/keycloakUserMerge.cjs
@@ -4,7 +4,22 @@
  * returns 400 "User name is missing" when editUsernameAllowed is true.
  *
  * Always merge changes onto the UserRepresentation from GET before PUT.
+ *
+ * When `patch.attributes` is set, it is deep-merged into `existingUser.attributes`
+ * so a partial map (e.g. only `matrix_user_handle`) does not wipe other custom
+ * attributes such as `picture`. To remove an attribute, pass an empty array for
+ * that key (Keycloak convention).
+ *
+ * Strips read-only fields sometimes present on GET responses (`userProfileMetadata`,
+ * `access`, etc.) so PUT does not fail validation or behave unexpectedly.
  */
+const READ_ONLY_OR_DERIVED_FIELDS = [
+  "userProfileMetadata",
+  "access",
+  "self",
+  "credentials",
+];
+
 function mergeUserPutPayload(existingUser, patch) {
   if (!existingUser?.username) {
     throw new Error(
@@ -13,7 +28,15 @@ function mergeUserPutPayload(existingUser, patch) {
   }
   const merged = { ...existingUser, ...patch };
   if (patch.attributes !== undefined) {
-    merged.attributes = patch.attributes;
+    merged.attributes = {
+      ...(existingUser.attributes || {}),
+      ...patch.attributes,
+    };
+  }
+  for (const key of READ_ONLY_OR_DERIVED_FIELDS) {
+    if (Object.prototype.hasOwnProperty.call(merged, key)) {
+      delete merged[key];
+    }
   }
   return merged;
 }

--- a/functions/shared_libs/node/keycloakUserMerge.cjs
+++ b/functions/shared_libs/node/keycloakUserMerge.cjs
@@ -17,7 +17,6 @@ const READ_ONLY_OR_DERIVED_FIELDS = [
   "userProfileMetadata",
   "access",
   "self",
-  "credentials",
 ];
 
 function mergeUserPutPayload(existingUser, patch) {

--- a/functions/shared_libs/node/keycloakUserMerge.test.cjs
+++ b/functions/shared_libs/node/keycloakUserMerge.test.cjs
@@ -1,0 +1,67 @@
+/**
+ * Run: node --test keycloakUserMerge.test.cjs
+ */
+const { test } = require("node:test");
+const assert = require("node:assert/strict");
+const { mergeUserPutPayload } = require("./keycloakUserMerge.cjs");
+
+test("merges partial attributes without dropping existing custom attributes", () => {
+  const existing = {
+    username: "u@example.com",
+    firstName: "A",
+    lastName: "B",
+    email: "u@example.com",
+    attributes: {
+      picture: ["https://cdn.example.com/p.jpg"],
+      locale: ["de"],
+    },
+    userProfileMetadata: { readOnly: false },
+    access: { manage: true },
+  };
+  const patch = {
+    attributes: {
+      matrix_user_handle: ["anna.bo.abc123"],
+    },
+  };
+  const out = mergeUserPutPayload(existing, patch);
+  assert.equal(out.picture, undefined);
+  assert.deepEqual(out.attributes, {
+    picture: ["https://cdn.example.com/p.jpg"],
+    locale: ["de"],
+    matrix_user_handle: ["anna.bo.abc123"],
+  });
+  assert.equal(out.userProfileMetadata, undefined);
+  assert.equal(out.access, undefined);
+});
+
+test("patch attribute values override existing keys", () => {
+  const existing = {
+    username: "x@y.com",
+    attributes: { picture: ["old"] },
+  };
+  const out = mergeUserPutPayload(existing, {
+    attributes: { picture: ["new"] },
+  });
+  assert.deepEqual(out.attributes, { picture: ["new"] });
+});
+
+test("clears an attribute when patch sets empty array", () => {
+  const existing = {
+    username: "x@y.com",
+    attributes: { picture: ["x"], matrix_user_handle: ["h"] },
+  };
+  const out = mergeUserPutPayload(existing, {
+    attributes: { picture: [] },
+  });
+  assert.deepEqual(out.attributes, {
+    picture: [],
+    matrix_user_handle: ["h"],
+  });
+});
+
+test("throws when username missing", () => {
+  assert.throws(
+    () => mergeUserPutPayload({ email: "a@b.com" }, { firstName: "A" }),
+    /username/
+  );
+});

--- a/keycloak/imports-dev/edu-hub.json
+++ b/keycloak/imports-dev/edu-hub.json
@@ -2143,6 +2143,17 @@
         }
       }
     ],
+    "org.keycloak.userprofile.UserProfileProvider": [
+      {
+        "providerId": "declarative-user-profile",
+        "subComponents": {},
+        "config": {
+          "kc.user.profile.config": [
+            "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}}},{\"name\":\"email\",\"displayName\":\"${email}\",\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"validations\":{\"email\":{},\"length\":{\"max\":255}}},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}}},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}}},{\"name\":\"matrix_user_handle\",\"displayName\":\"Matrix User Handle\",\"permissions\":{\"view\":[\"admin\"],\"edit\":[\"admin\"]}},{\"name\":\"picture\",\"displayName\":\"Picture\",\"permissions\":{\"view\":[\"admin\"],\"edit\":[\"admin\"]}}]}"
+          ]
+        }
+      }
+    ],
     "org.keycloak.keys.KeyProvider": [
       {
         "id": "01fe2dbf-e1aa-49a9-a7a7-b39bb6b9174e",

--- a/keycloak/imports/edu-hub-realm.json
+++ b/keycloak/imports/edu-hub-realm.json
@@ -1324,7 +1324,9 @@
       "id" : "de6f022e-9f68-447e-963d-8dcb925ea472",
       "providerId" : "declarative-user-profile",
       "subComponents" : { },
-      "config" : { }
+      "config" : {
+        "kc.user.profile.config" : [ "{\"attributes\":[{\"name\":\"username\",\"displayName\":\"${username}\",\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"validations\":{\"length\":{\"min\":3,\"max\":255},\"username-prohibited-characters\":{},\"up-username-not-idn-homograph\":{}}},{\"name\":\"email\",\"displayName\":\"${email}\",\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"validations\":{\"email\":{},\"length\":{\"max\":255}}},{\"name\":\"firstName\",\"displayName\":\"${firstName}\",\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}}},{\"name\":\"lastName\",\"displayName\":\"${lastName}\",\"required\":{\"roles\":[\"user\"]},\"permissions\":{\"view\":[\"admin\",\"user\"],\"edit\":[\"admin\",\"user\"]},\"validations\":{\"length\":{\"max\":255},\"person-name-prohibited-characters\":{}}},{\"name\":\"matrix_user_handle\",\"displayName\":\"Matrix User Handle\",\"permissions\":{\"view\":[\"admin\"],\"edit\":[\"admin\"]}},{\"name\":\"picture\",\"displayName\":\"Picture\",\"permissions\":{\"view\":[\"admin\"],\"edit\":[\"admin\"]}}]}" ]
+      }
     } ],
     "org.keycloak.keys.KeyProvider" : [ {
       "id" : "01fe2dbf-e1aa-49a9-a7a7-b39bb6b9174e",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### Keycloak user PUT merge (functions)
- Deep-merge `patch.attributes` into existing Keycloak attributes; strip read-only GET fields before PUT.
- Unit tests: `cd functions/shared_libs/node && node --test keycloakUserMerge.test.cjs`

### CI: staging SHA alignment
- Staging now computes `keycloak_sha` and `hasura_sha` the **same way as production**: `$(calculate_sha "<folder>")-$(date +%s)` so Terraform gets a new value each run and Cloud Run can roll out fresh `:latest` images.

## Staging theme warnings

Unrelated to attribute sync; theme parent resolution in Keycloak.

## Verification

- `node --test` on keycloakUserMerge (local).
- Docker Keycloak E2E: SPI works when image includes `matrix-handle-listener.jar`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2547aab2-7aa7-4dd8-bc0d-901d1ffaa463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2547aab2-7aa7-4dd8-bc0d-901d1ffaa463"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced user profile schema with additional attributes, display/permission settings, and validation rules (username, email, names, handle, picture).

* **Bug Fixes**
  * Partial profile updates now merge custom attributes instead of replacing them.
  * Read-only and derived fields are excluded from modification payloads.

* **Tests**
  * Added tests covering attribute merge behavior, overrides, empty-array handling, and required-field validation.

* **Chores**
  * CI adjusted to ensure back-end/profile-related builds run consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->