### PR TITLE
fix(functions): paginate Formbricks response fetching to handle >100 responses

### DIFF
--- a/functions/callNodeFunction/createEnrollmentWithAddons/index.js
+++ b/functions/callNodeFunction/createEnrollmentWithAddons/index.js
@@ -1,5 +1,5 @@
 import { GraphQLClient } from 'graphql-request';
-import { validateAndExtractFormbricksSurvey, buildLabelToChoiceIdMap, matchAddonsFromResponse } from '../lib/formbricks.js';
+import { validateAndExtractFormbricksSurvey, buildLabelToChoiceIdMap, matchAddonsFromResponse, fetchAllFormbricksResponses } from '../lib/formbricks.js';
 
 const normalizeUserId = (value) => String(value ?? '').trim().toLowerCase();
 
@@ -113,9 +113,6 @@ async function fetchFormbricksResponseWithRetry(
   retryDelayMs = 2000
 ) {
   const normalizedUserId = normalizeUserId(userId);
-  const responsesUrl = new URL(`${formbricksApiUrl}/api/v1/management/responses`);
-  responsesUrl.searchParams.append('surveyId', formbricksSurveyId);
-  responsesUrl.searchParams.append('limit', '100');
 
   // Initial delay before first attempt - Formbricks needs time to persist the response
   // The survey completion event can fire before Formbricks has saved the response
@@ -133,27 +130,19 @@ async function fetchFormbricksResponseWithRetry(
         courseId: String(courseId)
       });
 
-      const responsesResponse = await fetch(responsesUrl.toString(), {
-        method: 'GET',
-        headers: {
-          'x-api-key': formbricksApiKey,
-          'Content-Type': 'application/json'
-        }
-      });
-
-      if (!responsesResponse.ok) {
-        const errorText = await responsesResponse.text();
-        logger.error(`Failed to fetch responses: ${responsesResponse.status}`, { errorText });
+      let allResponses;
+      try {
+        allResponses = await fetchAllFormbricksResponses(
+          formbricksApiUrl, formbricksSurveyId, formbricksApiKey, logger
+        );
+      } catch (fetchError) {
+        logger.error(`Failed to fetch responses: ${fetchError.message}`);
         if (attempt === maxRetries) {
-          throw new Error(`Failed to fetch Formbricks responses: ${responsesResponse.status}`);
+          throw fetchError;
         }
-        // Wait before retrying on API error
         await new Promise(resolve => setTimeout(resolve, retryDelayMs));
         continue;
       }
-
-      const responsesData = await responsesResponse.json();
-      const allResponses = responsesData.data || [];
 
       logger.info(`Formbricks API returned ${allResponses.length} total responses`, {
         attempt,

--- a/functions/callNodeFunction/getFormbricksAddonSelections/index.js
+++ b/functions/callNodeFunction/getFormbricksAddonSelections/index.js
@@ -15,7 +15,7 @@ const GET_COURSE_ADDONS = `
   }
 `;
 
-import { validateAndExtractFormbricksSurvey, buildLabelToChoiceIdMap, matchAddonsFromResponse } from '../lib/formbricks.js';
+import { validateAndExtractFormbricksSurvey, buildLabelToChoiceIdMap, matchAddonsFromResponse, fetchAllFormbricksResponses } from '../lib/formbricks.js';
 
 /**
  * Fetches selected addons from the latest Formbricks response for a user/course.
@@ -124,54 +124,30 @@ export default async function getFormbricksAddonSelections(req, logger) {
       });
     }
     
-    // Fetch the latest Formbricks response for this user/course
-    const responsesUrl = new URL(`${formbricksApiUrl}/api/v1/management/responses`);
-    responsesUrl.searchParams.append('surveyId', formbricksSurveyId);
-    responsesUrl.searchParams.append('limit', '100');
-    
-    const responsesResponse = await fetch(responsesUrl.toString(), {
-      method: 'GET',
-      headers: {
-        'x-api-key': formbricksApiKey,
-        'Content-Type': 'application/json'
-      }
-    });
-    
-    if (!responsesResponse.ok) {
-      const errorText = await responsesResponse.text();
-      logger.error(`Failed to fetch responses: ${responsesResponse.status}`, { errorText });
+    // Fetch all Formbricks responses for this survey (paginated)
+    let allResponseData;
+    try {
+      allResponseData = await fetchAllFormbricksResponses(
+        formbricksApiUrl, formbricksSurveyId, formbricksApiKey, logger
+      );
+    } catch (fetchError) {
+      logger.error('Failed to fetch Formbricks responses', { error: fetchError.message });
       return {
         success: false,
         selectedAddons: [],
-        error: `Failed to fetch Formbricks responses: ${responsesResponse.status}`,
+        error: `Failed to fetch Formbricks responses: ${fetchError.message}`,
         messageKey: 'FORMBRICKS_FETCH_ERROR'
       };
     }
     
-    const responsesData = await responsesResponse.json();
-    
     logger.info('Formbricks API response', {
-      totalResponses: responsesData.data?.length || 0,
+      totalResponses: allResponseData.length,
       lookingFor: { userId, courseId }
     });
     
-    // Log all responses for debugging
-    if (responsesData.data && responsesData.data.length > 0) {
-      responsesData.data.forEach((response, index) => {
-        const rd = response.data || {};
-        logger.debug(`Response ${index}`, {
-          id: response.id,
-          finished: response.finished,
-          eduhubUserId: rd.eduhubUserId,
-          eduhubCourseId: rd.eduhubCourseId,
-          dataKeys: Object.keys(rd)
-        });
-      });
-    }
-    
     // Filter responses by userId and courseId (from hidden fields)
     // Note: Convert to String for comparison as Formbricks stores these as strings
-    const userResponses = (responsesData.data || []).filter(response => {
+    const userResponses = allResponseData.filter(response => {
       const responseData = response.data || {};
       const responseUserId = responseData.eduhubUserId;
       const responseCourseId = responseData.eduhubCourseId;
@@ -196,7 +172,7 @@ export default async function getFormbricksAddonSelections(req, logger) {
     });
     
     // Also check for unfinished responses that match (to detect timing issues)
-    const unfinishedMatchingResponses = (responsesData.data || []).filter(response => {
+    const unfinishedMatchingResponses = allResponseData.filter(response => {
       const responseData = response.data || {};
       const matchesUser = String(responseData.eduhubUserId) === String(userId);
       const matchesCourse = String(responseData.eduhubCourseId) === String(courseId);
@@ -233,7 +209,7 @@ export default async function getFormbricksAddonSelections(req, logger) {
         logger.warn('No responses found for user/course', {
           userId: String(userId),
           courseId: String(courseId),
-          totalResponsesFromApi: responsesData.data?.length || 0
+          totalResponsesFromApi: allResponseData.length
         });
         return {
           success: true,

--- a/functions/callNodeFunction/getFormbricksResponses/index.js
+++ b/functions/callNodeFunction/getFormbricksResponses/index.js
@@ -1,4 +1,4 @@
-import { validateAndExtractFormbricksSurvey } from '../lib/formbricks.js';
+import { validateAndExtractFormbricksSurvey, fetchAllFormbricksResponses } from '../lib/formbricks.js';
 
 /**
  * Fetches Formbricks survey responses for a specific enrollment.
@@ -122,36 +122,20 @@ export default async function getFormbricksResponses(req, logger) {
     
     const surveyData = await surveyResponse.json();
     
-    // Fetch responses filtered by surveyId
-    const responsesUrl = new URL(`${formbricksApiUrl}/api/v1/management/responses`);
-    responsesUrl.searchParams.append('surveyId', formbricksSurveyId);
-    responsesUrl.searchParams.append('limit', '100');
-    
-    const responsesResponse = await fetch(responsesUrl.toString(), {
-      method: 'GET',
-      headers: {
-        'x-api-key': formbricksApiKey,
-        'Content-Type': 'application/json'
-      }
-    });
-    
-    if (!responsesResponse.ok) {
-      const errorText = await responsesResponse.text();
-      logger.error(`Failed to fetch responses: ${responsesResponse.status}`, { errorText });
-      throw new Error(`Failed to fetch responses: ${responsesResponse.status} - ${errorText}`);
-    }
-    
-    const responsesData = await responsesResponse.json();
+    // Fetch all responses for the survey (paginated)
+    const allResponseData = await fetchAllFormbricksResponses(
+      formbricksApiUrl, formbricksSurveyId, formbricksApiKey, logger
+    );
     
     logger.debug('Fetched responses from Formbricks', {
-      totalResponses: responsesData.data?.length || 0,
+      totalResponses: allResponseData.length,
       lookingFor: { userId, courseId, enrollmentId }
     });
     
     // Filter responses by eduhub* hidden fields
     // Hidden fields are stored directly in response.data (not in response.data.hiddenFields)
     // Note: We use 'eduhub*' prefix to avoid conflicts with Formbricks internal variables
-    const userResponses = (responsesData.data || []).filter(response => {
+    const userResponses = allResponseData.filter(response => {
       // Hidden fields are stored directly in response.data alongside question answers
       const responseData = response.data || {};
       
@@ -196,7 +180,7 @@ export default async function getFormbricksResponses(req, logger) {
     
     logger.debug('Filtered responses', {
       matchedCount: userResponses.length,
-      totalChecked: responsesData.data?.length || 0
+      totalChecked: allResponseData.length
     });
     
     // Transform responses to include question labels

--- a/functions/callNodeFunction/lib/formbricks.js
+++ b/functions/callNodeFunction/lib/formbricks.js
@@ -84,6 +84,65 @@ export function matchAddonsFromResponse(responseData, addonMappings, labelToChoi
 }
 
 /**
+ * Fetches all Formbricks responses for a survey, handling pagination automatically.
+ * The Formbricks v1 Management API returns at most `limit` responses per request
+ * and supports `skip` for offset-based pagination.
+ *
+ * @param {string} formbricksApiUrl - Base URL of Formbricks instance (e.g. "https://app.formbricks.com")
+ * @param {string} surveyId - Formbricks survey ID
+ * @param {string} apiKey - Formbricks Management API key
+ * @param {Object} [logger] - Optional Winston logger instance
+ * @param {number} [pageSize=100] - Number of responses per page (max ~250 for v1)
+ * @returns {Promise<Array>} All response objects for the survey
+ */
+export async function fetchAllFormbricksResponses(formbricksApiUrl, surveyId, apiKey, logger, pageSize = 100) {
+  const allResponses = [];
+  let skip = 0;
+  const MAX_PAGES = 50; // safety limit to avoid infinite loops
+
+  for (let page = 0; page < MAX_PAGES; page++) {
+    const url = new URL(`${formbricksApiUrl}/api/v1/management/responses`);
+    url.searchParams.append('surveyId', surveyId);
+    url.searchParams.append('limit', String(pageSize));
+    url.searchParams.append('skip', String(skip));
+
+    logger?.debug('Fetching Formbricks responses page', { page, skip, pageSize, surveyId });
+
+    const res = await fetch(url.toString(), {
+      method: 'GET',
+      headers: {
+        'x-api-key': apiKey,
+        'Content-Type': 'application/json',
+      },
+    });
+
+    if (!res.ok) {
+      const errorText = await res.text();
+      logger?.error(`Failed to fetch responses page ${page}: ${res.status}`, { errorText });
+      throw new Error(`Failed to fetch Formbricks responses: ${res.status} - ${errorText}`);
+    }
+
+    const body = await res.json();
+    const pageData = body.data || [];
+
+    allResponses.push(...pageData);
+
+    if (pageData.length < pageSize) {
+      break; // last page
+    }
+
+    skip += pageData.length;
+  }
+
+  logger?.debug('Finished paginated fetch of Formbricks responses', {
+    surveyId,
+    totalFetched: allResponses.length,
+  });
+
+  return allResponses;
+}
+
+/**
  * Shared Formbricks utilities for URL validation and extraction.
  * Enforces HTTPS, validates against trusted origins, and parses survey URL.
  * Used by createEnrollmentWithAddons, getFormbricksResponses, getFormbricksAddonSelections,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Formbricks survey answers were not displayed in the Applications tab for courses whose survey had more than 100 total responses. The UI showed "Keine Fragebogen-Antworten vorhanden" (no questionnaire answers found) even though responses were actually collected and visible in Formbricks.

## Root Cause

The Formbricks Management API v1 returns at most `limit` responses per request. All three serverless functions that fetch Formbricks responses used `limit=100` with **no pagination**, so any response beyond the first 100 was silently missed. When a user's response fell outside this window (common for popular surveys), the filtering step found no match and returned an empty result.

## Solution

Added a shared `fetchAllFormbricksResponses()` utility to `functions/callNodeFunction/lib/formbricks.js` that paginates through all responses using the `skip` + `limit` parameters. Updated all three consumer functions to use it:

- **`getFormbricksResponses`** — Applications tab display
- **`getFormbricksAddonSelections`** — addon matching during registration
- **`createEnrollmentWithAddons`** — enrollment retry flow

The utility includes a safety limit of 50 pages (5,000 responses) to prevent infinite loops.

## Files Changed

| File | Change |
|------|--------|
| `functions/callNodeFunction/lib/formbricks.js` | Added `fetchAllFormbricksResponses()` with paginated fetching |
| `functions/callNodeFunction/getFormbricksResponses/index.js` | Use paginated fetch instead of single `limit=100` call |
| `functions/callNodeFunction/getFormbricksAddonSelections/index.js` | Use paginated fetch instead of single `limit=100` call |
| `functions/callNodeFunction/createEnrollmentWithAddons/index.js` | Use paginated fetch in retry helper |

## Testing

- Verified all three modules load and export correctly
- Tested pagination logic with mock API: 0, 1, 99, 100 (boundary), 101, 200, and 500 response scenarios all pass
- Frontend lint passes (no new warnings/errors)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9647d205-6bce-43c1-87e7-24ae7808e4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9647d205-6bce-43c1-87e7-24ae7808e4f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of survey response data retrieval and error handling.
  * Enhanced error logging for API operations to better support troubleshooting.

* **Refactor**
  * Streamlined internal response fetching logic for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->