### PR TITLE
MOOCHub feed: include DLC-funded EVENTS programs

### DIFF
--- a/functions/apiProxy/main.py
+++ b/functions/apiProxy/main.py
@@ -93,6 +93,39 @@ def get_cors_headers():
     }
     return headers
 
+
+def _course_has_dlc_funding(course):
+    """True if the course lists Digital Learning Campus (DLC) as a funding organization."""
+    for funding_org in course.get("CourseFundingOrganizations", []):
+        organization = funding_org.get("Organization", {})
+        org_name_normalized = organization.get("name", "").strip().upper()
+        if org_name_normalized in ("DIGITAL LEARNING CAMPUS", "DLC"):
+            return True
+        aliases = organization.get("aliases")
+        if aliases and isinstance(aliases, list):
+            for alias in aliases:
+                alias_normalized = str(alias).strip().upper() if alias else ""
+                if alias_normalized in ("DIGITAL LEARNING CAMPUS", "DLC"):
+                    return True
+    return False
+
+
+def _moochub_include_course(course):
+    """
+    Include published courses from COURSES programs, exclude DEGREES, and include
+    EVENTS programs only when DLC is a funding organization.
+    """
+    program = course.get("Program") or {}
+    program_type = program.get("type") or program.get("shortTitle")
+    if program_type == "DEGREES":
+        return False
+    if program_type == "COURSES":
+        return True
+    if program_type == "EVENTS":
+        return _course_has_dlc_funding(course)
+    return False
+
+
 def handle_moochub_data(page=1, per_page=25):
     try:
         # Use the existing EduHubClient
@@ -127,6 +160,7 @@ def handle_moochub_data(page=1, per_page=25):
                 Program {
                     id
                     shortTitle
+                    type
                     applicationStart
                 }
                 Sessions(order_by: { startDateTime: asc }) {
@@ -171,10 +205,10 @@ def handle_moochub_data(page=1, per_page=25):
         if not isinstance(courses, dict) or "data" not in courses:
             return {'error': 'Failed to fetch data from EduHub'}, 500
 
-        # Filter courses
+        # Filter courses: COURSES programs; EVENTS only with DLC funding; exclude DEGREES
         courses["data"]["Course"] = [
             course for course in courses["data"]["Course"]
-            if course["Program"]["shortTitle"] not in ["EVENTS", "DEGREES"]
+            if _moochub_include_course(course)
         ]
 
         # Transform to MOOCHub schema - one entry per course location
@@ -217,28 +251,8 @@ def handle_moochub_data(page=1, per_page=25):
                 html_content = markdown.markdown(course["contentDescriptionField2"])
                 description_parts.append(html_content)
 
-            # Check for Digital Learning Campus funding organization to add keywords
-            # Matches organization name or aliases that normalize to "DLC" or "DIGITAL LEARNING CAMPUS"
-            has_dlc_funding = False
-            for funding_org in course.get("CourseFundingOrganizations", []):
-                organization = funding_org.get("Organization", {})
-                
-                # Normalize organization name
-                org_name_normalized = organization.get("name", "").strip().upper()
-                if org_name_normalized in ("DIGITAL LEARNING CAMPUS", "DLC"):
-                    has_dlc_funding = True
-                    break
-                
-                # Check aliases if present
-                aliases = organization.get("aliases")
-                if aliases and isinstance(aliases, list):
-                    for alias in aliases:
-                        alias_normalized = str(alias).strip().upper() if alias else ""
-                        if alias_normalized in ("DIGITAL LEARNING CAMPUS", "DLC"):
-                            has_dlc_funding = True
-                            break
-                    if has_dlc_funding:
-                        break
+            # Keywords for DLC-funded courses (same logic as EVENTS inclusion filter)
+            has_dlc_funding = _course_has_dlc_funding(course)
 
             # Build start/end date arrays from all sessions (irregular series per MOOCHub schema)
             # Deduplicate by (start, end) pair - schema requires uniqueItems for startDate/endDate

--- a/functions/apiProxy/main.py
+++ b/functions/apiProxy/main.py
@@ -116,12 +116,16 @@ def _moochub_include_course(course):
     EVENTS programs only when DLC is a funding organization.
     """
     program = course.get("Program") or {}
-    program_type = program.get("type") or program.get("shortTitle")
-    if program_type == "DEGREES":
+    raw_type = program.get("type") or program.get("shortTitle")
+    if raw_type is None:
+        program_type_normalized = ""
+    else:
+        program_type_normalized = str(raw_type).strip().upper()
+    if program_type_normalized == "DEGREES":
         return False
-    if program_type == "COURSES":
+    if program_type_normalized == "COURSES":
         return True
-    if program_type == "EVENTS":
+    if program_type_normalized == "EVENTS":
         return _course_has_dlc_funding(course)
     return False
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The MOOCHub API (`/moochub`) previously dropped all courses whose program `shortTitle` was `EVENTS` or `DEGREES`, which effectively limited the feed to **COURSES**-type programs only.

This change keeps **DEGREES** excluded, keeps **COURSES** included, and **additionally includes EVENTS** programs when the course has **Digital Learning Campus (DLC)** as a funding organization (same name/alias matching as the existing `DLC-Original` keyword logic).

Program type matching uses normalized `type` / `shortTitle` (strip + uppercase) so whitespace/case variants still filter correctly.

## Implementation

- Added `_course_has_dlc_funding()` and `_moochub_include_course()` in `functions/apiProxy/main.py`.
- GraphQL query requests `Program.type` for reliable program-type checks (with fallback to `shortTitle`).

## Testing

- `python3 -m py_compile functions/apiProxy/main.py`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6984f695-bee6-48e6-811c-e64dfab25f87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6984f695-bee6-48e6-811c-e64dfab25f87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected course feed filtering to exclude degree programs and to include event items only when they have specific DLC funding, ensuring eligible events appear.

* **Refactor**
  * Consolidated and clarified the course inclusion rules for the feed.

* **Other**
  * DLC-funded items are now consistently tagged with the DLC keyword in feed output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->