### PR TITLE
Fix course invitation email templates for direct registration types

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/ExpandableCourseRow.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/ExpandableCourseRow.tsx
@@ -23,6 +23,7 @@ import {
   UserSelectionWithFilter_User,
 } from '../../../queries/__generated__/UserSelectionWithFilter';
 import { CourseRegistrationType_enum, order_by } from '../../../__generated__/globalTypes';
+import { getEmailTemplateTypesForCourseRegistration } from '../../../utils/getEmailTemplateTypesForCourseRegistration';
 import { SelectUserDialog } from '../../common/dialogs/SelectUserDialog';
 import { SelectOrganizationDialog } from '../../common/dialogs/SelectOrganizationDialog';
 import { CreateUserDialog } from '../../common/dialogs/CreateUserDialog';
@@ -272,35 +273,6 @@ const ExpandableCourseRow: FC<ExpandableCourseRowProps> = ({
     return undefined;
   }, [course, requiresPayment, stripeSyncStatus, isStripeSyncing, handleSyncStripeBasePrice]);
 
-  // Determine available template types based on registration type
-  const getAvailableTemplates = useCallback((): string[] => {
-    const allTemplates = [
-      'APPLICATION_RECEIVED',
-      'APPLICATION_CONFIRMED',
-      'SESSION_REMINDER',
-      'INVITE',
-      'DECLINE',
-      'REGISTRATION_CONFIRMED',
-    ];
-
-    if (!course.registrationType || course.registrationType === CourseRegistrationType_enum.EXTERNAL_REGISTRATION) {
-      return []; // No templates for external registration
-    }
-
-    if (
-      course.registrationType === CourseRegistrationType_enum.DIRECT_WITH_INPUT ||
-      course.registrationType === CourseRegistrationType_enum.DIRECT_CONFIRMATION
-    ) {
-      return ['REGISTRATION_CONFIRMED', 'SESSION_REMINDER'];
-    }
-
-    if (course.registrationType === CourseRegistrationType_enum.APPROVAL_WITH_INPUT) {
-      return allTemplates.filter((t) => t !== 'REGISTRATION_CONFIRMED');
-    }
-
-    return [];
-  }, [course.registrationType]);
-
   // Handle button click - create templates if needed, then navigate
   const handleManageEmailTemplates = useCallback(async () => {
     if (isExternalRegistration) {
@@ -309,7 +281,7 @@ const ExpandableCourseRow: FC<ExpandableCourseRowProps> = ({
 
     // If templates don't exist, create them from defaults
     if (!hasCustomTemplates && defaultTemplatesData?.MailTemplate) {
-      const availableTemplateTypes = getAvailableTemplates();
+      const availableTemplateTypes = getEmailTemplateTypesForCourseRegistration(course.registrationType);
       if (availableTemplateTypes.length > 0) {
         try {
           // Create templates for available types from defaults
@@ -360,7 +332,7 @@ const ExpandableCourseRow: FC<ExpandableCourseRowProps> = ({
     isExternalRegistration,
     hasCustomTemplates,
     defaultTemplatesData,
-    getAvailableTemplates,
+    course.registrationType,
     insertEmailTemplate,
     course.id,
     refetchTemplatesCount,

--- a/frontend-nx/apps/edu-hub/pages/manage/course/[courseId]/email-templates/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/course/[courseId]/email-templates/index.tsx
@@ -1,5 +1,5 @@
 import Head from 'next/head';
-import { FC, useEffect, useState, useCallback } from 'react';
+import { FC, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Page } from '../../../../../components/layout/Page';
 import { useIsAdmin, useIsLoggedIn } from '../../../../../hooks/authentication';
@@ -10,7 +10,7 @@ import Loading from '../../../../../components/common/Loading';
 import { MANAGED_COURSE } from '../../../../../queries/course';
 import { ManagedCourse } from '../../../../../queries/__generated__/ManagedCourse';
 import ManageEmailTemplatesContent from '../../../../../components/pages/ManageEmailTemplatesContent';
-import { CourseRegistrationType_enum } from '../../../../../__generated__/globalTypes';
+import { getEmailTemplateTypesForCourseRegistration } from '../../../../../utils/getEmailTemplateTypesForCourseRegistration';
 import {
   GET_DEFAULT_TEMPLATES,
   GET_COURSE_TEMPLATES_COUNT,
@@ -52,38 +52,6 @@ const CourseEmailTemplates: FC = () => {
     INSERT_EMAIL_TEMPLATE
   );
 
-  // Determine available template types based on registration type
-  const getAvailableTemplates = useCallback((registrationType: CourseRegistrationType_enum | null): string[] => {
-    const allTemplates = [
-      'APPLICATION_RECEIVED',
-      'APPLICATION_CONFIRMED',
-      'SESSION_REMINDER',
-      'INVITE',
-      'DECLINE',
-      'REGISTRATION_CONFIRMED',
-      'ORGANIZER_ADDED',
-    ];
-
-    if (!registrationType || registrationType === CourseRegistrationType_enum.EXTERNAL_REGISTRATION) {
-      return []; // No templates for external registration
-    }
-
-    if (
-      registrationType === CourseRegistrationType_enum.DIRECT_WITH_INPUT ||
-      registrationType === CourseRegistrationType_enum.DIRECT_CONFIRMATION ||
-      registrationType === CourseRegistrationType_enum.DIRECT_WITH_INPUT_AND_PAYMENT ||
-      registrationType === CourseRegistrationType_enum.DIRECT_CONFIRMATION_AND_PAYMENT
-    ) {
-      return ['REGISTRATION_CONFIRMED', 'SESSION_REMINDER', 'ORGANIZER_ADDED'];
-    }
-
-    if (registrationType === CourseRegistrationType_enum.APPROVAL_WITH_INPUT) {
-      return allTemplates.filter((t) => t !== 'REGISTRATION_CONFIRMED');
-    }
-
-    return [];
-  }, []);
-
   // Create templates from defaults if they don't exist
   useEffect(() => {
     const createTemplatesFromDefaults = async () => {
@@ -100,7 +68,7 @@ const CourseEmailTemplates: FC = () => {
       const course = data?.Course_by_pk;
       if (!course) return;
 
-      const availableTemplateTypes = getAvailableTemplates(course.registrationType);
+      const availableTemplateTypes = getEmailTemplateTypesForCourseRegistration(course.registrationType);
       if (availableTemplateTypes.length === 0) return;
 
       try {
@@ -154,7 +122,6 @@ const CourseEmailTemplates: FC = () => {
     data,
     insertEmailTemplate,
     refetchTemplatesCount,
-    getAvailableTemplates,
   ]);
 
   if (!isLoggedIn || !isAdmin) {
@@ -183,7 +150,7 @@ const CourseEmailTemplates: FC = () => {
   }
 
   const course = data.Course_by_pk;
-  const availableTemplateTypes = getAvailableTemplates(course.registrationType);
+  const availableTemplateTypes = getEmailTemplateTypesForCourseRegistration(course.registrationType);
 
   return (
     <>

--- a/frontend-nx/apps/edu-hub/utils/getEmailTemplateTypesForCourseRegistration.test.tsx
+++ b/frontend-nx/apps/edu-hub/utils/getEmailTemplateTypesForCourseRegistration.test.tsx
@@ -1,0 +1,33 @@
+import { CourseRegistrationType_enum } from '../__generated__/globalTypes';
+import { getEmailTemplateTypesForCourseRegistration } from './getEmailTemplateTypesForCourseRegistration';
+
+describe('getEmailTemplateTypesForCourseRegistration', () => {
+  it('returns empty for external or missing registration type', () => {
+    expect(getEmailTemplateTypesForCourseRegistration(null)).toEqual([]);
+    expect(getEmailTemplateTypesForCourseRegistration(CourseRegistrationType_enum.EXTERNAL_REGISTRATION)).toEqual(
+      []
+    );
+  });
+
+  it('includes INVITE and paid variants for direct registration types', () => {
+    const directTypes = [
+      CourseRegistrationType_enum.DIRECT_WITH_INPUT,
+      CourseRegistrationType_enum.DIRECT_CONFIRMATION,
+      CourseRegistrationType_enum.DIRECT_WITH_INPUT_AND_PAYMENT,
+      CourseRegistrationType_enum.DIRECT_CONFIRMATION_AND_PAYMENT,
+    ];
+    for (const rt of directTypes) {
+      const types = getEmailTemplateTypesForCourseRegistration(rt);
+      expect(types).toContain('INVITE');
+      expect(types).toContain('APPLICATION_RECEIVED_PAID');
+      expect(types).toContain('REGISTRATION_CONFIRMED_PAID');
+    }
+  });
+
+  it('excludes self-registration confirmed templates for approval flow', () => {
+    const types = getEmailTemplateTypesForCourseRegistration(CourseRegistrationType_enum.APPROVAL_WITH_INPUT);
+    expect(types).toContain('INVITE');
+    expect(types).not.toContain('REGISTRATION_CONFIRMED');
+    expect(types).not.toContain('REGISTRATION_CONFIRMED_PAID');
+  });
+});

--- a/frontend-nx/apps/edu-hub/utils/getEmailTemplateTypesForCourseRegistration.ts
+++ b/frontend-nx/apps/edu-hub/utils/getEmailTemplateTypesForCourseRegistration.ts
@@ -1,0 +1,44 @@
+import { CourseRegistrationType_enum } from '../__generated__/globalTypes';
+
+/**
+ * Mail template types that can be edited per course, scoped by course registration type.
+ * Must stay aligned with {@link sendEnrollmentEmail}: any status-driven mail needs its
+ * template type available here so course-specific rows are created and shown in the UI.
+ */
+export function getEmailTemplateTypesForCourseRegistration(
+  registrationType: CourseRegistrationType_enum | null
+): string[] {
+  const allTemplates = [
+    'APPLICATION_RECEIVED',
+    'APPLICATION_RECEIVED_PAID',
+    'APPLICATION_CONFIRMED',
+    'SESSION_REMINDER',
+    'INVITE',
+    'DECLINE',
+    'REGISTRATION_CONFIRMED',
+    'REGISTRATION_CONFIRMED_PAID',
+    'ORGANIZER_ADDED',
+  ];
+
+  if (!registrationType || registrationType === CourseRegistrationType_enum.EXTERNAL_REGISTRATION) {
+    return [];
+  }
+
+  if (
+    registrationType === CourseRegistrationType_enum.DIRECT_WITH_INPUT ||
+    registrationType === CourseRegistrationType_enum.DIRECT_CONFIRMATION ||
+    registrationType === CourseRegistrationType_enum.DIRECT_WITH_INPUT_AND_PAYMENT ||
+    registrationType === CourseRegistrationType_enum.DIRECT_CONFIRMATION_AND_PAYMENT
+  ) {
+    // Self-service registration plus admin actions (invite, add as applied, etc.)
+    return [...allTemplates];
+  }
+
+  if (registrationType === CourseRegistrationType_enum.APPROVAL_WITH_INPUT) {
+    return allTemplates.filter(
+      (t) => t !== 'REGISTRATION_CONFIRMED' && t !== 'REGISTRATION_CONFIRMED_PAID'
+    );
+  }
+
+  return [];
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When new registration types were added, the UI logic that decides **which course-level `MailTemplate` rows** to create and show treated **direct** registration flows as only needing self-registration templates (`REGISTRATION_CONFIRMED`, `SESSION_REMINDER`, etc.). Admin actions such as **inviting** a user still send mail via `sendEnrollmentEmail` using the **`INVITE`** template type (see `functions/callNodeFunction/sendEnrollmentEmail/index.js`), but **`INVITE` was excluded** from the allowed list for those courses.

That could produce **empty or misleading course-specific `INVITE` content** (unique index allows one row per type per course) while the onboarding UI still worked—matching “email broken, page OK”.

## Changes

- Add `getEmailTemplateTypesForCourseRegistration()` in `frontend-nx/apps/edu-hub/utils/getEmailTemplateTypesForCourseRegistration.ts` so **all non-external** registration types get the **full set** of status-driven templates, including **`INVITE`**, **`APPLICATION_RECEIVED_PAID`**, and **`REGISTRATION_CONFIRMED_PAID`** (aligned with `sendEnrollmentEmail`).
- **`APPROVAL_WITH_INPUT`** still omits self-registration confirmed templates only.
- Wire **course email templates page** and **ExpandableCourseRow** “email templates” bootstrap to this helper.
- Unit tests for the helper (`*.test.tsx`); run with `yarn jest --config apps/edu-hub/jest.config.ts …`.

## Testing

- `yarn eslint` on touched files
- `yarn jest --config apps/edu-hub/jest.config.ts apps/edu-hub/utils/getEmailTemplateTypesForCourseRegistration.test.tsx`
- `npm test` in `functions/callNodeFunction` for `sendEnrollmentEmail` (unchanged; still passes)

## Note for existing data

Courses that already have a **course-level `INVITE` row created with empty body** while on a direct registration type may need that template **edited** in the admin UI (or removed so the default global template applies). New courses get correct defaults from this fix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7eaad672-5857-4230-8a91-656e28448142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7eaad672-5857-4230-8a91-656e28448142"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated email template selection logic into a centralized utility function across the application, eliminating duplicate implementations.

* **Tests**
  * Added comprehensive test coverage for email template type selection based on course registration type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->