### PR TITLE
Fix enrollment status email trigger for invoice-based payment schema

### DIFF
--- a/functions/callNodeFunction/sendEnrollmentEmail/index.js
+++ b/functions/callNodeFunction/sendEnrollmentEmail/index.js
@@ -41,9 +41,11 @@ export default async function sendEnrollmentEmail(req, logger) {
         CourseEnrollment_by_pk(id: $enrollmentId) {
           id
           status
-          paymentStatus
           created_at
           invitationExpirationDate
+          Invoices(limit: 1, order_by: { created_at: desc }) {
+            status
+          }
           User {
             id
             firstName
@@ -138,10 +140,11 @@ export default async function sendEnrollmentEmail(req, logger) {
         };
     }
     
-    // Select paid template variant if payment is completed
-    // Only for APPLICATION_RECEIVED and REGISTRATION_CONFIRMED
+    // Select paid template variant if latest invoice is paid
+    // (CourseEnrollment.paymentStatus was removed in favor of Invoice.status)
     let templateType = baseTemplateType;
-    const isPaid = enrollmentDetails.paymentStatus === 'COMPLETED';
+    const latestInvoiceStatus = enrollmentDetails.Invoices?.[0]?.status;
+    const isPaid = latestInvoiceStatus === 'PAID';
     if (isPaid) {
       if (baseTemplateType === 'REGISTRATION_CONFIRMED') {
         templateType = 'REGISTRATION_CONFIRMED_PAID';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix `sendEnrollmentEmail` to stop querying removed `CourseEnrollment.paymentStatus`
- derive paid template selection from latest related `Invoice.status` (`PAID`)
- keep existing behavior for template resolution and mail queue insertion

## Root cause
`send_enrollment_status_email` was firing, but `sendEnrollmentEmail` failed before MailLog insertion because its GraphQL query still requested `CourseEnrollment.paymentStatus`, which no longer exists in the schema.

## Validation
- reproduced trigger failure and confirmed Hasura invocation response error: `field 'paymentStatus' not found in type: 'CourseEnrollment'`
- applied fix and re-triggered enrollment update
- confirmed invocation now returns `EMAIL_QUEUED_SUCCESS` and new `MailLog` row is created
- ran targeted unit tests for `sendEnrollmentEmail` (all passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e7310b25-8441-4cb5-9ebb-e66202041582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e7310b25-8441-4cb5-9ebb-e66202041582"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of enrollment confirmation emails to ensure they reflect the correct payment status based on the latest invoice information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->