### PR TITLE
feat: add organizer Element chat welcome prompt on applications tab

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
@@ -60,11 +60,15 @@ const isExpired = (enrollment: ManagedCourse_Course_by_pk_CourseEnrollments) => 
 export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
   const t = useTranslations('manageCourse');
   const tCommon = useTranslations('common');
+  const tCourse = useTranslations('course');
   const locale = useLocale();
   const displayDate = useDisplayDate();
   const isInstructor = useIsInstructor();
   const isAdmin = useIsAdmin();
   const theme = useTheme();
+  const matrixRoomId = course.matrixRoomId?.trim();
+  const elementBaseUrl = process.env.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL?.replace(/\/+$/, '');
+  const organizerCourseChatLink = matrixRoomId && elementBaseUrl ? `${elementBaseUrl}/#/room/${matrixRoomId}` : null;
 
   const features = useMemo(
     () => getRegistrationFeatures(course.registrationType),
@@ -874,35 +878,47 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
       )}
 
       <div>
-            <OnlyInstructor>
-              <TableGrid<ManagedCourse_Course_by_pk_CourseEnrollments>
-                columns={columns}
-                data={filteredEnrollments}
-                loading={false}
-                error={null as unknown as ApolloError}
-                expandableRowComponent={ExpandableApplicationRow}
-                bulkActions={bulkActions}
-                onBulkAction={handleBulkEmailAction}
-                enablePagination={true}
-                totalCount={filteredEnrollments.length}
-                pageIndex={pageIndex}
-                onPageChange={setPageIndex}
-                pageSize={pageSize}
-                onPageSizeChange={handlePageSizeChange}
-                searchFilter={searchFilter}
-                onSearchFilterChange={setSearchFilter}
-                refetchQueries={[]}
-                {...(isAdmin && {
-                  addButtonText: t('add_participants'),
-                  onAddButtonClick: openAddParticipantsModal,
-                })}
-              />
-            </OnlyInstructor>
+        <OnlyInstructor>
+          {organizerCourseChatLink && (
+            <div className="mb-4 flex flex-col gap-3 rounded-lg border border-border-primary bg-bg-secondary p-4 sm:flex-row sm:items-center sm:justify-between">
+              <p className="text-sm text-label-primary">{t('element_chat_welcome_prompt')}</p>
+              <OldButton
+                className="!bg-brand !text-white !border-brand hover:!bg-brand-light hover:!border-brand-light px-8 py-3.5 sm:px-10 sm:py-4 text-base sm:text-lg font-semibold uppercase tracking-wide shadow-md hover:shadow-lg transition-shadow whitespace-nowrap"
+                as="a"
+                href={organizerCourseChatLink}
+                filled
+              >
+                {tCourse('general.to_course_chat')}
+              </OldButton>
+            </div>
+          )}
+          <TableGrid<ManagedCourse_Course_by_pk_CourseEnrollments>
+            columns={columns}
+            data={filteredEnrollments}
+            loading={false}
+            error={null as unknown as ApolloError}
+            expandableRowComponent={ExpandableApplicationRow}
+            bulkActions={bulkActions}
+            onBulkAction={handleBulkEmailAction}
+            enablePagination={true}
+            totalCount={filteredEnrollments.length}
+            pageIndex={pageIndex}
+            onPageChange={setPageIndex}
+            pageSize={pageSize}
+            onPageSizeChange={handlePageSizeChange}
+            searchFilter={searchFilter}
+            onSearchFilterChange={setSearchFilter}
+            refetchQueries={[]}
+            {...(isAdmin && {
+              addButtonText: t('add_participants'),
+              onAddButtonClick: openAddParticipantsModal,
+            })}
+          />
+        </OnlyInstructor>
 
-            {filteredEnrollments.length > 0 && features.hasApplicationProcess && (
-              <div className="-mt-8 mb-3">{infoDots}</div>
-            )}
-
+        {filteredEnrollments.length > 0 && features.hasApplicationProcess && (
+          <div className="-mt-8 mb-3">{infoDots}</div>
+        )}
       </div>
 
       {/* Invitation Dialog */}

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
@@ -838,6 +838,22 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         <AddParticipantsForm courseId={course.id} onSubmit={closeAddParticipantsModal} />
       </Modal>
 
+      <OnlyInstructor>
+        {organizerCourseChatLink && (
+          <div className="mb-6 flex items-center justify-center gap-3 rounded-lg border border-border-primary bg-bg-secondary p-4">
+            <p className="text-sm text-label-primary">{t('element_chat_welcome_prompt')}</p>
+            <OldButton
+              className="!bg-brand !text-white !border-brand hover:!bg-brand-light hover:!border-brand-light whitespace-nowrap"
+              as="a"
+              href={organizerCourseChatLink}
+              filled
+            >
+              {tCourse('general.to_course_chat')}
+            </OldButton>
+          </div>
+        )}
+      </OnlyInstructor>
+
       {/* Statistics Cards */}
       {courseEnrollments.length > 0 && (
         <div className={`grid grid-cols-1 md:grid-cols-2 ${features.hasApplicationProcess ? 'lg:grid-cols-4' : 'lg:grid-cols-2'} gap-4 mb-6`}>
@@ -879,19 +895,6 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
 
       <div>
         <OnlyInstructor>
-          {organizerCourseChatLink && (
-            <div className="mb-4 flex flex-col gap-3 rounded-lg border border-border-primary bg-bg-secondary p-4 sm:flex-row sm:items-center sm:justify-between">
-              <p className="text-sm text-label-primary">{t('element_chat_welcome_prompt')}</p>
-              <OldButton
-                className="!bg-brand !text-white !border-brand hover:!bg-brand-light hover:!border-brand-light whitespace-nowrap"
-                as="a"
-                href={organizerCourseChatLink}
-                filled
-              >
-                {tCourse('general.to_course_chat')}
-              </OldButton>
-            </div>
-          )}
           <TableGrid<ManagedCourse_Course_by_pk_CourseEnrollments>
             columns={columns}
             data={filteredEnrollments}

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
@@ -883,7 +883,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
             <div className="mb-4 flex flex-col gap-3 rounded-lg border border-border-primary bg-bg-secondary p-4 sm:flex-row sm:items-center sm:justify-between">
               <p className="text-sm text-label-primary">{t('element_chat_welcome_prompt')}</p>
               <OldButton
-                className="!bg-brand !text-white !border-brand hover:!bg-brand-light hover:!border-brand-light px-8 py-3.5 sm:px-10 sm:py-4 text-base sm:text-lg font-semibold uppercase tracking-wide shadow-md hover:shadow-lg transition-shadow whitespace-nowrap"
+                className="!bg-brand !text-white !border-brand hover:!bg-brand-light hover:!border-brand-light whitespace-nowrap"
                 as="a"
                 href={organizerCourseChatLink}
                 filled

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
@@ -839,7 +839,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
       </Modal>
 
       <OnlyInstructor>
-        {organizerCourseChatLink && (
+        {organizerCourseChatLink ? (
           <div className="mb-6 flex items-center justify-center gap-3 rounded-lg border border-border-primary bg-bg-secondary p-4">
             <p className="text-sm text-label-primary">{t('element_chat_welcome_prompt')}</p>
             <OldButton
@@ -851,7 +851,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
               {tCourse('general.to_course_chat')}
             </OldButton>
           </div>
-        )}
+        ) : undefined}
       </OnlyInstructor>
 
       {/* Statistics Cards */}

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1039,6 +1039,7 @@
     "application": "Bewerbung",
     "evaluation": "Beurteilung",
     "send_email_to_applicants": "E-Mail an Bewerber senden",
+    "element_chat_welcome_prompt": "Bitte begrüße deine Teilnehmenden im Element-Chat.",
     "select_applicants_first": "Bitte wähle zuerst Bewerber aus",
     "bulk_actions": {
       "expand_collapse_rows": "Zeilen aus-/einklappen",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1057,6 +1057,7 @@
     "application": "Application",
     "evaluation": "Evaluation",
     "send_email_to_applicants": "Send Email to Applicants",
+    "element_chat_welcome_prompt": "Please enter the Element chat and welcome your course participants.",
     "select_applicants_first": "Please select applicants first",
     "bulk_actions": {
       "expand_collapse_rows": "Expand/Collapse Rows",


### PR DESCRIPTION
## Summary
- add an organizer-only Element chat prompt row on Manage Course → Applications
- render the row only when an Element room can be derived (`matrixRoomId` + `NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL`)
- use standard button sizing for the organizer CTA (no large participant-page styling)
- place the prompt above statistics and center text+button side-by-side
- fix Next.js build type error by making `OnlyInstructor` child expression return `Element | undefined`
- remove unnecessary prompt encapsulation with `OnlyInstructor` so admins and instructors on this page both see it

## Changes
- update `ApplicationsTab` to:
  - derive an organizer course chat link from Matrix room id
  - render a compact prompt row when the link exists
  - position the prompt row above statistics cards
  - align prompt text and CTA in one centered horizontal row
  - reuse `course.general.to_course_chat` for CTA label consistency
  - satisfy `OnlyInstructor` child typing via ternary (`organizerCourseChatLink ? <div ... /> : undefined`)
  - remove `OnlyInstructor` wrapper from the prompt block (page access already restricts to instructor/admin)
- add i18n key `manageCourse.element_chat_welcome_prompt` to:
  - `frontend-nx/apps/edu-hub/locales/en.json`
  - `frontend-nx/apps/edu-hub/locales/de.json`

## Validation
- `yarn build` succeeds end-to-end
- build still reports pre-existing React Hooks warnings in:
  - `components/common/TableGrid/hooks.ts`
  - `components/inputs/InputField.tsx`
- manual UI validation on Manage Course → Applications tab confirms:
  - prompt appears only when matrix room exists
  - prompt is above statistics cards
  - text and button are side-by-side and centered
  - button remains standard-size

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Instructors get a banner with a link to the course Element (Matrix) chat when a valid chat link can be formed.
  * The banner shows a localized call-to-action and appears only for instructors when applicable.

* **Localization**
  * Added guidance text for the Element chat in English and German.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->