### PR TITLE
fix: bulk invite/decline emails only for applicants without prior invite/decline

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
@@ -17,7 +17,10 @@ import {
   UpdateEnrollmentRating,
   UpdateEnrollmentRatingVariables,
 } from '../../../../queries/__generated__/UpdateEnrollmentRating';
-import { UPDATE_ENROLLMENT_STATUS, UPDATE_ENROLLMENT_RATING } from '../../../../queries/insertEnrollment';
+import {
+  UPDATE_ENROLLMENT_STATUS_WHEN_APPLIED,
+  UPDATE_ENROLLMENT_RATING,
+} from '../../../../queries/insertEnrollment';
 import { Button as OldButton } from '../../../common/Button';
 import { Dialog, DialogTitle, Tooltip } from '@mui/material';
 import { HelpOutline } from '@mui/icons-material';
@@ -26,9 +29,9 @@ import { MdClose } from 'react-icons/md';
 import DatePicker from 'react-datepicker';
 import 'react-datepicker/dist/react-datepicker.css';
 import {
-  UpdateEnrollmentStatus,
-  UpdateEnrollmentStatusVariables,
-} from '../../../../queries/__generated__/UpdateEnrollmentStatus';
+  UpdateEnrollmentStatusWhenApplied,
+  UpdateEnrollmentStatusWhenAppliedVariables,
+} from '../../../../queries/__generated__/UpdateEnrollmentStatusWhenApplied';
 import { useTranslations, useLocale } from 'next-intl';
 import Modal from '../../../common/Modal';
 import AddParticipantsForm from './AddParticipantsForm';
@@ -44,6 +47,7 @@ import { ApolloError } from '@apollo/client';
 import { ErrorMessageDialog } from '../../../common/dialogs/ErrorMessageDialog';
 import { FormbricksResponsesDisplay } from './FormbricksResponsesDisplay';
 import { getRegistrationFeatures } from './registrationConfig';
+import NotificationSnackbar from '../../../common/dialogs/NotificationSnackbar';
 
 interface IProps {
   course: ManagedCourse_Course_by_pk;
@@ -89,6 +93,12 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
     return { totalApplications, approvedApplications, invitedApplicants, confirmedApplicants };
   }, [course.CourseEnrollments]);
 
+  const courseEnrollments = useMemo(() => {
+    const result = [...course.CourseEnrollments];
+    result.sort((a, b) => a.id - b.id);
+    return result;
+  }, [course]);
+
   const infoDots = (
     <div className="text-gray-400 text-sm">
       <div className="mb-1">{t('rating.label')}</div>
@@ -109,9 +119,20 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
     </div>
   );
 
-  const [updateEnrollmentStatus] = useRoleMutation<UpdateEnrollmentStatus, UpdateEnrollmentStatusVariables>(
-    UPDATE_ENROLLMENT_STATUS
-  );
+  const [updateEnrollmentStatusWhenApplied] = useRoleMutation<
+    UpdateEnrollmentStatusWhenApplied,
+    UpdateEnrollmentStatusWhenAppliedVariables
+  >(UPDATE_ENROLLMENT_STATUS_WHEN_APPLIED);
+
+  const [bulkNoticeOpen, setBulkNoticeOpen] = useState(false);
+  const [bulkNoticeMessage, setBulkNoticeMessage] = useState('');
+  const showBulkNotice = useCallback((message: string) => {
+    setBulkNoticeMessage(message);
+    setBulkNoticeOpen(true);
+  }, []);
+  const handleCloseBulkNotice = useCallback(() => {
+    setBulkNoticeOpen(false);
+  }, []);
 
   // Calculate default invitation expiration date (3 days before first session, or 3 days from now)
   const getDefaultInviteExpireDate = useCallback(() => {
@@ -148,12 +169,33 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
   } | null>(null);
 
   const handleOpenInviteDialog = useCallback(
-    (enrollmentsToSend: ManagedCourse_Course_by_pk_CourseEnrollments[], selectedCount: number | undefined, identifiedCount: number, actionType: 'selected' | 'all') => {
-      setInviteDialogData({ enrollmentsToSend, selectedCount, identifiedCount, actionType });
+    (
+      enrollmentIds: number[],
+      selectedCount: number | undefined,
+      identifiedCount: number,
+      actionType: 'selected' | 'all'
+    ) => {
+      const idToRow = new Map(courseEnrollments.map((e) => [e.id, e]));
+      const enrollmentsToSend = enrollmentIds
+        .map((id) => idToRow.get(id))
+        .filter(
+          (e): e is ManagedCourse_Course_by_pk_CourseEnrollments =>
+            !!e && e.motivationRating === 'INVITE' && e.status === 'APPLIED'
+        );
+      if (enrollmentsToSend.length === 0) {
+        showBulkNotice(t('bulk_actions.no_eligible_invitations'));
+        return;
+      }
+      setInviteDialogData({
+        enrollmentsToSend,
+        selectedCount,
+        identifiedCount: enrollmentsToSend.length,
+        actionType,
+      });
       setInviteExpireDate(getDefaultInviteExpireDate());
       setIsInviteDialogOpen(true);
     },
-    [getDefaultInviteExpireDate]
+    [courseEnrollments, getDefaultInviteExpireDate, showBulkNotice, t]
   );
 
   const [inviteError, setInviteError] = useState<string | null>(null);
@@ -167,18 +209,35 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
   const handleSendInvitations = useCallback(async () => {
     if (!inviteDialogData) return;
 
+    const idToRow = new Map(courseEnrollments.map((e) => [e.id, e]));
+    const enrollmentIds = inviteDialogData.enrollmentsToSend
+      .map((e) => e.id)
+      .filter((id) => {
+        const row = idToRow.get(id);
+        return row?.motivationRating === 'INVITE' && row.status === 'APPLIED';
+      });
+
+    if (enrollmentIds.length === 0) {
+      showBulkNotice(t('bulk_actions.no_eligible_invitations'));
+      handleCloseInviteDialog();
+      return;
+    }
+
     try {
-      for (const enrollment of inviteDialogData.enrollmentsToSend) {
-        await updateEnrollmentStatus({
-          variables: {
-            enrollmentId: enrollment.id,
-            expire: inviteExpireDate,
-            status: CourseEnrollmentStatus_enum.INVITED,
-          },
-        });
+      const result = await updateEnrollmentStatusWhenApplied({
+        variables: {
+          enrollmentIds,
+          status: CourseEnrollmentStatus_enum.INVITED,
+          expire: inviteExpireDate,
+        },
+      });
+      if ((result.data?.update_CourseEnrollment?.affected_rows ?? 0) === 0) {
+        showBulkNotice(t('bulk_actions.no_eligible_invitations'));
+        await qResult.refetch();
+        handleCloseInviteDialog();
+        return;
       }
-      // Only refetch and close on success
-      qResult.refetch();
+      await qResult.refetch();
       handleCloseInviteDialog();
     } catch (error) {
       const errorMessage = error instanceof ApolloError 
@@ -191,7 +250,16 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         `Failed to send invitations: ${errorMessage}`
       );
     }
-  }, [inviteDialogData, inviteExpireDate, updateEnrollmentStatus, qResult, handleCloseInviteDialog, t]);
+  }, [
+    inviteDialogData,
+    inviteExpireDate,
+    courseEnrollments,
+    updateEnrollmentStatusWhenApplied,
+    qResult,
+    handleCloseInviteDialog,
+    showBulkNotice,
+    t,
+  ]);
 
   // Dialog state for rejections
   const [isRejectionDialogOpen, setIsRejectionDialogOpen] = useState(false);
@@ -203,11 +271,32 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
   } | null>(null);
 
   const handleOpenRejectionDialog = useCallback(
-    (enrollmentsToSend: ManagedCourse_Course_by_pk_CourseEnrollments[], selectedCount: number | undefined, identifiedCount: number, actionType: 'selected' | 'all') => {
-      setRejectionDialogData({ enrollmentsToSend, selectedCount, identifiedCount, actionType });
+    (
+      enrollmentIds: number[],
+      selectedCount: number | undefined,
+      identifiedCount: number,
+      actionType: 'selected' | 'all'
+    ) => {
+      const idToRow = new Map(courseEnrollments.map((e) => [e.id, e]));
+      const enrollmentsToSend = enrollmentIds
+        .map((id) => idToRow.get(id))
+        .filter(
+          (e): e is ManagedCourse_Course_by_pk_CourseEnrollments =>
+            !!e && e.motivationRating === 'DECLINE' && e.status === 'APPLIED'
+        );
+      if (enrollmentsToSend.length === 0) {
+        showBulkNotice(t('bulk_actions.no_eligible_rejections'));
+        return;
+      }
+      setRejectionDialogData({
+        enrollmentsToSend,
+        selectedCount,
+        identifiedCount: enrollmentsToSend.length,
+        actionType,
+      });
       setIsRejectionDialogOpen(true);
     },
-    []
+    [courseEnrollments, showBulkNotice, t]
   );
 
   const [rejectionError, setRejectionError] = useState<string | null>(null);
@@ -221,18 +310,35 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
   const handleSendRejections = useCallback(async () => {
     if (!rejectionDialogData) return;
 
+    const idToRow = new Map(courseEnrollments.map((e) => [e.id, e]));
+    const enrollmentIds = rejectionDialogData.enrollmentsToSend
+      .map((e) => e.id)
+      .filter((id) => {
+        const row = idToRow.get(id);
+        return row?.motivationRating === 'DECLINE' && row.status === 'APPLIED';
+      });
+
+    if (enrollmentIds.length === 0) {
+      showBulkNotice(t('bulk_actions.no_eligible_rejections'));
+      handleCloseRejectionDialog();
+      return;
+    }
+
     try {
-      for (const enrollment of rejectionDialogData.enrollmentsToSend) {
-        await updateEnrollmentStatus({
-          variables: {
-            enrollmentId: enrollment.id,
-            expire: null,
-            status: CourseEnrollmentStatus_enum.REJECTED,
-          },
-        });
+      const result = await updateEnrollmentStatusWhenApplied({
+        variables: {
+          enrollmentIds,
+          status: CourseEnrollmentStatus_enum.REJECTED,
+          expire: null,
+        },
+      });
+      if ((result.data?.update_CourseEnrollment?.affected_rows ?? 0) === 0) {
+        showBulkNotice(t('bulk_actions.no_eligible_rejections'));
+        await qResult.refetch();
+        handleCloseRejectionDialog();
+        return;
       }
-      // Only refetch and close on success
-      qResult.refetch();
+      await qResult.refetch();
       handleCloseRejectionDialog();
     } catch (error) {
       const errorMessage = error instanceof ApolloError 
@@ -245,7 +351,15 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         `Failed to send rejections: ${errorMessage}`
       );
     }
-  }, [rejectionDialogData, updateEnrollmentStatus, qResult, handleCloseRejectionDialog, t]);
+  }, [
+    rejectionDialogData,
+    courseEnrollments,
+    updateEnrollmentStatusWhenApplied,
+    qResult,
+    handleCloseRejectionDialog,
+    showBulkNotice,
+    t,
+  ]);
 
   // Dialog state for "no selection" warning
   const [isNoSelectionDialogOpen, setIsNoSelectionDialogOpen] = useState(false);
@@ -261,12 +375,6 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
     identityEventMapper,
     qResult
   );
-
-  const courseEnrollments = useMemo(() => {
-    const result = [...course.CourseEnrollments];
-    result.sort((a, b) => a.id - b.id);
-    return result;
-  }, [course]);
 
   const [isAddParticipantsModalOpen, setAddParticipantsModalOpen] = useState(false);
   const [pageIndex, setPageIndex] = useState(0);
@@ -318,17 +426,31 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         const enrollmentsToSend = selectedRows.filter(
           (e) => e.motivationRating === 'INVITE' && e.status === 'APPLIED'
         );
-        if (enrollmentsToSend.length > 0) {
-          handleOpenInviteDialog(enrollmentsToSend, selectedRows.length, enrollmentsToSend.length, 'selected');
+        if (enrollmentsToSend.length === 0) {
+          showBulkNotice(t('bulk_actions.no_eligible_invitations'));
+          return;
         }
+        handleOpenInviteDialog(
+          enrollmentsToSend.map((e) => e.id),
+          selectedRows.length,
+          enrollmentsToSend.length,
+          'selected'
+        );
         return;
       } else if (action === 'send_invitations_all') {
         const enrollmentsToSend = courseEnrollments.filter(
           (e) => e.motivationRating === 'INVITE' && e.status === 'APPLIED'
         );
-        if (enrollmentsToSend.length > 0) {
-          handleOpenInviteDialog(enrollmentsToSend, undefined, enrollmentsToSend.length, 'all');
+        if (enrollmentsToSend.length === 0) {
+          showBulkNotice(t('bulk_actions.no_eligible_invitations'));
+          return;
         }
+        handleOpenInviteDialog(
+          enrollmentsToSend.map((e) => e.id),
+          undefined,
+          enrollmentsToSend.length,
+          'all'
+        );
         return;
       }
 
@@ -341,17 +463,31 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         const enrollmentsToSend = selectedRows.filter(
           (e) => e.motivationRating === 'DECLINE' && e.status === 'APPLIED'
         );
-        if (enrollmentsToSend.length > 0) {
-          handleOpenRejectionDialog(enrollmentsToSend, selectedRows.length, enrollmentsToSend.length, 'selected');
+        if (enrollmentsToSend.length === 0) {
+          showBulkNotice(t('bulk_actions.no_eligible_rejections'));
+          return;
         }
+        handleOpenRejectionDialog(
+          enrollmentsToSend.map((e) => e.id),
+          selectedRows.length,
+          enrollmentsToSend.length,
+          'selected'
+        );
         return;
       } else if (action === 'send_rejections_all') {
         const enrollmentsToSend = courseEnrollments.filter(
           (e) => e.motivationRating === 'DECLINE' && e.status === 'APPLIED'
         );
-        if (enrollmentsToSend.length > 0) {
-          handleOpenRejectionDialog(enrollmentsToSend, undefined, enrollmentsToSend.length, 'all');
+        if (enrollmentsToSend.length === 0) {
+          showBulkNotice(t('bulk_actions.no_eligible_rejections'));
+          return;
         }
+        handleOpenRejectionDialog(
+          enrollmentsToSend.map((e) => e.id),
+          undefined,
+          enrollmentsToSend.length,
+          'all'
+        );
         return;
       }
 
@@ -375,7 +511,14 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         window.location.href = `mailto:?bcc=${emails}`;
       }
     },
-    [courseEnrollments, handleOpenInviteDialog, handleOpenRejectionDialog, setIsNoSelectionDialogOpen]
+    [
+      courseEnrollments,
+      handleOpenInviteDialog,
+      handleOpenRejectionDialog,
+      setIsNoSelectionDialogOpen,
+      showBulkNotice,
+      t,
+    ]
   );
 
   const bulkActions: BulkAction[] = useMemo(() => {
@@ -393,8 +536,11 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
       { value: 'email_selected', label: t('bulk_actions.email_selected') },
     ];
 
-    // Invitation actions - only for instructors
-    if (isInstructor && courseEnrollments.some((e) => e.motivationRating === 'INVITE')) {
+    // Invitation actions - only for instructors (green rating + still applied)
+    if (
+      isInstructor &&
+      courseEnrollments.some((e) => e.motivationRating === 'INVITE' && e.status === 'APPLIED')
+    ) {
       actions.push({
         value: 'send_invitations_selected',
         label: t('bulk_actions.send_invitations_selected'),
@@ -407,8 +553,11 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
       });
     }
 
-    // Rejection actions - only for instructors
-    if (isInstructor && courseEnrollments.some((e) => e.motivationRating === 'DECLINE')) {
+    // Rejection actions - only for instructors (red rating + still applied)
+    if (
+      isInstructor &&
+      courseEnrollments.some((e) => e.motivationRating === 'DECLINE' && e.status === 'APPLIED')
+    ) {
       actions.push({
         value: 'send_rejections_selected',
         label: t('bulk_actions.send_rejections_selected'),
@@ -1053,6 +1202,11 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         errorMessage={rejectionError || ''}
         open={!!rejectionError}
         onClose={() => setRejectionError(null)}
+      />
+      <NotificationSnackbar
+        open={bulkNoticeOpen}
+        onClose={handleCloseBulkNotice}
+        message={bulkNoticeMessage}
       />
     </>
   );

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
@@ -171,12 +171,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
   } | null>(null);
 
   const handleOpenInviteDialog = useCallback(
-    (
-      enrollmentIds: number[],
-      selectedCount: number | undefined,
-      identifiedCount: number,
-      actionType: 'selected' | 'all'
-    ) => {
+    (enrollmentIds: number[], selectedCount: number | undefined, actionType: 'selected' | 'all') => {
       const idToRow = new Map(courseEnrollments.map((e) => [e.id, e]));
       const enrollmentsToSend = enrollmentIds
         .map((id) => idToRow.get(id))
@@ -280,12 +275,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
   } | null>(null);
 
   const handleOpenRejectionDialog = useCallback(
-    (
-      enrollmentIds: number[],
-      selectedCount: number | undefined,
-      identifiedCount: number,
-      actionType: 'selected' | 'all'
-    ) => {
+    (enrollmentIds: number[], selectedCount: number | undefined, actionType: 'selected' | 'all') => {
       const idToRow = new Map(courseEnrollments.map((e) => [e.id, e]));
       const enrollmentsToSend = enrollmentIds
         .map((id) => idToRow.get(id))
@@ -446,12 +436,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
           showBulkNotice(t('bulk_actions.no_eligible_invitations'));
           return;
         }
-        handleOpenInviteDialog(
-          enrollmentsToSend.map((e) => e.id),
-          selectedRows.length,
-          enrollmentsToSend.length,
-          'selected'
-        );
+        handleOpenInviteDialog(enrollmentsToSend.map((e) => e.id), selectedRows.length, 'selected');
         return;
       } else if (action === 'send_invitations_all') {
         const enrollmentsToSend = courseEnrollments.filter(
@@ -461,12 +446,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
           showBulkNotice(t('bulk_actions.no_eligible_invitations'));
           return;
         }
-        handleOpenInviteDialog(
-          enrollmentsToSend.map((e) => e.id),
-          undefined,
-          enrollmentsToSend.length,
-          'all'
-        );
+        handleOpenInviteDialog(enrollmentsToSend.map((e) => e.id), undefined, 'all');
         return;
       }
 
@@ -483,12 +463,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
           showBulkNotice(t('bulk_actions.no_eligible_rejections'));
           return;
         }
-        handleOpenRejectionDialog(
-          enrollmentsToSend.map((e) => e.id),
-          selectedRows.length,
-          enrollmentsToSend.length,
-          'selected'
-        );
+        handleOpenRejectionDialog(enrollmentsToSend.map((e) => e.id), selectedRows.length, 'selected');
         return;
       } else if (action === 'send_rejections_all') {
         const enrollmentsToSend = courseEnrollments.filter(
@@ -498,12 +473,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
           showBulkNotice(t('bulk_actions.no_eligible_rejections'));
           return;
         }
-        handleOpenRejectionDialog(
-          enrollmentsToSend.map((e) => e.id),
-          undefined,
-          enrollmentsToSend.length,
-          'all'
-        );
+        handleOpenRejectionDialog(enrollmentsToSend.map((e) => e.id), undefined, 'all');
         return;
       }
 

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
@@ -126,8 +126,10 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
 
   const [bulkNoticeOpen, setBulkNoticeOpen] = useState(false);
   const [bulkNoticeMessage, setBulkNoticeMessage] = useState('');
-  const showBulkNotice = useCallback((message: string) => {
+  const [bulkNoticeDurationMs, setBulkNoticeDurationMs] = useState(2000);
+  const showBulkNotice = useCallback((message: string, durationMs = 2000) => {
     setBulkNoticeMessage(message);
+    setBulkNoticeDurationMs(durationMs);
     setBulkNoticeOpen(true);
   }, []);
   const handleCloseBulkNotice = useCallback(() => {
@@ -231,12 +233,19 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
           expire: inviteExpireDate,
         },
       });
-      if ((result.data?.update_CourseEnrollment?.affected_rows ?? 0) === 0) {
+      const invitedCount = result.data?.update_CourseEnrollment?.affected_rows ?? 0;
+      if (invitedCount === 0) {
         showBulkNotice(t('bulk_actions.no_eligible_invitations'));
         await qResult.refetch();
         handleCloseInviteDialog();
         return;
       }
+      showBulkNotice(
+        invitedCount === 1
+          ? t('bulk_actions.invitations_sent_singular', { count: invitedCount })
+          : t('bulk_actions.invitations_sent_plural', { count: invitedCount }),
+        4000
+      );
       await qResult.refetch();
       handleCloseInviteDialog();
     } catch (error) {
@@ -332,12 +341,19 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
           expire: null,
         },
       });
-      if ((result.data?.update_CourseEnrollment?.affected_rows ?? 0) === 0) {
+      const declinedCount = result.data?.update_CourseEnrollment?.affected_rows ?? 0;
+      if (declinedCount === 0) {
         showBulkNotice(t('bulk_actions.no_eligible_rejections'));
         await qResult.refetch();
         handleCloseRejectionDialog();
         return;
       }
+      showBulkNotice(
+        declinedCount === 1
+          ? t('bulk_actions.declines_sent_singular', { count: declinedCount })
+          : t('bulk_actions.declines_sent_plural', { count: declinedCount }),
+        4000
+      );
       await qResult.refetch();
       handleCloseRejectionDialog();
     } catch (error) {
@@ -1207,6 +1223,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         open={bulkNoticeOpen}
         onClose={handleCloseBulkNotice}
         message={bulkNoticeMessage}
+        duration={bulkNoticeDurationMs}
       />
     </>
   );

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
@@ -316,7 +316,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
           return;
         }
         const enrollmentsToSend = selectedRows.filter(
-          (e) => e.motivationRating === 'INVITE' && ['APPLIED', 'INVITED', 'REJECTED'].includes(e.status)
+          (e) => e.motivationRating === 'INVITE' && e.status === 'APPLIED'
         );
         if (enrollmentsToSend.length > 0) {
           handleOpenInviteDialog(enrollmentsToSend, selectedRows.length, enrollmentsToSend.length, 'selected');
@@ -324,7 +324,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         return;
       } else if (action === 'send_invitations_all') {
         const enrollmentsToSend = courseEnrollments.filter(
-          (e) => e.motivationRating === 'INVITE' && ['APPLIED', 'INVITED', 'REJECTED'].includes(e.status)
+          (e) => e.motivationRating === 'INVITE' && e.status === 'APPLIED'
         );
         if (enrollmentsToSend.length > 0) {
           handleOpenInviteDialog(enrollmentsToSend, undefined, enrollmentsToSend.length, 'all');
@@ -339,7 +339,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
           return;
         }
         const enrollmentsToSend = selectedRows.filter(
-          (e) => e.motivationRating === 'DECLINE' && ['APPLIED', 'INVITED', 'REJECTED'].includes(e.status)
+          (e) => e.motivationRating === 'DECLINE' && e.status === 'APPLIED'
         );
         if (enrollmentsToSend.length > 0) {
           handleOpenRejectionDialog(enrollmentsToSend, selectedRows.length, enrollmentsToSend.length, 'selected');
@@ -347,7 +347,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         return;
       } else if (action === 'send_rejections_all') {
         const enrollmentsToSend = courseEnrollments.filter(
-          (e) => e.motivationRating === 'DECLINE' && ['APPLIED', 'INVITED', 'REJECTED'].includes(e.status)
+          (e) => e.motivationRating === 'DECLINE' && e.status === 'APPLIED'
         );
         if (enrollmentsToSend.length > 0) {
           handleOpenRejectionDialog(enrollmentsToSend, undefined, enrollmentsToSend.length, 'all');

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1075,6 +1075,8 @@
       "send_rejections_confirm": "Ablehnungen senden",
       "send_invitations_error": "Fehler beim Senden der Einladungen: {error}",
       "send_rejections_error": "Fehler beim Senden der Ablehnungen: {error}",
+      "no_eligible_invitations": "Gerade gibt es niemanden mit grüner Bewertung und Status „beworben“, den du einladen könntest.",
+      "no_eligible_rejections": "Gerade gibt es niemanden mit roter Bewertung und Status „beworben“, dem du eine Ablehnung schicken könntest.",
       "no_selection_dialog_title": "Keine Auswahl"
     },
     "statistics_applications_total": "Bewerbungen gesamt",

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1077,6 +1077,10 @@
       "send_rejections_error": "Fehler beim Senden der Ablehnungen: {error}",
       "no_eligible_invitations": "Gerade gibt es niemanden mit grüner Bewertung und Status „beworben“, den du einladen könntest.",
       "no_eligible_rejections": "Gerade gibt es niemanden mit roter Bewertung und Status „beworben“, dem du eine Ablehnung schicken könntest.",
+      "invitations_sent_singular": "{count} Einladung wurde verschickt.",
+      "invitations_sent_plural": "{count} Einladungen wurden verschickt.",
+      "declines_sent_singular": "{count} Ablehnung wurde verschickt.",
+      "declines_sent_plural": "{count} Ablehnungen wurden verschickt.",
       "no_selection_dialog_title": "Keine Auswahl"
     },
     "statistics_applications_total": "Bewerbungen gesamt",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1093,6 +1093,8 @@
       "send_rejections_confirm": "Send Rejections",
       "send_invitations_error": "Failed to send invitations: {error}",
       "send_rejections_error": "Failed to send rejections: {error}",
+      "no_eligible_invitations": "No applicants are eligible for an invitation right now (green rating and applied status only).",
+      "no_eligible_rejections": "No applicants are eligible for a decline email right now (red rating and applied status only).",
       "no_selection_dialog_title": "No Selection"
     },
     "statistics_applications_total": "Total Applications",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1095,6 +1095,10 @@
       "send_rejections_error": "Failed to send rejections: {error}",
       "no_eligible_invitations": "No applicants are eligible for an invitation right now (green rating and applied status only).",
       "no_eligible_rejections": "No applicants are eligible for a decline email right now (red rating and applied status only).",
+      "invitations_sent_singular": "{count} invitation was sent.",
+      "invitations_sent_plural": "{count} invitations were sent.",
+      "declines_sent_singular": "{count} decline was sent.",
+      "declines_sent_plural": "{count} declines were sent.",
       "no_selection_dialog_title": "No Selection"
     },
     "statistics_applications_total": "Total Applications",

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateEnrollmentStatusWhenApplied.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateEnrollmentStatusWhenApplied.ts
@@ -1,0 +1,31 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// Manually aligned with UPDATE_ENROLLMENT_STATUS_WHEN_APPLIED; run yarn apollo when Hasura is available.
+
+import { CourseEnrollmentStatus_enum } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: UpdateEnrollmentStatusWhenApplied
+// ====================================================
+
+export interface UpdateEnrollmentStatusWhenApplied_update_CourseEnrollment_returning {
+  __typename: "CourseEnrollment";
+  id: number;
+}
+
+export interface UpdateEnrollmentStatusWhenApplied_update_CourseEnrollment {
+  __typename: "CourseEnrollment_mutation_response";
+  affected_rows: number;
+  returning: UpdateEnrollmentStatusWhenApplied_update_CourseEnrollment_returning[];
+}
+
+export interface UpdateEnrollmentStatusWhenApplied {
+  update_CourseEnrollment: UpdateEnrollmentStatusWhenApplied_update_CourseEnrollment | null;
+}
+
+export interface UpdateEnrollmentStatusWhenAppliedVariables {
+  enrollmentIds: number[];
+  status: CourseEnrollmentStatus_enum;
+  expire?: any | null;
+}

--- a/frontend-nx/apps/edu-hub/queries/insertEnrollment.ts
+++ b/frontend-nx/apps/edu-hub/queries/insertEnrollment.ts
@@ -100,3 +100,27 @@ export const UPDATE_ENROLLMENT_STATUS = gql`
     }
   }
 `;
+
+/** Bulk status change only for rows still in APPLIED (avoids duplicate invite/decline emails on race). */
+export const UPDATE_ENROLLMENT_STATUS_WHEN_APPLIED = gql`
+  mutation UpdateEnrollmentStatusWhenApplied(
+    $enrollmentIds: [Int!]!
+    $status: CourseEnrollmentStatus_enum!
+    $expire: date
+  ) {
+    update_CourseEnrollment(
+      where: {
+        _and: [
+          { id: { _in: $enrollmentIds } }
+          { status: { _eq: APPLIED } }
+        ]
+      }
+      _set: { status: $status, invitationExpirationDate: $expire }
+    ) {
+      affected_rows
+      returning {
+        id
+      }
+    }
+  }
+`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bulk actions **Send invitations** (green rating) and **Send declines** (red rating) on the manage course Applications tab previously included enrollments with status `INVITED` or `REJECTED` in addition to `APPLIED`.

The `sendEnrollmentEmail` serverless function runs on `CourseEnrollment` status updates and sends **INVITE** / **DECLINE** template emails when status is set to `INVITED` or `REJECTED`. Re-running the bulk action for rows already in those states would queue duplicate invitation or decline emails.

## Changes

### Initial fix
- Restrict bulk invite and bulk decline targets to enrollments with `status === 'APPLIED'` (still filtered by `motivationRating` INVITE / DECLINE).

### Follow-up (code review)
- **Gating**: Bulk invite/decline actions only appear when there is at least one enrollment with green/red rating **and** `APPLIED` status (not merely green/red rating).
- **No silent no-op**: If the user runs an action with no eligible rows (e.g. all selected are already invited), show a **NotificationSnackbar** with a translated message instead of doing nothing.
- **Re-check before dialog and mutate**: `handleOpenInviteDialog` / `handleOpenRejectionDialog` take enrollment ids and re-resolve rows from current `courseEnrollments` so stale selection uses fresh eligibility. Confirm handlers re-filter ids again before calling the mutation.
- **Server guard**: New GraphQL mutation `UpdateEnrollmentStatusWhenApplied` uses `update_CourseEnrollment` with `where: { id: { _in: $ids }, status: { _eq: APPLIED } }` so concurrent updates cannot move a row out of `APPLIED` and still get a duplicate email from this bulk path.
- **Success feedback**: After a successful bulk invite or decline, the snackbar shows how many rows were updated (`affected_rows`), with singular/plural strings; success toasts use a 4s duration.

## Locales

- `manageCourse.bulk_actions.no_eligible_invitations`
- `manageCourse.bulk_actions.no_eligible_rejections`
- `manageCourse.bulk_actions.invitations_sent_singular` / `invitations_sent_plural`
- `manageCourse.bulk_actions.declines_sent_singular` / `declines_sent_plural`

(English + German Du form)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48d86512-55e2-41d9-b95a-439f3c06ecee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48d86512-55e2-41d9-b95a-439f3c06ecee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened bulk invitation/rejection eligibility so only applicants with the correct rating and current "applied" status are targeted.

* **New Features**
  * Added race-safe batch enrollment updates with early feedback when no rows are affected.
  * Bulk dialogs open only when eligible targets exist; confirmations show count-aware success notices.

* **Localization**
  * Added English and German messages for "no eligible" notices and singular/plural success messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->