### PR TITLE
fix: applications tab dialog button contrast on light modal

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
@@ -922,12 +922,18 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         )}
       </div>
 
-      {/* Invitation Dialog */}
-      <Dialog open={isInviteDialogOpen} onClose={handleCloseInviteDialog} maxWidth="sm" fullWidth>
+      {/* Invitation Dialog — Paper uses .light so semantic button/text colors match white surface */}
+      <Dialog
+        open={isInviteDialogOpen}
+        onClose={handleCloseInviteDialog}
+        maxWidth="sm"
+        fullWidth
+        PaperProps={{ className: 'light' }}
+      >
         <DialogTitle>
           <div className="flex justify-between items-center">
-            <div className="text-xl font-semibold">{t('bulk_actions.send_invitations_dialog_title')}</div>
-            <div className="cursor-pointer" onClick={handleCloseInviteDialog}>
+            <div className="text-xl font-semibold text-label-primary">{t('bulk_actions.send_invitations_dialog_title')}</div>
+            <div className="cursor-pointer text-label-primary" onClick={handleCloseInviteDialog}>
               <MdClose className="w-6 h-6" />
             </div>
           </div>
@@ -936,7 +942,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
           {inviteDialogData && (
             <>
               <div className="mb-6">
-                <p className="text-gray-700 mb-4">
+                <p className="text-label-primary mb-4">
                   {inviteDialogData.actionType === 'selected' ? (
                     inviteDialogData.selectedCount !== undefined && inviteDialogData.selectedCount > 0 ? (
                       inviteDialogData.identifiedCount === 1
@@ -952,7 +958,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
                   )}
                 </p>
                 <div className="flex flex-col gap-4">
-                  <label className="text-sm font-medium text-gray-700">
+                  <label className="text-sm font-medium text-label-primary">
                     {t('invitation_deadline')}
                   </label>
                   <DatePicker
@@ -961,7 +967,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
                     onChange={handleSetInviteExpireDate}
                     minDate={new Date()}
                     locale={locale}
-                    className="w-full p-2 border border-gray-300 rounded"
+                    className="w-full p-2 rounded border border-border-primary bg-fill-primary text-label-primary"
                   />
                 </div>
               </div>
@@ -979,11 +985,17 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
       </Dialog>
 
       {/* Rejection Dialog */}
-      <Dialog open={isRejectionDialogOpen} onClose={handleCloseRejectionDialog} maxWidth="sm" fullWidth>
+      <Dialog
+        open={isRejectionDialogOpen}
+        onClose={handleCloseRejectionDialog}
+        maxWidth="sm"
+        fullWidth
+        PaperProps={{ className: 'light' }}
+      >
         <DialogTitle>
           <div className="flex justify-between items-center">
-            <div className="text-xl font-semibold">{t('bulk_actions.send_rejections_dialog_title')}</div>
-            <div className="cursor-pointer" onClick={handleCloseRejectionDialog}>
+            <div className="text-xl font-semibold text-label-primary">{t('bulk_actions.send_rejections_dialog_title')}</div>
+            <div className="cursor-pointer text-label-primary" onClick={handleCloseRejectionDialog}>
               <MdClose className="w-6 h-6" />
             </div>
           </div>
@@ -992,7 +1004,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
           {rejectionDialogData && (
             <>
               <div className="mb-6">
-                <p className="text-gray-700">
+                <p className="text-label-primary">
                   {rejectionDialogData.actionType === 'selected' ? (
                     rejectionDialogData.selectedCount !== undefined && rejectionDialogData.selectedCount > 0 ? (
                       rejectionDialogData.identifiedCount === 1
@@ -1022,18 +1034,24 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
       </Dialog>
 
       {/* No Selection Dialog */}
-      <Dialog open={isNoSelectionDialogOpen} onClose={handleCloseNoSelectionDialog} maxWidth="sm" fullWidth>
+      <Dialog
+        open={isNoSelectionDialogOpen}
+        onClose={handleCloseNoSelectionDialog}
+        maxWidth="sm"
+        fullWidth
+        PaperProps={{ className: 'light' }}
+      >
         <DialogTitle>
           <div className="flex justify-between items-center">
-            <div className="text-xl font-semibold">{t('bulk_actions.no_selection_dialog_title')}</div>
-            <div className="cursor-pointer" onClick={handleCloseNoSelectionDialog}>
+            <div className="text-xl font-semibold text-label-primary">{t('bulk_actions.no_selection_dialog_title')}</div>
+            <div className="cursor-pointer text-label-primary" onClick={handleCloseNoSelectionDialog}>
               <MdClose className="w-6 h-6" />
             </div>
           </div>
         </DialogTitle>
         <div className="px-6 pb-6">
           <div className="mb-6">
-            <p className="text-gray-700">{t('select_applicants_first')}</p>
+            <p className="text-label-primary">{t('select_applicants_first')}</p>
           </div>
           <div className="flex justify-end gap-3">
             <OldButton onClick={handleCloseNoSelectionDialog} filled>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bulk action dialogs on the Manage Course **Applications** tab (send invitations, send rejections, no selection) use a white MUI `Dialog` surface while the shared `Button` component styles itself with semantic Tailwind classes (`text-label-primary`, `bg-label-primary`, etc.) that resolve against the **global `:root`** dark-theme CSS variables. That produced very low contrast: light grey label text on white for the outline/cancel button, and a washed-out primary action.

## Change

- Set `PaperProps={{ className: 'light' }}` on those three dialogs so semantic colors follow the [theme rule](https://github.com/eduhub-org/eduhub/blob/develop/frontend-nx/apps/edu-hub/.cursor/rules/theme-and-styling.mdc) for light surfaces (inverted `--eduhub-label-*` / `--eduhub-fill-*` under `.light`).
- Align dialog copy, titles, close icons, and the invitation date field with `text-label-primary` / `border-border-primary` / `bg-fill-primary` under the same scope.

## Testing

- `npx eslint apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8644b709-7a29-41d1-8301-f28c7067b921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8644b709-7a29-41d1-8301-f28c7067b921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dialog components and form inputs with improved theme-based styling for enhanced visual consistency
  * Standardized text colors and borders across the application using semantic design tokens
  * Refined appearance of interactive elements for better visual coherence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->