### PR TITLE
fix: prevent unpublished content from appearing on landing page

### DIFF
--- a/frontend-nx/apps/edu-hub/pages/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/index.tsx
@@ -15,6 +15,7 @@ import NotificationSnackbar from '../components/common/dialogs/NotificationSnack
 import { useAuthedQuery, useInstructorQuery } from '../hooks/authedQuery';
 import { useIsLoggedIn, useIsInstructor, useIsAdmin } from '../hooks/authentication';
 import { useUserId } from '../hooks/user';
+import { AuthRoles } from '../types/enums';
 
 import { COURSE_GROUP_OPTIONS } from '../queries/courseGroupOptions';
 import { COURSE_TILES, COURSES_BY_INSTRUCTOR, COURSES_ENROLLED_BY_USER } from '../queries/courseQueries';
@@ -71,7 +72,9 @@ const Home: FC = () => {
     }
   );
 
-  const { data: coursesData, loading: coursesLoading } = useQuery<CourseTiles>(COURSE_TILES);
+  const { data: coursesData, loading: coursesLoading } = useQuery<CourseTiles>(COURSE_TILES, {
+    context: { role: AuthRoles.anonymous },
+  });
 
   const { data: courseGroupOptionsData } = useAuthedQuery<CourseGroupOptions>(COURSE_GROUP_OPTIONS);
 
@@ -81,7 +84,10 @@ const Home: FC = () => {
 
   const myAdminCourses = useMemo(() => adminCoursesData?.Course ?? [], [adminCoursesData]);
   const myCourses = useMemo(() => enrolledCoursesData?.Course ?? [], [enrolledCoursesData]);
-  const publishedCourses = useMemo(() => coursesData?.Course ?? [], [coursesData]);
+  const publishedCourses = useMemo(
+    () => (coursesData?.Course ?? []).filter((course) => course.published && course.Program.published),
+    [coursesData]
+  );
 
   const coursesGroupsAuthenticated = useMemo(
     () => [

--- a/frontend-nx/apps/edu-hub/queries/courseQueries.ts
+++ b/frontend-nx/apps/edu-hub/queries/courseQueries.ts
@@ -4,7 +4,10 @@ import { COURSE_TILE_FRAGMENT } from "./courseFragements";
 export const COURSE_TILES = gql`
   ${COURSE_TILE_FRAGMENT}
   query CourseTiles {
-    Course(order_by: { updated_at: desc }) {
+    Course(
+      order_by: { updated_at: desc }
+      where: { published: { _eq: true }, Program: { published: { _eq: true } } }
+    ) {
       ...CourseTileFragment
       CourseGroups {
         CourseGroupOption {
@@ -22,6 +25,8 @@ export const COURSE_TILES_BY_ORGANIZATION = gql`
     Course(
       order_by: { updated_at: desc }
       where: {
+        published: { _eq: true }
+        Program: { published: { _eq: true } }
         CourseFundingOrganizations: {
           organizationId: { _eq: $organizationId }
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- constrain landing-page tile queries so only courses with `Course.published = true` and `Program.published = true` are returned
- fetch landing-page tiles using anonymous role context to avoid role/cache-dependent visibility drift in authenticated sessions
- add a defensive UI filter before grouping/rendering tiles

## Root cause
Landing page fetched `COURSE_TILES` without publish constraints, so depending on role/session/cache state (more likely to surface as intermittent browser-specific behavior), unpublished courses or courses in unpublished programs could be present in the dataset and rendered.

## Validation
- `yarn lint` passes (only pre-existing warnings)
- `yarn build` succeeds
- manual browser verification at `http://localhost:5000` confirmed forbidden sample unpublished titles do not appear
- direct GraphQL checks show unpublished data exists globally but is excluded by the landing filter

### Walkthrough artifacts
[landing_page_published_content_filter_verification.mp4](https://cursor.com/agents/bc-a9966c83-f781-4593-a852-25887c1f716a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page_published_content_filter_verification.mp4)
[Landing page top sections](https://cursor.com/agents/bc-a9966c83-f781-4593-a852-25887c1f716a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page_tiles_top_sections.webp)
[Landing page mid sections](https://cursor.com/agents/bc-a9966c83-f781-4593-a852-25887c1f716a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Flanding_page_tiles_mid_sections.webp)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a9966c83-f781-4593-a852-25887c1f716a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9966c83-f781-4593-a852-25887c1f716a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Refined course filtering to display only published courses from published programs, improving content visibility consistency across all course browsing views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->