### PR TITLE
fix: Fresh GCS signed URLs for documentation and certificate downloads

### DIFF
--- a/frontend-nx/apps/edu-hub/components/common/CertificateDownload.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/CertificateDownload.tsx
@@ -4,7 +4,7 @@ import { Dispatch, SetStateAction } from 'react';
 import { useEffect } from 'react';
 import { useRoleQuery } from '../../hooks/authedQuery';
 import { CourseWithEnrollment_Course_by_pk_CourseEnrollments } from '../../queries/__generated__/CourseWithEnrollment';
-import { GET_SIGNED_URL } from '../../queries/actions';
+import { GET_SIGNED_URL, GET_SIGNED_URL_QUERY_OPTIONS } from '../../queries/actions';
 import { GetSignedUrl, GetSignedUrlVariables } from '../../queries/__generated__/GetSignedUrl';
 import { Button } from './Button';
 import { ExtendedDegreeParticipantsEnrollment } from '../pages/ManageCourseContent/DegreeParticipationsTab';
@@ -36,6 +36,7 @@ export const CertificateDownload: FC<IProps> = ({
     GetSignedUrl,
     GetSignedUrlVariables
   >(GET_SIGNED_URL, {
+    ...GET_SIGNED_URL_QUERY_OPTIONS,
     variables: {
       path: courseEnrollment?.achievementCertificateURL ?? '',
     },
@@ -53,6 +54,7 @@ export const CertificateDownload: FC<IProps> = ({
     GetSignedUrl,
     GetSignedUrlVariables
   >(GET_SIGNED_URL, {
+    ...GET_SIGNED_URL_QUERY_OPTIONS,
     variables: {
       path: courseEnrollment?.attendanceCertificateURL ?? '',
     },

--- a/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
@@ -4,7 +4,11 @@ import { GetApp } from '@mui/icons-material';
 import { TileBase } from './TileSlider/TileBase';
 import { useRoleQuery } from '../../hooks/authedQuery';
 import { useRoleMutation } from '../../hooks/authedMutation';
-import { GET_SIGNED_URL, MAKE_CERTIFICATE_PUBLIC } from '../../queries/actions';
+import {
+  GET_SIGNED_URL,
+  GET_SIGNED_URL_QUERY_OPTIONS,
+  MAKE_CERTIFICATE_PUBLIC,
+} from '../../queries/actions';
 import { GetSignedUrl, GetSignedUrlVariables } from '../../queries/__generated__/GetSignedUrl';
 import { MakeCertificatePublic, MakeCertificatePublicVariables } from '../../queries/__generated__/MakeCertificatePublic';
 import { Button } from './Button';
@@ -29,6 +33,7 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
     GetSignedUrl,
     GetSignedUrlVariables
   >(GET_SIGNED_URL, {
+    ...GET_SIGNED_URL_QUERY_OPTIONS,
     variables: {
       path: enrollment.achievementCertificateURL || '',
     },
@@ -40,6 +45,7 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
     GetSignedUrl,
     GetSignedUrlVariables
   >(GET_SIGNED_URL, {
+    ...GET_SIGNED_URL_QUERY_OPTIONS,
     variables: {
       path: enrollment.attendanceCertificateURL || '',
     },

--- a/frontend-nx/apps/edu-hub/components/inputs/FileUploadField/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/inputs/FileUploadField/index.tsx
@@ -5,7 +5,7 @@ import { CircularProgress, IconButton, Tooltip, LinearProgress } from '@mui/mate
 import { useAdminMutation } from '../../../hooks/authedMutation';
 import { useLazyRoleQuery } from '../../../hooks/authedQuery';
 import { getPublicImageUrl, parseFileUploadEvent, getPublicUrl, UploadFile } from '../../../helpers/filehandling';
-import { GET_SIGNED_URL } from '../../../queries/actions';
+import { GET_SIGNED_URL, GET_SIGNED_URL_QUERY_OPTIONS } from '../../../queries/actions';
 import { GetSignedUrl, GetSignedUrlVariables } from '../../../queries/__generated__/GetSignedUrl';
 import {
   detectFileType,
@@ -50,7 +50,7 @@ export const FileUploadField: FC<FileUploadFieldProps> = ({
   const dragCounterRef = useRef(0);
 
   const [getFileSignedUrl, { data: signedUrlData }] =
-    useLazyRoleQuery<GetSignedUrl, GetSignedUrlVariables>(GET_SIGNED_URL);
+    useLazyRoleQuery<GetSignedUrl, GetSignedUrlVariables>(GET_SIGNED_URL, GET_SIGNED_URL_QUERY_OPTIONS);
 
   // Always auto-detect file type from URL
   // This ensures the component always shows the correct icon/preview for the actual file
@@ -61,7 +61,10 @@ export const FileUploadField: FC<FileUploadFieldProps> = ({
   const needsSignedUrlForDisplay = detectedType === 'image' && !!isPrivateFile;
   useEffect(() => {
     if (needsSignedUrlForDisplay && currentFileUrl) {
-      getFileSignedUrl({ variables: { path: currentFileUrl } });
+      getFileSignedUrl({
+        variables: { path: currentFileUrl },
+        ...GET_SIGNED_URL_QUERY_OPTIONS,
+      });
     }
   }, [currentFileUrl, needsSignedUrlForDisplay, getFileSignedUrl]);
 
@@ -355,7 +358,10 @@ export const FileUploadField: FC<FileUploadFieldProps> = ({
 
     // For private files (e.g. certificate templates), fetch authenticated signed URL
     try {
-      const result = await getFileSignedUrl({ variables: { path: currentFileUrl } });
+      const result = await getFileSignedUrl({
+        variables: { path: currentFileUrl },
+        ...GET_SIGNED_URL_QUERY_OPTIONS,
+      });
       const signedUrl = result.data?.getSignedUrl?.link;
       if (signedUrl) {
         window.open(signedUrl, '_blank');

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
@@ -13,7 +13,11 @@ import {
   REMOVE_ACHIEVEMENT_CERTIFICATES,
   REMOVE_ATTENDANCE_CERTIFICATES,
 } from '../../../../queries/courseEnrollment';
-import { CREATE_CERTIFICATES, GET_SIGNED_URL } from '../../../../queries/actions';
+import {
+  CREATE_CERTIFICATES,
+  GET_SIGNED_URL,
+  GET_SIGNED_URL_QUERY_OPTIONS,
+} from '../../../../queries/actions';
 import { COURSE_PARTICIPATIONS } from '../../../../queries/courseParticipation';
 import {
   CourseParticipations_Course_by_pk_AchievementOptionCourses,
@@ -830,7 +834,10 @@ function ExpandableRowContent({
   locale: string;
 }) {
   const [downloadError, setDownloadError] = useState<string | null>(null);
-  const [getDoc, docResult] = useLazyRoleQuery<GetSignedUrl, GetSignedUrlVariables>(GET_SIGNED_URL);
+  const [getDoc, docResult] = useLazyRoleQuery<GetSignedUrl, GetSignedUrlVariables>(
+    GET_SIGNED_URL,
+    GET_SIGNED_URL_QUERY_OPTIONS
+  );
   const [setAchievementRecord] = useRoleMutation<
     UpdateAchievementRecordByPk,
     UpdateAchievementRecordByPkVariables
@@ -848,7 +855,10 @@ function ExpandableRowContent({
 
       setDownloadError(null);
       try {
-        const result = await getDoc({ variables: { path: docPath } });
+        const result = await getDoc({
+          variables: { path: docPath },
+          ...GET_SIGNED_URL_QUERY_OPTIONS,
+        });
         const signedUrl = result.data?.getSignedUrl?.link;
         if (signedUrl) {
           window.open(signedUrl, '_blank', 'noopener,noreferrer');

--- a/frontend-nx/apps/edu-hub/hooks/signedUrl.ts
+++ b/frontend-nx/apps/edu-hub/hooks/signedUrl.ts
@@ -1,12 +1,13 @@
 import { useLazyRoleQuery } from "./authedQuery";
 import { GetSignedUrl, GetSignedUrlVariables } from "../queries/__generated__/GetSignedUrl";
-import { GET_SIGNED_URL } from "../queries/actions";
+import { GET_SIGNED_URL, GET_SIGNED_URL_QUERY_OPTIONS } from "../queries/actions";
 import { useCallback, useState } from 'react';
 import { getPublicUrl } from "../helpers/filehandling";
 
 export const useSignedUrl = (filePath: string): { getSignedUrl: () => Promise<{ url: string | null }>; loading: boolean; error: any; } => {
-  const [getFileSignedUrl, { data, loading }] = useLazyRoleQuery<GetSignedUrl, GetSignedUrlVariables>(GET_SIGNED_URL, {
+  const [getFileSignedUrl, { loading }] = useLazyRoleQuery<GetSignedUrl, GetSignedUrlVariables>(GET_SIGNED_URL, {
     variables: { path: filePath },
+    ...GET_SIGNED_URL_QUERY_OPTIONS,
   });
   const [error, setError] = useState<unknown>(null);
 
@@ -19,20 +20,22 @@ export const useSignedUrl = (filePath: string): { getSignedUrl: () => Promise<{ 
       return { url: publicUrl };
     }
     try {
-      await getFileSignedUrl();
-      if (data?.getSignedUrl?.link) {
-        console.log(`Returning signed file URL: ${data.getSignedUrl.link}`); // Debugging log
-        return { url: data.getSignedUrl.link };
-      } else {
-        throw new Error('Signed URL not found in the response');
+      const result = await getFileSignedUrl({
+        variables: { path: filePath },
+        ...GET_SIGNED_URL_QUERY_OPTIONS,
+      });
+      const link = result.data?.getSignedUrl?.link;
+      if (link) {
+        return { url: link };
       }
+      throw new Error('Signed URL not found in the response');
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`Error in getSignedUrl: ${message}`, err);
       setError(err);
       return { url: null };
     }
-  }, [getFileSignedUrl, data, publicUrl]);
+  }, [getFileSignedUrl, filePath, publicUrl]);
 
   return { getSignedUrl, loading, error };
 };

--- a/frontend-nx/apps/edu-hub/queries/actions.ts
+++ b/frontend-nx/apps/edu-hub/queries/actions.ts
@@ -124,6 +124,11 @@ export const GET_SIGNED_URL = gql`
   }
 `;
 
+/** GCS signed URLs expire; Apollo must not return cached links after they are invalid. */
+export const GET_SIGNED_URL_QUERY_OPTIONS = {
+  fetchPolicy: 'network-only' as const,
+};
+
 export const MAKE_CERTIFICATE_PUBLIC = gql`
   mutation MakeCertificatePublic($certificatePath: String!) {
     makeCertificatePublic(certificatePath: $certificatePath) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Google Cloud Storage signed URLs expire after a short time. The participations tab (and other flows) used Apollo Client with the default **cache-first** policy for `getSignedUrl`. After the page stayed open, Apollo returned the **cached** signed URL instead of requesting a new one from the backend, so opening the link showed GCS XML with `ExpiredToken` / "The provided token has expired."

## Solution

- Export shared options `GET_SIGNED_URL_QUERY_OPTIONS` with `fetchPolicy: 'network-only'` next to `GET_SIGNED_URL` in `queries/actions.ts`.
- Apply these options everywhere `GET_SIGNED_URL` is used (participations documentation download, certificate components, `FileUploadField`, `useSignedUrl`).
- Fix `useSignedUrl` to read the signed URL from the **promise result** of `getFileSignedUrl()` instead of stale `data` from the hook closure (correct behavior after any network fetch).

No backend changes; each download click now triggers a fresh signed URL from the API.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-02a81c49-9f80-408f-8915-02e8148e31c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02a81c49-9f80-408f-8915-02e8148e31c0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

