### PR TITLE
fix: prevent expired signed URL downloads by bypassing Apollo cache

### DIFF
--- a/frontend-nx/apps/edu-hub/components/common/CertificateDownload.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/CertificateDownload.tsx
@@ -40,6 +40,7 @@ export const CertificateDownload: FC<IProps> = ({
       path: courseEnrollment?.achievementCertificateURL ?? '',
     },
     skip: !courseEnrollment?.achievementCertificateURL,
+    fetchPolicy: 'network-only',
     onError: () => handleQueryError(t('errorMessages.loadAchievementCertificateError')),
     onCompleted: (data) => {
       console.log('Achievement Certificate Query Completed:', {
@@ -57,6 +58,7 @@ export const CertificateDownload: FC<IProps> = ({
       path: courseEnrollment?.attendanceCertificateURL ?? '',
     },
     skip: !courseEnrollment?.attendanceCertificateURL,
+    fetchPolicy: 'network-only',
     onError: () => handleQueryError(t('errorMessages.loadAttendanceCertificateError')),
     onCompleted: (data) => {
       console.log('Attendance Certificate Query Completed:', {

--- a/frontend-nx/apps/edu-hub/components/common/CertificateDownload.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/CertificateDownload.tsx
@@ -1,116 +1,120 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import { useTranslations } from 'next-intl';
-import { Dispatch, SetStateAction } from 'react';
-import { useEffect } from 'react';
-import { useRoleQuery } from '../../hooks/authedQuery';
+import { useLazyRoleQuery } from '../../hooks/authedQuery';
 import { CourseWithEnrollment_Course_by_pk_CourseEnrollments } from '../../queries/__generated__/CourseWithEnrollment';
 import { GET_SIGNED_URL } from '../../queries/actions';
 import { GetSignedUrl, GetSignedUrlVariables } from '../../queries/__generated__/GetSignedUrl';
 import { Button } from './Button';
 import { ExtendedDegreeParticipantsEnrollment } from '../pages/ManageCourseContent/DegreeParticipationsTab';
 import { ErrorMessageDialog } from '../../components/common/dialogs/ErrorMessageDialog';
+import { CircularProgress } from '@mui/material';
 
 interface IProps {
   courseEnrollment: CourseWithEnrollment_Course_by_pk_CourseEnrollments | ExtendedDegreeParticipantsEnrollment;
   manageView?: boolean;
-  refetchAchievementCertificates?: boolean;
-  refetchAttendanceCertificates?: boolean;
-  setRefetchAchievementCertificates?: Dispatch<SetStateAction<boolean>>;
-  setRefetchAttendanceCertificates?: Dispatch<SetStateAction<boolean>>;
 }
 
 export const CertificateDownload: FC<IProps> = ({
   courseEnrollment,
   manageView,
 }) => {
-
   const t = useTranslations();
+  const tCert = useTranslations('certificates');
   const [errorMessage, setErrorMessage] = useState('');
 
-  const handleQueryError = (error: string) => {
-    console.error('Certificate Query Error:', error);
-    setErrorMessage(error);
-  };
-
-  const { data: loadAchievementCertificateData, loading: loadAchievementCertificateLoading } = useRoleQuery<
+  const [getAchievementUrl, { loading: achievementLoading }] = useLazyRoleQuery<
     GetSignedUrl,
     GetSignedUrlVariables
-  >(GET_SIGNED_URL, {
-    variables: {
-      path: courseEnrollment?.achievementCertificateURL ?? '',
-    },
-    skip: !courseEnrollment?.achievementCertificateURL,
-    fetchPolicy: 'network-only',
-    onError: () => handleQueryError(t('errorMessages.loadAchievementCertificateError')),
-    onCompleted: (data) => {
-      console.log('Achievement Certificate Query Completed:', {
-        url: data?.getSignedUrl?.link,
-        hasData: !!data
-      });
-    }
-  });
+  >(GET_SIGNED_URL, { fetchPolicy: 'network-only' });
 
-  const { data: loadAttendanceCertificateData, loading: loadAttendanceCertificateLoading } = useRoleQuery<
+  const [getAttendanceUrl, { loading: attendanceLoading }] = useLazyRoleQuery<
     GetSignedUrl,
     GetSignedUrlVariables
-  >(GET_SIGNED_URL, {
-    variables: {
-      path: courseEnrollment?.attendanceCertificateURL ?? '',
-    },
-    skip: !courseEnrollment?.attendanceCertificateURL,
-    fetchPolicy: 'network-only',
-    onError: () => handleQueryError(t('errorMessages.loadAttendanceCertificateError')),
-    onCompleted: (data) => {
-      console.log('Attendance Certificate Query Completed:', {
-        url: data?.getSignedUrl?.link,
-        hasData: !!data
-      });
-    }
-  });
+  >(GET_SIGNED_URL, { fetchPolicy: 'network-only' });
 
-  useEffect(() => {
-    console.log('Certificate URLs Updated:', {
-      achievement: courseEnrollment?.achievementCertificateURL,
-      attendance: courseEnrollment?.attendanceCertificateURL
-    });
-  }, [courseEnrollment?.achievementCertificateURL, courseEnrollment?.attendanceCertificateURL]);
+  const handleAchievementDownload = useCallback(async (e: React.MouseEvent) => {
+    e.preventDefault();
+    const path = courseEnrollment?.achievementCertificateURL;
+    if (!path) return;
+
+    try {
+      const result = await getAchievementUrl({ variables: { path } });
+      const link = result.data?.getSignedUrl?.link;
+      if (link) {
+        window.open(link, '_blank', 'noopener,noreferrer');
+      } else {
+        setErrorMessage(tCert('errorMessages.certificate_download_error'));
+      }
+    } catch {
+      setErrorMessage(tCert('errorMessages.certificate_download_error'));
+    }
+  }, [courseEnrollment?.achievementCertificateURL, getAchievementUrl, tCert]);
+
+  const handleAttendanceDownload = useCallback(async (e: React.MouseEvent) => {
+    e.preventDefault();
+    const path = courseEnrollment?.attendanceCertificateURL;
+    if (!path) return;
+
+    try {
+      const result = await getAttendanceUrl({ variables: { path } });
+      const link = result.data?.getSignedUrl?.link;
+      if (link) {
+        window.open(link, '_blank', 'noopener,noreferrer');
+      } else {
+        setErrorMessage(tCert('errorMessages.certificate_download_error'));
+      }
+    } catch {
+      setErrorMessage(tCert('errorMessages.certificate_download_error'));
+    }
+  }, [courseEnrollment?.attendanceCertificateURL, getAttendanceUrl, tCert]);
+
+  const hasAchievement = !!courseEnrollment?.achievementCertificateURL;
+  const hasAttendance = !!courseEnrollment?.attendanceCertificateURL;
+
   return (
     <div className={!manageView ? 'mt-4' : ''}>
       <div
         className={`flex flex-wrap gap-4 min-w-0 items-center ${!manageView ? 'flex-col w-full' : ''}`}
       >
-        {loadAchievementCertificateData && !loadAchievementCertificateLoading && (
+        {hasAchievement && (
           <>
             {!manageView && <h3 className="text-3xl font-medium text-center w-full">{t('coursePage.congrats_completion')}</h3>}
             <Button
-              as="a"
+              as="button"
+              type="button"
               filled
               className={`flex justify-center items-center ${!manageView ? 'w-full' : ''}`}
-              href={loadAchievementCertificateData.getSignedUrl?.link ?? '#'}
-              target="_blank"
-              rel="noopener noreferrer"
+              disabled={achievementLoading}
+              onClick={handleAchievementDownload}
             >
-              {manageView
-                ? t('manageCourse.achievement_certificate_download')
-                : t('coursePage.achievementCertificateDownload')}
+              {achievementLoading ? (
+                <CircularProgress size={20} />
+              ) : (
+                manageView
+                  ? t('manageCourse.achievement_certificate_download')
+                  : t('coursePage.achievementCertificateDownload')
+              )}
             </Button>
           </>
         )}
-        {loadAttendanceCertificateData && !loadAttendanceCertificateLoading && (
+        {hasAttendance && (
           <Button
-            as="a"
+            as="button"
+            type="button"
             filled
             className={`flex justify-center items-center ${!manageView ? 'w-full' : ''}`}
-            href={loadAttendanceCertificateData.getSignedUrl?.link ?? '#'}
-            target="_blank"
-            rel="noopener noreferrer"
+            disabled={attendanceLoading}
+            onClick={handleAttendanceDownload}
           >
-            {manageView
-              ? t('manageCourse.attendance_certificate_download')
-              : t('coursePage.attendanceCertificateDownload')}
+            {attendanceLoading ? (
+              <CircularProgress size={20} />
+            ) : (
+              manageView
+                ? t('manageCourse.attendance_certificate_download')
+                : t('coursePage.attendanceCertificateDownload')
+            )}
           </Button>
         )}
-        {/* Error Message Dialog */}
         {errorMessage && (
           <ErrorMessageDialog errorMessage={errorMessage} open={!!errorMessage} onClose={() => setErrorMessage('')} />
         )}

--- a/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
@@ -1,8 +1,8 @@
-import React, { FC, useState } from 'react';
+import React, { FC, useCallback, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { GetApp } from '@mui/icons-material';
 import { TileBase } from './TileSlider/TileBase';
-import { useRoleQuery } from '../../hooks/authedQuery';
+import { useLazyRoleQuery } from '../../hooks/authedQuery';
 import { useRoleMutation } from '../../hooks/authedMutation';
 import { GET_SIGNED_URL, MAKE_CERTIFICATE_PUBLIC } from '../../queries/actions';
 import { GetSignedUrl, GetSignedUrlVariables } from '../../queries/__generated__/GetSignedUrl';
@@ -11,6 +11,7 @@ import { Button } from './Button';
 import { LinkedInSharingDialog } from './dialogs/LinkedInSharingDialog';
 import { ErrorMessageDialog } from './dialogs/ErrorMessageDialog';
 import { MyCertificates_CourseEnrollment } from '../../queries/__generated__/MyCertificates';
+import { CircularProgress } from '@mui/material';
 
 interface CertificateTileProps {
   enrollment: MyCertificates_CourseEnrollment;
@@ -24,42 +25,39 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
   const course = enrollment.Course;
   const program = course?.Program;
 
-  const { data: achievementData, loading: achievementLoading } = useRoleQuery<
+  const [getAchievementUrl, { loading: achievementLoading }] = useLazyRoleQuery<
     GetSignedUrl,
     GetSignedUrlVariables
-  >(GET_SIGNED_URL, {
-    variables: {
-      path: enrollment.achievementCertificateURL || '',
-    },
-    skip: !enrollment.achievementCertificateURL,
-    fetchPolicy: 'network-only',
-  });
+  >(GET_SIGNED_URL, { fetchPolicy: 'network-only' });
 
-  const { data: attendanceData, loading: attendanceLoading } = useRoleQuery<
+  const [getAttendanceUrl, { loading: attendanceLoading }] = useLazyRoleQuery<
     GetSignedUrl,
     GetSignedUrlVariables
-  >(GET_SIGNED_URL, {
-    variables: {
-      path: enrollment.attendanceCertificateURL || '',
-    },
-    skip: !enrollment.attendanceCertificateURL,
-    fetchPolicy: 'network-only',
-  });
+  >(GET_SIGNED_URL, { fetchPolicy: 'network-only' });
 
-  // Mutation for making certificate public
   const [makeCertificatePublic, { loading: makingPublic }] = useRoleMutation<MakeCertificatePublic, MakeCertificatePublicVariables>(
     MAKE_CERTIFICATE_PUBLIC
   );
 
-  const handleCertificateClick = (type: 'achievement' | 'attendance') => {
-    const url = type === 'achievement' 
-      ? achievementData?.getSignedUrl?.link 
-      : attendanceData?.getSignedUrl?.link;
-    
-    if (url) {
-      window.open(url, '_blank', 'noopener,noreferrer');
+  const handleCertificateClick = useCallback(async (type: 'achievement' | 'attendance') => {
+    const path = type === 'achievement'
+      ? enrollment.achievementCertificateURL
+      : enrollment.attendanceCertificateURL;
+    if (!path) return;
+
+    const fetchUrl = type === 'achievement' ? getAchievementUrl : getAttendanceUrl;
+    try {
+      const result = await fetchUrl({ variables: { path } });
+      const link = result.data?.getSignedUrl?.link;
+      if (link) {
+        window.open(link, '_blank', 'noopener,noreferrer');
+      } else {
+        setErrorMessage(t('errorMessages.certificate_download_error'));
+      }
+    } catch {
+      setErrorMessage(t('errorMessages.certificate_download_error'));
     }
-  };
+  }, [enrollment.achievementCertificateURL, enrollment.attendanceCertificateURL, getAchievementUrl, getAttendanceUrl, t]);
 
   const handleLinkedInClick = () => {
     setLinkedInDialogOpen(true);
@@ -108,7 +106,6 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
       >
         <div className="flex flex-col h-full justify-between">
           <div className="flex flex-col gap-3">
-            {/* Download Certificate Buttons */}
             {hasAchievement && (
               <Button
                 filled
@@ -116,7 +113,11 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
                 disabled={achievementLoading}
                 className="flex items-center justify-center gap-2 text-sm py-2 px-3"
               >
-                <GetApp fontSize="small" />
+                {achievementLoading ? (
+                  <CircularProgress size={16} />
+                ) : (
+                  <GetApp fontSize="small" />
+                )}
                 {t('achievement_certificate')}
               </Button>
             )}
@@ -127,12 +128,15 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
                 disabled={attendanceLoading}
                 className="flex items-center justify-center gap-2 text-sm py-2 px-3"
               >
-                <GetApp fontSize="small" />
+                {attendanceLoading ? (
+                  <CircularProgress size={16} />
+                ) : (
+                  <GetApp fontSize="small" />
+                )}
                 {t('attendance_certificate')}
               </Button>
             )}
 
-            {/* Single LinkedIn Share Button */}
             {hasAnyCertificate && (
               <Button
                 onClick={handleLinkedInClick}
@@ -144,7 +148,6 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
             )}
           </div>
 
-          {/* Program Title at bottom */}
           {program && program.title && (
             <div className="text-xs tracking-wider mt-auto text-right">
               {program.title}

--- a/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/CertificateTile.tsx
@@ -24,7 +24,6 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
   const course = enrollment.Course;
   const program = course?.Program;
 
-  // Query for achievement certificate URL
   const { data: achievementData, loading: achievementLoading } = useRoleQuery<
     GetSignedUrl,
     GetSignedUrlVariables
@@ -33,9 +32,9 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
       path: enrollment.achievementCertificateURL || '',
     },
     skip: !enrollment.achievementCertificateURL,
+    fetchPolicy: 'network-only',
   });
 
-  // Query for attendance certificate URL
   const { data: attendanceData, loading: attendanceLoading } = useRoleQuery<
     GetSignedUrl,
     GetSignedUrlVariables
@@ -44,6 +43,7 @@ export const CertificateTile: FC<CertificateTileProps> = ({ enrollment }) => {
       path: enrollment.attendanceCertificateURL || '',
     },
     skip: !enrollment.attendanceCertificateURL,
+    fetchPolicy: 'network-only',
   });
 
   // Mutation for making certificate public

--- a/frontend-nx/apps/edu-hub/components/inputs/FileUploadField/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/inputs/FileUploadField/index.tsx
@@ -50,7 +50,9 @@ export const FileUploadField: FC<FileUploadFieldProps> = ({
   const dragCounterRef = useRef(0);
 
   const [getFileSignedUrl, { data: signedUrlData }] =
-    useLazyRoleQuery<GetSignedUrl, GetSignedUrlVariables>(GET_SIGNED_URL);
+    useLazyRoleQuery<GetSignedUrl, GetSignedUrlVariables>(GET_SIGNED_URL, {
+      fetchPolicy: 'network-only',
+    });
 
   // Always auto-detect file type from URL
   // This ensures the component always shows the correct icon/preview for the actual file

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
@@ -848,7 +848,10 @@ function ExpandableRowContent({
 
       setDownloadError(null);
       try {
-        const result = await getDoc({ variables: { path: docPath } });
+        const result = await getDoc({
+          variables: { path: docPath },
+          fetchPolicy: 'network-only',
+        });
         const signedUrl = result.data?.getSignedUrl?.link;
         if (signedUrl) {
           window.open(signedUrl, '_blank', 'noopener,noreferrer');

--- a/frontend-nx/apps/edu-hub/hooks/signedUrl.ts
+++ b/frontend-nx/apps/edu-hub/hooks/signedUrl.ts
@@ -5,24 +5,23 @@ import { useCallback, useState } from 'react';
 import { getPublicUrl } from "../helpers/filehandling";
 
 export const useSignedUrl = (filePath: string): { getSignedUrl: () => Promise<{ url: string | null }>; loading: boolean; error: any; } => {
-  const [getFileSignedUrl, { data, loading }] = useLazyRoleQuery<GetSignedUrl, GetSignedUrlVariables>(GET_SIGNED_URL, {
+  const [getFileSignedUrl, { loading }] = useLazyRoleQuery<GetSignedUrl, GetSignedUrlVariables>(GET_SIGNED_URL, {
     variables: { path: filePath },
+    fetchPolicy: 'network-only',
   });
   const [error, setError] = useState<unknown>(null);
 
-  // Sets publicUrl to null if file is not public
   const publicUrl = getPublicUrl(filePath)
 
   const getSignedUrl = useCallback(async () => {
-    // If the file is public, directly return the public URL
     if (publicUrl) {
       return { url: publicUrl };
     }
     try {
-      await getFileSignedUrl();
-      if (data?.getSignedUrl?.link) {
-        console.log(`Returning signed file URL: ${data.getSignedUrl.link}`); // Debugging log
-        return { url: data.getSignedUrl.link };
+      const result = await getFileSignedUrl();
+      const link = result.data?.getSignedUrl?.link;
+      if (link) {
+        return { url: link };
       } else {
         throw new Error('Signed URL not found in the response');
       }
@@ -32,7 +31,7 @@ export const useSignedUrl = (filePath: string): { getSignedUrl: () => Promise<{ 
       setError(err);
       return { url: null };
     }
-  }, [getFileSignedUrl, data, publicUrl]);
+  }, [getFileSignedUrl, publicUrl]);
 
   return { getSignedUrl, loading, error };
 };

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -806,6 +806,7 @@
     "not_authenticated": "Du musst angemeldet sein, um Deine Zertifikate anzusehen.",
     "errorMessages": {
       "certificate_not_found": "Zertifikat nicht gefunden",
+      "certificate_download_error": "Zertifikat konnte nicht heruntergeladen werden. Bitte versuche es erneut.",
       "linkedin_share_error": "Zertifikat konnte nicht auf LinkedIn geteilt werden. Bitte versuche es später erneut."
     }
   },

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -822,6 +822,7 @@
     "not_authenticated": "You need to be logged in to view your certificates.",
     "errorMessages": {
       "certificate_not_found": "Certificate not found",
+      "certificate_download_error": "Failed to download certificate. Please try again.",
       "linkedin_share_error": "Failed to share certificate on LinkedIn. Please try again later."
     }
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When the participations tab of the manage course page is open for more than 5 minutes, clicking "Download Documentation" for an achievement record produces an `ExpiredToken` error from Google Cloud Storage:

```xml
<Error>
  <Code>ExpiredToken</Code>
  <Message>Invalid argument.</Message>
  <Details>The provided token has expired.</Details>
</Error>
```

### Root Cause

GCS signed URLs generated by the backend expire after **5 minutes** (configured in `functions/callNodeFunction/lib/cloud-storage.js`). Apollo Client's default `cache-first` fetch policy caches the `GET_SIGNED_URL` query result. When a user clicks download after the URL has expired, Apollo returns the **stale cached URL** instead of requesting a fresh one from the backend.

## Solution

All `GET_SIGNED_URL` queries now fetch a fresh signed URL **at click time** using one of two strategies:

1. **Components already using lazy queries** (`CourseParticipationsTab`, `useSignedUrl` hook, `FileUploadField`): Added `fetchPolicy: 'network-only'` to prevent stale cache hits.

2. **Components using eager queries** (`CertificateDownload`, `CertificateTile`): Refactored from `useRoleQuery` (fires at mount) to `useLazyRoleQuery` (fires on click), so the signed URL is fetched on-demand when the user clicks the download button.

### Changed files

| File | Change |
|------|--------|
| `CourseParticipationsTab/index.tsx` | Added `fetchPolicy: 'network-only'` to the lazy query call in `handleDownloadClick` |
| `hooks/signedUrl.ts` | Added `fetchPolicy: 'network-only'` and fixed stale closure bug (read `data` from query result instead of hook state) |
| `FileUploadField/index.tsx` | Added `fetchPolicy: 'network-only'` to the lazy signed URL query |
| `CertificateDownload.tsx` | Switched from `useRoleQuery` to `useLazyRoleQuery` with on-click fetch-then-open pattern; removed unused `refetch*` props; added loading spinners |
| `CertificateTile.tsx` | Switched from `useRoleQuery` to `useLazyRoleQuery` with on-click fetch-then-open pattern; added loading spinners |
| `locales/en.json`, `locales/de.json` | Added `certificate_download_error` translation key |

## Testing

- Lint passes with no new warnings or errors (`yarn lint`)
- The fix is a well-understood Apollo query lifecycle change — eager-at-mount queries replaced with lazy-on-click queries to guarantee URL freshness at download time
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d7d07d0d-2982-4924-89dd-7ee445d3eb3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d7d07d0d-2982-4924-89dd-7ee445d3eb3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate, file, and document downloads now fetch fresh signed URLs on demand to avoid expired/invalid cached links; download buttons are disabled while fetching and show a spinner.
* **UI**
  * Download controls now use explicit click-triggered behavior that opens files in a new tab after successful fetch.
* **Localization**
  * Added a localized certificate download error message for user-facing failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->