### PR TITLE
feat: add waitlist flow for full courses

### DIFF
--- a/backend/metadata/databases/default/tables/public_Course.yaml
+++ b/backend/metadata/databases/default/tables/public_Course.yaml
@@ -88,6 +88,13 @@ array_relationships:
         table:
           name: CourseAddonMapping
           schema: public
+computed_fields:
+  - name: activeParticipantCount
+    definition:
+      function:
+        name: course_active_participant_count
+        schema: public
+      table_argument: course_row
 select_permissions:
   - role: anonymous
     permission:
@@ -124,6 +131,8 @@ select_permissions:
         - currency
         - stripeProductId
         - stripePriceId
+      computed_fields:
+        - activeParticipantCount
       filter:
         _and:
           - Program:
@@ -167,6 +176,8 @@ select_permissions:
         - stripeProductId
         - stripePriceId
         - matrixRoomId
+      computed_fields:
+        - activeParticipantCount
       filter: {}
   - role: user_access
     permission:
@@ -203,6 +214,8 @@ select_permissions:
         - stripeProductId
         - stripePriceId
         - matrixRoomId
+      computed_fields:
+        - activeParticipantCount
       filter:
         CourseEnrollments:
           User:

--- a/backend/migrations/default/1774000000000_add_waitlist_status/down.sql
+++ b/backend/migrations/default/1774000000000_add_waitlist_status/down.sql
@@ -1,2 +1,10 @@
+UPDATE "public"."CourseEnrollment"
+SET "status" = (
+  SELECT "value"
+  FROM "public"."CourseEnrollmentStatus"
+  WHERE "value" = 'APPLIED'
+)
+WHERE "status" = 'WAITLIST';
+
 DELETE FROM "public"."CourseEnrollmentStatus"
 WHERE "value" = 'WAITLIST';

--- a/backend/migrations/default/1774000000000_add_waitlist_status/down.sql
+++ b/backend/migrations/default/1774000000000_add_waitlist_status/down.sql
@@ -1,0 +1,2 @@
+DELETE FROM "public"."CourseEnrollmentStatus"
+WHERE "value" = 'WAITLIST';

--- a/backend/migrations/default/1774000000000_add_waitlist_status/up.sql
+++ b/backend/migrations/default/1774000000000_add_waitlist_status/up.sql
@@ -1,0 +1,2 @@
+INSERT INTO "public"."CourseEnrollmentStatus" ("value", "comment")
+VALUES ('WAITLIST', 'User is on the waitlist because the course is full');

--- a/backend/migrations/default/1774000000001_add_waitlist_email_template/down.sql
+++ b/backend/migrations/default/1774000000001_add_waitlist_email_template/down.sql
@@ -1,0 +1,5 @@
+DELETE FROM "public"."MailTemplate"
+WHERE "type" = 'WAITLIST_NOTICE' AND "courseId" IS NULL;
+
+DELETE FROM "public"."MailTemplateType"
+WHERE "value" = 'WAITLIST_NOTICE';

--- a/backend/migrations/default/1774000000001_add_waitlist_email_template/down.sql
+++ b/backend/migrations/default/1774000000001_add_waitlist_email_template/down.sql
@@ -1,5 +1,5 @@
 DELETE FROM "public"."MailTemplate"
-WHERE "type" = 'WAITLIST_NOTICE' AND "courseId" IS NULL;
+WHERE "type" = 'WAITLIST_NOTICE';
 
 DELETE FROM "public"."MailTemplateType"
 WHERE "value" = 'WAITLIST_NOTICE';

--- a/backend/migrations/default/1774000000001_add_waitlist_email_template/up.sql
+++ b/backend/migrations/default/1774000000001_add_waitlist_email_template/up.sql
@@ -11,7 +11,7 @@ SELECT
       <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
     </head>
     <body>
-      <p>Hello [User:Firstname] [User:LastName],</p>
+      <p>Hello [User:FirstName] [User:LastName],</p>
       <p>Thank you for your interest in <strong>[Enrollment:CourseId--Course:Name]</strong>.</p>
       <p>The course is currently full. We have placed you on the waitlist.</p>
       <p>You can only participate if a spot becomes available. If that happens, we will contact you with further information.</p>

--- a/backend/migrations/default/1774000000001_add_waitlist_email_template/up.sql
+++ b/backend/migrations/default/1774000000001_add_waitlist_email_template/up.sql
@@ -1,0 +1,30 @@
+INSERT INTO "public"."MailTemplateType" ("value", "comment")
+VALUES ('WAITLIST_NOTICE', 'Sent when a user joins the waitlist because the course is full')
+ON CONFLICT ("value") DO NOTHING;
+
+INSERT INTO "public"."MailTemplate" ("subject", "content", "from", "type", "courseId")
+SELECT
+  'Waitlist Confirmation - [Enrollment:CourseId--Course:Name]',
+  '<!DOCTYPE html>
+  <html>
+    <head>
+      <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    </head>
+    <body>
+      <p>Hello [User:Firstname] [User:LastName],</p>
+      <p>Thank you for your interest in <strong>[Enrollment:CourseId--Course:Name]</strong>.</p>
+      <p>The course is currently full. We have placed you on the waitlist.</p>
+      <p>You can only participate if a spot becomes available. If that happens, we will contact you with further information.</p>
+      <p>If you do not receive another message, participation is not possible. Please refrain from enquiries in the meantime.</p>
+      <p>You can view your enrollment status here: <a href="[Enrollment:CourseLink]">[Enrollment:CourseLink]</a></p>
+      <p>Best regards,<br>The EduHub Team</p>
+    </body>
+  </html>',
+  'noreply@opencampus.sh',
+  'WAITLIST_NOTICE',
+  NULL
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM "public"."MailTemplate"
+  WHERE "type" = 'WAITLIST_NOTICE' AND "courseId" IS NULL
+);

--- a/backend/migrations/default/1774000000002_add_course_active_participant_count_function/down.sql
+++ b/backend/migrations/default/1774000000002_add_course_active_participant_count_function/down.sql
@@ -1,0 +1,1 @@
+DROP FUNCTION "public"."course_active_participant_count"(course_row "public"."Course");

--- a/backend/migrations/default/1774000000002_add_course_active_participant_count_function/up.sql
+++ b/backend/migrations/default/1774000000002_add_course_active_participant_count_function/up.sql
@@ -1,0 +1,10 @@
+CREATE FUNCTION "public"."course_active_participant_count"(course_row "public"."Course")
+RETURNS bigint
+LANGUAGE sql
+STABLE
+AS $function$
+  SELECT COUNT(*)
+  FROM "public"."CourseEnrollment"
+  WHERE "courseId" = course_row.id
+    AND status IN ('CONFIRMED', 'INVITED');
+$function$;

--- a/backend/migrations/default/1774000000003_add_course_enrollment_courseid_status_index/down.sql
+++ b/backend/migrations/default/1774000000003_add_course_enrollment_courseid_status_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "public"."CourseEnrollment_courseId_status_idx";

--- a/backend/migrations/default/1774000000003_add_course_enrollment_courseid_status_index/up.sql
+++ b/backend/migrations/default/1774000000003_add_course_enrollment_courseid_status_index/up.sql
@@ -1,0 +1,2 @@
+CREATE INDEX "CourseEnrollment_courseId_status_idx"
+ON "public"."CourseEnrollment" ("courseId", "status");

--- a/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
+++ b/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
@@ -558,6 +558,7 @@ export enum CourseEnrollmentStatus_enum {
   INVITED = "INVITED",
   REGISTERED = "REGISTERED",
   REJECTED = "REJECTED",
+  WAITLIST = "WAITLIST",
 }
 
 /**
@@ -5445,6 +5446,7 @@ export interface Course_bool_exp {
   _not?: Course_bool_exp | null;
   _or?: Course_bool_exp[] | null;
   achievementCertificatePossible?: Boolean_comparison_exp | null;
+  activeParticipantCount?: bigint_comparison_exp | null;
   applicationEnd?: date_comparison_exp | null;
   attendanceCertificatePossible?: Boolean_comparison_exp | null;
   basePrice?: Int_comparison_exp | null;
@@ -5636,6 +5638,7 @@ export interface Course_order_by {
   Sessions_aggregate?: Session_aggregate_order_by | null;
   Weekday?: Weekday_order_by | null;
   achievementCertificatePossible?: order_by | null;
+  activeParticipantCount?: order_by | null;
   applicationEnd?: order_by | null;
   attendanceCertificatePossible?: order_by | null;
   basePrice?: order_by | null;
@@ -8777,6 +8780,21 @@ export interface Weekday_on_conflict {
 export interface Weekday_order_by {
   comment?: order_by | null;
   value?: order_by | null;
+}
+
+/**
+ * Boolean expression to compare columns of type "bigint". All fields are combined with logical 'AND'.
+ */
+export interface bigint_comparison_exp {
+  _eq?: any | null;
+  _gt?: any | null;
+  _gte?: any | null;
+  _in?: any[] | null;
+  _is_null?: boolean | null;
+  _lt?: any | null;
+  _lte?: any | null;
+  _neq?: any | null;
+  _nin?: any[] | null;
 }
 
 /**

--- a/frontend-nx/apps/edu-hub/components/inputs/InputField.tsx
+++ b/frontend-nx/apps/edu-hub/components/inputs/InputField.tsx
@@ -378,7 +378,6 @@ const InputField: React.FC<InputFieldProps> = ({
         onValueUpdated({ text: newText });
       }
       setErrorMessage('');
-      setShowSavedNotification(!!updateValueMutation);
     } else {
       setErrorMessage(getErrorMessage(type));
     }
@@ -398,10 +397,16 @@ const InputField: React.FC<InputFieldProps> = ({
   const handleTextChange = useCallback(
     (event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
       const newText = event.target.value;
+      if (type === 'number') {
+        const numberPattern = min !== undefined && min >= 0 ? /^\d*$/ : /^-?\d*$/;
+        if (!numberPattern.test(newText)) {
+          return;
+        }
+      }
       setLocalText(newText);
       debouncedUpdateText(newText);
     },
-    [debouncedUpdateText]
+    [debouncedUpdateText, type, min]
   );
 
   const handleBlur = useCallback(() => {
@@ -553,9 +558,11 @@ const InputField: React.FC<InputFieldProps> = ({
                 min={type === 'number' ? min : undefined}
                 max={type === 'number' ? max : undefined}
                 step={type === 'number' ? 1 : undefined}
+                inputMode={type === 'number' ? 'numeric' : undefined}
+                pattern={type === 'number' ? '[0-9]*' : undefined}
                 {...props}
               />
-              {showCharacterCount && type !== 'ects' && (
+              {showCharacterCount && type !== 'ects' && type !== 'number' && (
                 <div className="absolute top-0 right-0 mr-2 mt-1 text-xs text-label-secondary">
                   {`${localText.length}/${maxLength}`}
                 </div>

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/RegistrationButton.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/RegistrationButton.tsx
@@ -110,7 +110,7 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({ course, regist
   return (
     <div className="flex flex-1 flex-col justify-center items-center space-y-4 w-full">
       {isCourseFull && (
-        <div className="bg-amber-50 rounded-lg p-4 w-full text-amber-800 text-sm">
+        <div className="bg-warning/20 rounded-lg p-4 w-full text-label-primary text-sm">
           {t('status.course_full_notice')}
         </div>
       )}

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/RegistrationButton.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/RegistrationButton.tsx
@@ -17,6 +17,8 @@ interface RegistrationButtonProps {
   registrationType: CourseRegistrationType_enum;
   /** Callback function triggered when the registration button is clicked */
   onClick: () => void;
+  /** Whether active participants reached the maximum for the course */
+  isCourseFull: boolean;
 }
 
 /**
@@ -40,7 +42,7 @@ interface RegistrationButtonProps {
  * @param props - The component props
  * @returns JSX element representing the registration button and deadline info
  */
-export const RegistrationButton: FC<RegistrationButtonProps> = ({ course, registrationType, onClick }) => {
+export const RegistrationButton: FC<RegistrationButtonProps> = ({ course, registrationType, onClick, isCourseFull }) => {
   const t = useTranslations('course');
   const locale = useLocale();
   const config = getRegistrationTypeConfig(registrationType);
@@ -86,6 +88,10 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({ course, regist
 
   // Get button text based on registration type and login status
   const getButtonText = () => {
+    if (isCourseFull) {
+      return t('registration.join_waitlist');
+    }
+
     if (course.externalRegistrationLink) {
       return t('registration.register_external');
     }
@@ -103,6 +109,11 @@ export const RegistrationButton: FC<RegistrationButtonProps> = ({ course, regist
 
   return (
     <div className="flex flex-1 flex-col justify-center items-center space-y-4 w-full">
+      {isCourseFull && (
+        <div className="bg-amber-50 rounded-lg p-4 w-full text-amber-800 text-sm">
+          {t('status.course_full_notice')}
+        </div>
+      )}
       <Button
         filled
         onClick={onClick}

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/RegistrationModal.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/RegistrationModal.tsx
@@ -39,6 +39,12 @@ interface RegistrationModalProps {
   isLoading: boolean;
   /** Optional enrollment ID for retry payment flow - triggers prefilled survey */
   retryEnrollmentId?: number | null;
+  /**
+   * When the course is at capacity, registration must go to the waitlist: skip payment enrollment
+   * creation, summary step, and payment-only validation; submit uses the same handler as normal
+   * but the parent resolves to WAITLIST.
+   */
+  isCourseFull?: boolean;
 }
 
 /**
@@ -73,6 +79,7 @@ export const RegistrationModal: FC<RegistrationModalProps> = ({
   onSubmit,
   isLoading,
   retryEnrollmentId,
+  isCourseFull = false,
 }) => {
   const t = useTranslations('course');
   const router = useRouter();
@@ -183,6 +190,10 @@ export const RegistrationModal: FC<RegistrationModalProps> = ({
 
   // Determine current step for payment flows
   const currentStep: ModalStep = useMemo(() => {
+    // Full course / waitlist: never show the payment summary step
+    if (isCourseFull) {
+      return 'questionnaire';
+    }
     if (!config.requiresPayment) {
       // Non-payment flows don't use steps
       return 'questionnaire';
@@ -192,7 +203,7 @@ export const RegistrationModal: FC<RegistrationModalProps> = ({
       return 'questionnaire';
     }
     return 'summary';
-  }, [config, useFormbricks, formbricksSurveyCompleted]);
+  }, [config, useFormbricks, formbricksSurveyCompleted, isCourseFull]);
 
   // Format price helper
   const formatPrice = useCallback((priceInCents: number, currency: string): string => {
@@ -223,7 +234,26 @@ export const RegistrationModal: FC<RegistrationModalProps> = ({
     }
     
     setFormbricksSurveyCompleted(true);
-    
+
+    // Waitlist: same as non-payment — submit once; do not create APPLIED enrollment for Stripe flow
+    if (isCourseFull) {
+      setIsFetchingAddons(false);
+      try {
+        const result = await onSubmit({
+          motivationLetter: '[Formbricks Survey Completed]',
+          acceptTerms: false,
+        });
+        if (result.success) {
+          closeModal();
+        } else {
+          setError(result.error || t('errors.registration_failed'));
+        }
+      } catch (err: unknown) {
+        setError(err instanceof Error ? err.message : t('errors.registration_failed'));
+      }
+      return;
+    }
+
     // For payment flows, create enrollment with addons and show summary
     if (config.requiresPayment && effectiveSurveyUrl && userId) {
       setIsFetchingAddons(true);
@@ -277,7 +307,19 @@ export const RegistrationModal: FC<RegistrationModalProps> = ({
       // Payment flow but no survey URL - proceed with empty addons
       setSelectedAddons([]);
     }
-  }, [onSubmit, closeModal, t, isLoading, formbricksSurveyCompleted, config, effectiveSurveyUrl, userId, course.id, createEnrollmentWithAddons]);
+  }, [
+    onSubmit,
+    closeModal,
+    t,
+    isLoading,
+    formbricksSurveyCompleted,
+    config,
+    effectiveSurveyUrl,
+    userId,
+    course.id,
+    createEnrollmentWithAddons,
+    isCourseFull,
+  ]);
 
   const handleSubmit = useCallback(async () => {
     // If using Formbricks and survey not completed, don't allow submit
@@ -291,34 +333,38 @@ export const RegistrationModal: FC<RegistrationModalProps> = ({
       return;
     }
 
-    if (config.requiresPayment && !acceptTerms) {
-      setError(t('errors.terms_required'));
-      return;
-    }
-
-    // Validate that there's something to charge for payment flows
-    if (config.requiresPayment) {
-      const hasBasePrice = basePrice > 0;
-      const hasAddons = selectedAddons.length > 0 && selectedAddons.some(addon => addon.validatedPrice > 0);
-      
-      if (!hasBasePrice && !hasAddons) {
-        setError(t('errors.no_items_to_charge'));
+    if (!isCourseFull) {
+      if (config.requiresPayment && !acceptTerms) {
+        setError(t('errors.terms_required'));
         return;
       }
 
-      // Validate currency consistency
-      if (currencyMismatch) {
-        setError(t('errors.currency_mismatch') || 'All add-ons must use the same currency as the course');
-        return;
+      // Validate that there's something to charge for payment flows
+      if (config.requiresPayment) {
+        const hasBasePrice = basePrice > 0;
+        const hasAddons = selectedAddons.length > 0 && selectedAddons.some((addon) => addon.validatedPrice > 0);
+
+        if (!hasBasePrice && !hasAddons) {
+          setError(t('errors.no_items_to_charge'));
+          return;
+        }
+
+        // Validate currency consistency
+        if (currencyMismatch) {
+          setError(t('errors.currency_mismatch') || 'All add-ons must use the same currency as the course');
+          return;
+        }
       }
     }
 
     setError(null);
 
     const result = await onSubmit({
-      motivationLetter: motivationLetter.trim(),
-      acceptTerms,
-      enrollmentId: config.requiresPayment ? (enrollmentId ?? undefined) : undefined,
+      motivationLetter: useFormbricks
+        ? '[Formbricks Survey Completed]'
+        : motivationLetter.trim(),
+      acceptTerms: isCourseFull ? false : acceptTerms,
+      enrollmentId: !isCourseFull && config.requiresPayment ? (enrollmentId ?? undefined) : undefined,
     });
 
     if (result.success) {
@@ -327,7 +373,22 @@ export const RegistrationModal: FC<RegistrationModalProps> = ({
     } else {
       setError(result.error || t('errors.registration_failed'));
     }
-  }, [config, motivationLetter, acceptTerms, onSubmit, t, closeModal, useFormbricks, formbricksSurveyCompleted, currentStep, basePrice, enrollmentId, selectedAddons, currencyMismatch]);
+  }, [
+    config,
+    motivationLetter,
+    acceptTerms,
+    onSubmit,
+    t,
+    closeModal,
+    useFormbricks,
+    formbricksSurveyCompleted,
+    currentStep,
+    basePrice,
+    enrollmentId,
+    selectedAddons,
+    currencyMismatch,
+    isCourseFull,
+  ]);
 
   const handleClose = useCallback(() => {
     if (!isLoading) {
@@ -356,21 +417,42 @@ export const RegistrationModal: FC<RegistrationModalProps> = ({
   const isSubmitDisabled = useMemo(() => {
     if (isLoading) return true;
     if (isFetchingAddons) return true;
-    
+
+    if (isCourseFull) {
+      if (useFormbricks) {
+        return !formbricksSurveyCompleted;
+      }
+      if (config.requiresInput) {
+        return !motivationLetter.trim();
+      }
+      return false;
+    }
+
     if (config.requiresPayment && currentStep === 'summary') {
       return !acceptTerms || currencyMismatch;
     }
-    
+
     if (useFormbricks) {
       return !formbricksSurveyCompleted;
     }
-    
+
     if (config.requiresInput) {
       return !motivationLetter.trim();
     }
-    
+
     return false;
-  }, [isLoading, isFetchingAddons, config, currentStep, acceptTerms, currencyMismatch, useFormbricks, formbricksSurveyCompleted, motivationLetter]);
+  }, [
+    isLoading,
+    isFetchingAddons,
+    config,
+    currentStep,
+    acceptTerms,
+    currencyMismatch,
+    useFormbricks,
+    formbricksSurveyCompleted,
+    motivationLetter,
+    isCourseFull,
+  ]);
 
   const renderQuestionnaireStep = () => (
     <>
@@ -562,8 +644,13 @@ export const RegistrationModal: FC<RegistrationModalProps> = ({
         {currentStep === 'summary' && renderSummaryStep()}
       </DialogContent>
 
-      {/* Submit button - show for summary step or non-payment flows */}
-      {(currentStep === 'summary' || (!config.requiresPayment && (!useFormbricks || formbricksSurveyCompleted))) && (
+      {/* Submit button - show for summary step or non-payment flows; waitlist shows actions on questionnaire after survey or with motivation text */}
+      {(currentStep === 'summary' ||
+        (!config.requiresPayment && (!useFormbricks || formbricksSurveyCompleted)) ||
+        (isCourseFull &&
+          currentStep === 'questionnaire' &&
+          ((!useFormbricks && config.requiresInput && motivationLetter.trim().length > 0) ||
+            (useFormbricks && formbricksSurveyCompleted)))) && (
         <DialogActions sx={{ padding: { xs: '16px', sm: '24px' }, paddingTop: 0 }} className="light">
           <div className="flex flex-col sm:flex-row justify-end space-y-3 sm:space-y-0 sm:space-x-3 w-full">
             <Button onClick={handleClose} disabled={isLoading} className="px-6 py-3 w-full sm:w-auto order-2 sm:order-1">
@@ -580,7 +667,7 @@ export const RegistrationModal: FC<RegistrationModalProps> = ({
                   <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-label-primary"></div>
                   <span>{t('modal.submitting')}</span>
                 </div>
-              ) : config.requiresPayment ? (
+              ) : config.requiresPayment && !isCourseFull ? (
                 t('modal.proceed_to_payment')
               ) : (
                 t('modal.submit')

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/RegistrationStatus.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/RegistrationStatus.tsx
@@ -205,6 +205,13 @@ export const RegistrationStatus: FC<RegistrationStatusProps> = ({ courseEnrollme
     case CourseEnrollmentStatus_enum.COMPLETED: {
       return <CourseLinkInfos course={course} />;
     }
+    case CourseEnrollmentStatus_enum.WAITLIST: {
+      return (
+        <StatusCard status="info" icon={<MdHourglassEmpty />}>
+          {t('status.waitlist')}
+        </StatusCard>
+      );
+    }
     default: {
       return null;
     }

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
@@ -17,6 +17,8 @@ import { getRegistrationTypeConfig, RegistrationFormData, RegistrationResult } f
 interface UseRegistrationHandlerProps {
   /** Course data containing registration configuration and details */
   course: Course_Course_by_pk;
+  /** Whether active participants reached the course capacity */
+  isCourseFull: boolean;
   /** Optional callback function called after successful registration */
   onSuccess?: () => void;
 }
@@ -50,6 +52,7 @@ interface UseRegistrationHandlerProps {
  */
 export const useRegistrationHandler = ({
   course,
+  isCourseFull,
   onSuccess,
 }: UseRegistrationHandlerProps) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -87,9 +90,14 @@ export const useRegistrationHandler = ({
       setIsLoading(true);
       try {
         // Determine the correct status based on registration type
-        const status = config.isDirect 
-          ? CourseEnrollmentStatus_enum.CONFIRMED 
-          : CourseEnrollmentStatus_enum.APPLIED;
+        let status: CourseEnrollmentStatus_enum;
+        if (isCourseFull) {
+          status = CourseEnrollmentStatus_enum.WAITLIST;
+        } else if (config.isDirect) {
+          status = CourseEnrollmentStatus_enum.CONFIRMED;
+        } else {
+          status = CourseEnrollmentStatus_enum.APPLIED;
+        }
 
         const result = await updateEnrollmentMutation({
           variables: {
@@ -187,6 +195,15 @@ export const useRegistrationHandler = ({
       return;
     }
 
+    if (isCourseFull) {
+      if (config.requiresInput || config.requiresPayment) {
+        setIsModalOpen(true);
+        return;
+      }
+      handleDirectRegistration();
+      return;
+    }
+
     if (config.isExternal) {
       handleExternalRegistration();
       return;
@@ -202,17 +219,21 @@ export const useRegistrationHandler = ({
     if (config.isDirect) {
       handleDirectRegistration();
     }
-  }, [userId, handleLogin, config, handleExternalRegistration, handleDirectRegistration]);
+  }, [userId, handleLogin, config, handleExternalRegistration, handleDirectRegistration, isCourseFull]);
 
   const submitRegistration = useCallback(
     async (formData: RegistrationFormData): Promise<RegistrationResult> => {
+      if (isCourseFull) {
+        return handleDirectRegistration(formData);
+      }
+
       if (config.requiresPayment) {
         return handlePaymentRegistration(formData);
       }
 
       return handleDirectRegistration(formData);
     },
-    [config.requiresPayment, handlePaymentRegistration, handleDirectRegistration]
+    [config.requiresPayment, handlePaymentRegistration, handleDirectRegistration, isCourseFull]
   );
 
   const retryPayment = useCallback(

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
@@ -125,7 +125,7 @@ export const useRegistrationHandler = ({
         setIsLoading(false);
       }
     },
-    [course.id, updateEnrollmentMutation, userId, onSuccess, config.isDirect]
+    [course.id, updateEnrollmentMutation, userId, onSuccess, config.isDirect, isCourseFull]
   );
 
   const handlePaymentRegistration = useCallback(

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
@@ -196,7 +196,9 @@ export const useRegistrationHandler = ({
     }
 
     if (isCourseFull) {
-      if (config.requiresInput || config.requiresPayment) {
+      // Waitlist: only open the modal when there is an application form (survey or motivation letter).
+      // Payment UI and createEnrollmentWithAddons must not run for full courses; submit goes to WAITLIST.
+      if (config.requiresInput) {
         setIsModalOpen(true);
         return;
       }

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/index.tsx
@@ -80,6 +80,7 @@ export const Registration: FC<RegistrationProps> = ({ course, courseEnrollment, 
           onSubmit={registrationHandler.submitRegistration}
           isLoading={registrationHandler.isLoading}
           retryEnrollmentId={registrationHandler.retryEnrollmentId}
+          isCourseFull={isCourseFull && !registrationHandler.retryEnrollmentId}
         />
       </div>
     );
@@ -122,6 +123,7 @@ export const Registration: FC<RegistrationProps> = ({ course, courseEnrollment, 
         onSubmit={registrationHandler.submitRegistration}
         isLoading={registrationHandler.isLoading}
         retryEnrollmentId={registrationHandler.retryEnrollmentId}
+        isCourseFull={isCourseFull && !registrationHandler.retryEnrollmentId}
       />
     </div>
   );

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/index.tsx
@@ -49,9 +49,13 @@ interface RegistrationProps {
  */
 export const Registration: FC<RegistrationProps> = ({ course, courseEnrollment, onRegistrationSuccess }) => {
   const isLoggedIn = useIsLoggedIn();
+  const isCourseFull =
+    course.maxParticipants != null &&
+    (course.activeParticipantCount ?? 0) >= course.maxParticipants;
 
   const registrationHandler = useRegistrationHandler({
     course,
+    isCourseFull,
     onSuccess: onRegistrationSuccess,
   });
 
@@ -84,12 +88,13 @@ export const Registration: FC<RegistrationProps> = ({ course, courseEnrollment, 
   // If not logged in: for external link registration, open link directly; otherwise prompt login
   if (!isLoggedIn) {
     const isExternalWithLink =
-      registrationHandler.config.isExternal && course.externalRegistrationLink;
+      !isCourseFull && registrationHandler.config.isExternal && course.externalRegistrationLink;
     return (
       <div className="w-full">
         <RegistrationButton
           course={course}
           registrationType={course.registrationType || CourseRegistrationType_enum.APPROVAL_WITH_INPUT}
+          isCourseFull={isCourseFull}
           onClick={
             isExternalWithLink
               ? registrationHandler.handleExternalRegistration
@@ -106,6 +111,7 @@ export const Registration: FC<RegistrationProps> = ({ course, courseEnrollment, 
       <RegistrationButton
         course={course}
         registrationType={course.registrationType || CourseRegistrationType_enum.APPROVAL_WITH_INPUT}
+        isCourseFull={isCourseFull}
         onClick={registrationHandler.handleRegistration}
       />
       <RegistrationModal

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/ApplicationsTab/index.tsx
@@ -597,6 +597,13 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
         group: t('bulk_actions.email_all_by_status'),
       });
     }
+    if (courseEnrollments.some((e) => e.status === 'WAITLIST')) {
+      actions.push({
+        value: 'email_status_WAITLIST',
+        label: t('bulk_actions.email_all_waitlist'),
+        group: t('bulk_actions.email_all_by_status'),
+      });
+    }
 
     // Email by rating
     if (courseEnrollments.some((e) => e.motivationRating === 'INVITE')) {
@@ -646,6 +653,7 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
       ABORTED: 5,
       CANCELLED: 6,
       REGISTERED: 7,
+      WAITLIST: 8,
     };
     return order[a] - order[b];
   }, []);
@@ -775,6 +783,9 @@ export const ApplicationsTab: FC<IProps> = ({ course, qResult }) => {
               )}
               {enrollment.status === 'CANCELLED' && (
                 <IoIosCloseCircle title={t('status.cancelled')} color="red" size="1.5em" className="inline" />
+              )}
+              {enrollment.status === 'WAITLIST' && (
+                <GoDotFill className="inline" title={t('status.waitlist')} color="orange" size="1.5em" />
               )}
               {expired && (enrollment.status === 'APPLIED' || enrollment.status === 'INVITED') && (
                 <IoIosCloseCircle

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -105,6 +105,7 @@
     "ABORTED": "abgebrochen",
     "COMPLETED": "abgeschlossen",
     "CANCELLED": "abgesagt",
+    "WAITLIST": "warteliste",
     "password": "Password",
     "employmentStatus": "Aktuelle Tätigkeit",
     "nameOfUniversity": "Name der Universität",
@@ -384,6 +385,7 @@
       "application_deadline": "Bewerbungsschluss: ",
       "registration_deadline": "Anmeldeschluss: ",
       "apply_now": "Jetzt anmelden",
+      "join_waitlist": "Auf die Warteliste setzen",
       "register_external": "Über externen Link registrieren",
       "register_with_payment": "Jetzt Registrieren",
       "register_now": "Jetzt registrieren",
@@ -400,6 +402,8 @@
       "invitation_expired": "Deine Einladung ist abgelaufen",
       "payment_pending": "Deine Zahlung wurde noch nicht abgeschlossen. Du kannst deine Auswahl überprüfen und es erneut versuchen.",
       "payment_failed": "Deine Zahlung konnte nicht verarbeitet werden. Du kannst deine Auswahl überprüfen und es erneut versuchen.",
+      "waitlist": "Du stehst auf der Warteliste. Der Kurs ist derzeit voll. Wir informieren dich, falls ein Platz frei wird.",
+      "course_full_notice": "Dieser Kurs ist derzeit voll. Du kannst dich auf die Warteliste setzen lassen.",
       "application_period_ended": "Die Bewerbungsfrist  ist leider abgelaufen. Du kannst unseren <a>Newsletter</a> abonnieren, um über neue Angebote informiert zu bleiben.",
       "application_period_ended_title": "Bewerbungsfrist abgelaufen",
       "registration_period_ended": "Die Anmeldefrist ist leider abgelaufen. Du kannst unseren <a>Newsletter</a> abonnieren, um über neue Angebote informiert zu bleiben.",
@@ -1051,6 +1055,7 @@
       "email_all_invited": "E-Mail an alle Eingeladenen",
       "email_all_applied": "E-Mail an alle Beworbenen",
       "email_all_rejected": "E-Mail an alle Abgelehnten",
+      "email_all_waitlist": "E-Mail an alle auf der Warteliste",
       "email_all_invite_rating": "E-Mail an alle mit Bewertung 'Einladen'",
       "email_all_decline_rating": "E-Mail an alle mit Bewertung 'Ablehnen'",
       "email_all_review_rating": "E-Mail an alle mit Bewertung 'Unklar'",
@@ -1147,7 +1152,7 @@
     "max_participants": {
       "label": "Max. Teilnehmendenanzahl",
       "placeholder": "Max. Teilnehmendenanzahl",
-      "help_text": "Die maximale Teilnehmendenanzahl diesnt als Information zur Zulassung."
+      "help_text": "Sobald die maximale Teilnehmendenanzahl erreicht ist, können sich Nutzer nur noch auf die Warteliste setzen."
     },
     "formbricks": {
       "title": "Fragebogen URL",
@@ -1217,6 +1222,7 @@
       "invited": "Eingeladen",
       "invitation_confirmed": "Einladung bestätigt",
       "registered": "Registriert",
+      "waitlist": "Warteliste",
       "aborted": "Abgebrochen",
       "rejected": "Bewerbung abgelehnt",
       "cancelled": "Einladung abgelehnt",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -105,6 +105,7 @@
     "ABORTED": "aborted",
     "COMPLETED": "completed",
     "CANCELLED": "canceled",
+    "WAITLIST": "waitlist",
     "password": "Password",
     "employmentStatus": "Employment Status",
     "nameOfUniversity": "Name of University",
@@ -384,6 +385,7 @@
       "application_deadline": "Application deadline: ",
       "registration_deadline": "Registration deadline: ",
       "apply_now": "Apply now",
+      "join_waitlist": "Join Waitlist",
       "register_external": "Register via External Link",
       "register_with_payment": "Register Now",
       "register_now": "Register Now",
@@ -400,6 +402,8 @@
       "invitation_expired": "Your invitation has expired",
       "payment_pending": "Your payment has not been completed yet. You can review your selections and try again.",
       "payment_failed": "Your payment could not be processed. You can review your selections and try again.",
+      "waitlist": "You are on the waitlist. The course is currently full. We will inform you if a spot becomes available.",
+      "course_full_notice": "This course is currently full. You can join the waitlist.",
       "application_period_ended": "Unfortunately, the application period has ended. You can subscribe to our <a>newsletter</a> to stay informed about new offers.",
       "application_period_ended_title": "Application Period Ended",
       "registration_period_ended": "Unfortunately, the registration period has ended. You can subscribe to our <a>newsletter</a> to stay informed about new offers.",
@@ -1069,6 +1073,7 @@
       "email_all_invited": "Email all Invited",
       "email_all_applied": "Email all Applied",
       "email_all_rejected": "Email all Rejected",
+      "email_all_waitlist": "Email all on Waitlist",
       "email_all_invite_rating": "Email all with Rating 'Invite'",
       "email_all_decline_rating": "Email all with Rating 'Decline'",
       "email_all_review_rating": "Email all with Rating 'Review'",
@@ -1165,7 +1170,7 @@
     "max_participants": {
       "label": "Maximum number of participants",
       "placeholder": "Maximum number of participants",
-      "help_text": "The maximum number of participants is used as information for admission."
+      "help_text": "After the maximum number of participants is reached, users can only join the waitlist."
     },
     "formbricks": {
       "title": "Enrollment Questionnaire",
@@ -1235,6 +1240,7 @@
       "invited": "Invited",
       "invitation_confirmed": "invitation confirmed",
       "registered": "Registered",
+      "waitlist": "Waitlist",
       "aborted": "aborted",
       "rejected": "Rejected",
       "cancelled": "Cancelled",

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseFragment.ts
@@ -343,6 +343,10 @@ export interface AdminCourseFragment {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseList.ts
@@ -401,6 +401,10 @@ export interface AdminCourseList_Course {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/Course.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/Course.ts
@@ -342,6 +342,10 @@ export interface Course_Course_by_pk {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseAnonymous.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseAnonymous.ts
@@ -338,6 +338,10 @@ export interface CourseAnonymous_Course_by_pk {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseFragment.ts
@@ -342,6 +342,10 @@ export interface CourseFragment {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseFragmentAnonymous.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseFragmentAnonymous.ts
@@ -338,6 +338,10 @@ export interface CourseFragmentAnonymous {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseFragmentMinimum.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseFragmentMinimum.ts
@@ -77,6 +77,10 @@ export interface CourseFragmentMinimum {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * The time the course ends each week.
    */
   endTime: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseList.ts
@@ -342,6 +342,10 @@ export interface CourseList_Course {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseMinimum.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseMinimum.ts
@@ -115,6 +115,10 @@ export interface CourseMinimum_Course_by_pk {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * The time the course ends each week.
    */
   endTime: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseWithEnrollment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseWithEnrollment.ts
@@ -448,6 +448,10 @@ export interface CourseWithEnrollment_Course_by_pk {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/InsertEnrollment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/InsertEnrollment.ts
@@ -413,6 +413,10 @@ export interface InsertEnrollment_insert_CourseEnrollment_returning_Course {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ManagedCourse.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ManagedCourse.ts
@@ -615,6 +615,10 @@ export interface ManagedCourse_Course_by_pk {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MyCertificates.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MyCertificates.ts
@@ -132,6 +132,10 @@ export interface MyCertificates_CourseEnrollment_Course {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * The time the course ends each week.
    */
   endTime: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MyCourses.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MyCourses.ts
@@ -451,6 +451,10 @@ export interface MyCourses_User_by_pk_CourseEnrollments_Course {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MyEnrollmentsForCourseQuery.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MyEnrollmentsForCourseQuery.ts
@@ -359,6 +359,10 @@ export interface MyEnrollmentsForCourseQuery_CourseEnrollment_Course {
    */
   maxParticipants: number | null;
   /**
+   * A computed field, executes function "course_active_participant_count"
+   */
+  activeParticipantCount: any | null;
+  /**
    * An array of texts including the learning goals for the course
    */
   learningGoals: string | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateEnrollmentStatusWhenApplied.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateEnrollmentStatusWhenApplied.ts
@@ -1,7 +1,7 @@
 /* tslint:disable */
 /* eslint-disable */
 // @generated
-// Manually aligned with UPDATE_ENROLLMENT_STATUS_WHEN_APPLIED; run yarn apollo when Hasura is available.
+// This file was automatically generated and should not be edited.
 
 import { CourseEnrollmentStatus_enum } from "./../../__generated__/globalTypes";
 
@@ -16,11 +16,20 @@ export interface UpdateEnrollmentStatusWhenApplied_update_CourseEnrollment_retur
 
 export interface UpdateEnrollmentStatusWhenApplied_update_CourseEnrollment {
   __typename: "CourseEnrollment_mutation_response";
+  /**
+   * number of rows affected by the mutation
+   */
   affected_rows: number;
+  /**
+   * data from the rows affected by the mutation
+   */
   returning: UpdateEnrollmentStatusWhenApplied_update_CourseEnrollment_returning[];
 }
 
 export interface UpdateEnrollmentStatusWhenApplied {
+  /**
+   * update data of the table: "CourseEnrollment"
+   */
   update_CourseEnrollment: UpdateEnrollmentStatusWhenApplied_update_CourseEnrollment | null;
 }
 

--- a/frontend-nx/apps/edu-hub/queries/courseFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/courseFragment.ts
@@ -49,6 +49,7 @@ export const COURSE_FRAGMENT = gql`
     attendanceCertificatePossible
     programId
     maxParticipants
+    activeParticipantCount
     learningGoals
     headingDescriptionField1
     contentDescriptionField1
@@ -160,6 +161,7 @@ export const COURSE_FRAGMENT_MINIMUM = gql`
     chatLink
     published
     maxParticipants
+    activeParticipantCount
     endTime
     startTime
     registrationType
@@ -188,6 +190,7 @@ export const COURSE_FRAGMENT_ANONYMOUS = gql`
     attendanceCertificatePossible
     programId
     maxParticipants
+    activeParticipantCount
     learningGoals
     headingDescriptionField1
     contentDescriptionField1

--- a/frontend-nx/apps/edu-hub/utils/getEmailTemplateTypesForCourseRegistration.ts
+++ b/frontend-nx/apps/edu-hub/utils/getEmailTemplateTypesForCourseRegistration.ts
@@ -17,6 +17,7 @@ export function getEmailTemplateTypesForCourseRegistration(
     'DECLINE',
     'REGISTRATION_CONFIRMED',
     'REGISTRATION_CONFIRMED_PAID',
+    'WAITLIST_NOTICE',
     'ORGANIZER_ADDED',
   ];
 

--- a/functions/apiProxy/schemas/participant-data-v1.0.0.json
+++ b/functions/apiProxy/schemas/participant-data-v1.0.0.json
@@ -42,7 +42,8 @@
             "EXPIRED",
             "INVITED",
             "REGISTERED",
-            "REJECTED"
+            "REJECTED",
+            "WAITLIST"
           ]
         },
         "enrollmentDate": { "type": "string", "format": "date-time" },

--- a/functions/callNodeFunction/sendEnrollmentEmail/index.js
+++ b/functions/callNodeFunction/sendEnrollmentEmail/index.js
@@ -131,6 +131,9 @@ export default async function sendEnrollmentEmail(req, logger) {
       case 'REGISTERED':
         baseTemplateType = 'REGISTRATION_CONFIRMED';
         break;
+      case 'WAITLIST':
+        baseTemplateType = 'WAITLIST_NOTICE';
+        break;
       default:
         // Don't send emails for other status changes
         return {


### PR DESCRIPTION
## Summary
- add a new `WAITLIST` enrollment status plus DB migrations, computed participant count (`CONFIRMED + INVITED`), and Hasura metadata wiring
- route full-course registrations to waitlist with dedicated UI state and waitlist status handling on both learner and organizer views
- add `WAITLIST_NOTICE` email template support and update participant data schema plus generated GraphQL/TypeScript types

## Test plan
- [x] Apply Hasura migrations and metadata locally
- [x] Regenerate GraphQL types (`yarn apollo`)
- [ ] Verify on a full course that the button changes to waitlist mode and creates `WAITLIST` enrollment
- [ ] Verify waitlist confirmation email is queued/sent with `WAITLIST_NOTICE`
- [ ] Verify organizer Applications tab displays waitlist status and bulk email action

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Waitlist support: join-waitlist option, waitlist status display, and waitlist-specific emails/templates.
  * Active participant count exposed for courses.

* **Improvements**
  * Registration flow updated for full courses (button text, notices, modal and submission flow for waitlist).
  * Admin: bulk email action for waitlisted enrollments and sorting/indicators for WAITLIST.
  * Numeric inputs enforce numeric entry and hide char count.
  * English/German translations and API schema updated for WAITLIST.

* **Performance**
  * Added index to speed enrollment queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->