### PR TITLE
fix(statistics): hide application chart dots for future days

### DIFF
--- a/frontend-nx/apps/edu-hub/components/common/charts/TimeSeriesLineChart.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/charts/TimeSeriesLineChart.tsx
@@ -48,6 +48,7 @@ export const TimeSeriesLineChart: FC<TimeSeriesLineChartProps> = ({ data, series
               name={serie.label}
               stroke={`hsl(${(index * 137.5) % 360}, 70%, 50%)`}
               strokeWidth={2}
+              connectNulls={false}
             />
           ))}
         </LineChart>

--- a/frontend-nx/apps/edu-hub/components/pages/StatisticsContent/statistics/ApplicationStatistics.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/StatisticsContent/statistics/ApplicationStatistics.tsx
@@ -61,6 +61,17 @@ export const ApplicationStatistics: FC = () => {
     return diffDays;
   }, []);
 
+  /** X-axis "today" (days until application end) per program — used to omit future points in relative-deadline charts */
+  const programDaysUntilEndToday = useMemo(() => {
+    if (!data?.Program.length) return new Map<string, number>();
+    const todayStr = new Date().toISOString().split('T')[0];
+    const map = new Map<string, number>();
+    data.Program.forEach((p) => {
+      map.set(p.title, calculateDaysUntilEnd(todayStr, p.defaultApplicationEnd));
+    });
+    return map;
+  }, [data?.Program, calculateDaysUntilEnd]);
+
   // Process data for cumulative chart
   const cumulativeChartData = useMemo(() => {
     if (!data?.Program.length) return [];
@@ -139,13 +150,6 @@ export const ApplicationStatistics: FC = () => {
       const maxDays = Math.max(...allDays);
       const minDays = Math.min(...allDays, 0);
 
-      // "Today" on the X-axis (days until application end) per program — hide points in the calendar future
-      const todayStr = new Date().toISOString().split('T')[0];
-      const programDaysUntilEndToday = new Map<string, number>();
-      data.Program.forEach((p) => {
-        programDaysUntilEndToday.set(p.title, calculateDaysUntilEnd(todayStr, p.defaultApplicationEnd));
-      });
-
       // Build cumulative counts from max days down to min days
       const programCumulativeCounts = new Map<string, number>();
       const result: Array<{ date: string; [key: string]: any }> = [];
@@ -180,7 +184,7 @@ export const ApplicationStatistics: FC = () => {
 
       return result;
     }
-  }, [data, useActualDates, calculateDaysUntilEnd]);
+  }, [data, useActualDates, calculateDaysUntilEnd, programDaysUntilEndToday]);
 
   // Process data for daily chart
   const dailyChartData = useMemo(() => {
@@ -245,12 +249,6 @@ export const ApplicationStatistics: FC = () => {
       const maxDays = Math.max(...allDays);
       const minDays = Math.min(...allDays, 0);
 
-      const todayStr = new Date().toISOString().split('T')[0];
-      const programDaysUntilEndToday = new Map<string, number>();
-      data.Program.forEach((p) => {
-        programDaysUntilEndToday.set(p.title, calculateDaysUntilEnd(todayStr, p.defaultApplicationEnd));
-      });
-
       // Build result with all days from max to min, filling zeros where needed
       const result: Array<{ date: string; [key: string]: any }> = [];
 
@@ -273,7 +271,7 @@ export const ApplicationStatistics: FC = () => {
 
       return result;
     }
-  }, [data, useActualDates, calculateDaysUntilEnd]);
+  }, [data, useActualDates, calculateDaysUntilEnd, programDaysUntilEndToday]);
 
   // Create series configuration for charts
   const series = useMemo(

--- a/frontend-nx/apps/edu-hub/components/pages/StatisticsContent/statistics/ApplicationStatistics.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/StatisticsContent/statistics/ApplicationStatistics.tsx
@@ -139,6 +139,13 @@ export const ApplicationStatistics: FC = () => {
       const maxDays = Math.max(...allDays);
       const minDays = Math.min(...allDays, 0);
 
+      // "Today" on the X-axis (days until application end) per program — hide points in the calendar future
+      const todayStr = new Date().toISOString().split('T')[0];
+      const programDaysUntilEndToday = new Map<string, number>();
+      data.Program.forEach((p) => {
+        programDaysUntilEndToday.set(p.title, calculateDaysUntilEnd(todayStr, p.defaultApplicationEnd));
+      });
+
       // Build cumulative counts from max days down to min days
       const programCumulativeCounts = new Map<string, number>();
       const result: Array<{ date: string; [key: string]: any }> = [];
@@ -163,7 +170,9 @@ export const ApplicationStatistics: FC = () => {
         // Create entry with all cumulative counts (even if no change for this day)
         const entry: { date: string; [key: string]: any } = { date: days.toString() };
         programCumulativeCounts.forEach((count, program) => {
-          entry[program] = count;
+          const todayDU = programDaysUntilEndToday.get(program) ?? 0;
+          // X-axis decreases toward the deadline; days < todayDU are still in the future — omit series value
+          entry[program] = days < todayDU ? null : count;
         });
 
         result.push(entry);
@@ -236,14 +245,25 @@ export const ApplicationStatistics: FC = () => {
       const maxDays = Math.max(...allDays);
       const minDays = Math.min(...allDays, 0);
 
+      const todayStr = new Date().toISOString().split('T')[0];
+      const programDaysUntilEndToday = new Map<string, number>();
+      data.Program.forEach((p) => {
+        programDaysUntilEndToday.set(p.title, calculateDaysUntilEnd(todayStr, p.defaultApplicationEnd));
+      });
+
       // Build result with all days from max to min, filling zeros where needed
       const result: Array<{ date: string; [key: string]: any }> = [];
 
       for (let days = maxDays; days >= minDays; days--) {
         const entry: { date: string; [key: string]: any } = { date: days.toString() };
-        
+
         // Fill in counts for each program (0 if no enrollments for this day)
         allPrograms.forEach((program) => {
+          const todayDU = programDaysUntilEndToday.get(program) ?? 0;
+          if (days < todayDU) {
+            entry[program] = null;
+            return;
+          }
           const counts = daysMap.get(days);
           entry[program] = counts?.[program] || 0;
         });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Application statistics (cumulative and daily) when **not** using calendar dates on the X-axis compare series by "days until application end". The chart previously filled every integer day in the range, so programs whose deadline was still in the future showed a flat line with markers for "future" X positions (repeating the last known cumulative value or zero daily counts).

## Changes

- For each program, compute **today's** position on the same scale (`days until application end` from today to `defaultApplicationEnd`).
- For each chart row with X value `days`, if `days` is **less** than that program's "today" value, set the series value to **`null`** instead of a number (those X positions are still in the calendar future for that program).
- Set **`connectNulls={false}`** on `TimeSeriesLineChart` `Line` components so gaps do not span with a line.
- **Refactor:** `programDaysUntilEndToday` is built once in a shared `useMemo` and reused by both cumulative and daily chart memos (same cutoff values, no duplicate construction).

## Notes

- Only affects the **relative deadline** view (`useActualDates` unchecked). Calendar-date view is unchanged.
- Recharts omits dots and does not draw through `null` points, so the line ends at the last real day instead of extending to the right with markers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f6f0eb7a-ae45-4ecc-a830-5ac0635e5d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f6f0eb7a-ae45-4ecc-a830-5ac0635e5d7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Charts now stop drawing lines across gaps where data is missing, improving visual accuracy.
  * Application statistics charts now hide values for future days in relative-deadline mode so forecasts don’t appear prematurely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->