### PR TITLE
Program instructor Element room (admin config, invites, description tab)

### DIFF
--- a/backend/metadata/actions.graphql
+++ b/backend/metadata/actions.graphql
@@ -39,6 +39,12 @@ type Mutation {
 }
 
 type Mutation {
+  syncProgramInstructorMatrixRoom(
+    programId: Int!
+  ): SyncProgramInstructorMatrixRoomResult!
+}
+
+type Mutation {
   createEnrollmentWithAddons(
     courseId: Int!
     userId: uuid!
@@ -530,6 +536,15 @@ type CreateMatrixRoomResult {
   error: String
   partialSpaceId: String
   partialRoomId: String
+}
+
+type SyncProgramInstructorMatrixRoomResult {
+  success: Boolean!
+  messageKey: String!
+  invitedCount: Int
+  skippedCount: Int
+  details: String
+  error: String
 }
 
 type CreateEnrollmentWithAddonsResult {

--- a/backend/metadata/actions.yaml
+++ b/backend/metadata/actions.yaml
@@ -59,6 +59,16 @@ actions:
     permissions:
       - role: instructor_access
     comment: Creates Matrix program space and course room, then stores matrix ids in Hasura
+  - name: syncProgramInstructorMatrixRoom
+    definition:
+      kind: synchronous
+      handler: '{{CLOUD_FUNCTION_LINK_CALL_NODE_FUNCTION}}'
+      headers:
+        - name: secret
+          value_from_env: HASURA_CLOUD_FUNCTION_SECRET
+        - name: name
+          value: syncProgramInstructorMatrixRoom
+    comment: Invites all program course instructors to the configured Matrix instructor room
   - name: createEnrollmentWithAddons
     definition:
       kind: synchronous
@@ -407,6 +417,7 @@ custom_types:
     - name: CreateEnrollmentWithAddonsResult
     - name: CreateStripeBasePriceResult
     - name: CreateMatrixRoomResult
+    - name: SyncProgramInstructorMatrixRoomResult
     - name: CreateStripeCheckoutResult
     - name: CourseAddonMapping
     - name: GetFormbricksAddonSelectionsResult

--- a/backend/metadata/databases/default/tables/public_Program.yaml
+++ b/backend/metadata/databases/default/tables/public_Program.yaml
@@ -63,5 +63,6 @@ select_permissions:
         - title
         - defaultFormbricksEnrollmentSurveyUrl
         - matrixSpaceId
+        - matrixInstructorRoomId
       filter: {}
 update_permissions:

--- a/backend/migrations/default/1775488481066_add_column_matrixInstructorRoomId_to_Program/down.sql
+++ b/backend/migrations/default/1775488481066_add_column_matrixInstructorRoomId_to_Program/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."Program" DROP COLUMN IF EXISTS "matrixInstructorRoomId";

--- a/backend/migrations/default/1775488481066_add_column_matrixInstructorRoomId_to_Program/up.sql
+++ b/backend/migrations/default/1775488481066_add_column_matrixInstructorRoomId_to_Program/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."Program" ADD COLUMN "matrixInstructorRoomId" text NULL;
+
+COMMENT ON COLUMN "public"."Program"."matrixInstructorRoomId" IS 'Matrix room id for the program-wide instructor Element chat (!room:server); invites are sent via admin API.';

--- a/docs/FORMBRICKS_INTEGRATION_PLAN.md
+++ b/docs/FORMBRICKS_INTEGRATION_PLAN.md
@@ -121,11 +121,11 @@ Add to `update_permissions` for `instructor_access`:
 Add to `select_permissions` for all roles that need it:
 
 ```yaml
-# Add this column to select_permissions for anonymous, instructor_access, admin-ras
+# Add this column to select_permissions for anonymous, instructor_access
 - defaultFormbricksEnrollmentSurveyUrl
 ```
 
-Add to `update_permissions` for `admin-ras`:
+Add to `update_permissions` for admin (as appropriate for your deployment):
 
 ```yaml
 # Add to update_permissions columns

--- a/docs/FORMBRICKS_INTEGRATION_PLAN.md
+++ b/docs/FORMBRICKS_INTEGRATION_PLAN.md
@@ -125,12 +125,7 @@ Add to `select_permissions` for all roles that need it:
 - defaultFormbricksEnrollmentSurveyUrl
 ```
 
-Add to `update_permissions` for admin (as appropriate for your deployment):
-
-```yaml
-# Add to update_permissions columns
-- defaultFormbricksEnrollmentSurveyUrl
-```
+Note: Hasura's built-in `admin` role bypasses all table/column permissions, so no explicit `update_permissions` entry is needed for `admin`. If your deployment uses a custom elevated role (e.g. `program_manager`) that is *not* `admin`, add `defaultFormbricksEnrollmentSurveyUrl` to that role's `update_permissions` columns.
 
 **File:** `backend/metadata/databases/default/tables/public_CourseEnrollment.yaml`
 

--- a/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
+++ b/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
@@ -1378,6 +1378,7 @@ export enum Program_select_column {
   id = "id",
   lectureEnd = "lectureEnd",
   lectureStart = "lectureStart",
+  matrixInstructorRoomId = "matrixInstructorRoomId",
   matrixSpaceId = "matrixSpaceId",
   organizationId = "organizationId",
   published = "published",
@@ -1422,6 +1423,7 @@ export enum Program_update_column {
   id = "id",
   lectureEnd = "lectureEnd",
   lectureStart = "lectureStart",
+  matrixInstructorRoomId = "matrixInstructorRoomId",
   matrixSpaceId = "matrixSpaceId",
   organizationId = "organizationId",
   published = "published",
@@ -7501,6 +7503,7 @@ export interface Program_bool_exp {
   id?: Int_comparison_exp | null;
   lectureEnd?: date_comparison_exp | null;
   lectureStart?: date_comparison_exp | null;
+  matrixInstructorRoomId?: String_comparison_exp | null;
   matrixSpaceId?: String_comparison_exp | null;
   organizationId?: Int_comparison_exp | null;
   published?: Boolean_comparison_exp | null;
@@ -7533,6 +7536,7 @@ export interface Program_insert_input {
   id?: number | null;
   lectureEnd?: any | null;
   lectureStart?: any | null;
+  matrixInstructorRoomId?: string | null;
   matrixSpaceId?: string | null;
   organizationId?: number | null;
   published?: boolean | null;
@@ -7561,6 +7565,7 @@ export interface Program_max_order_by {
   id?: order_by | null;
   lectureEnd?: order_by | null;
   lectureStart?: order_by | null;
+  matrixInstructorRoomId?: order_by | null;
   matrixSpaceId?: order_by | null;
   organizationId?: order_by | null;
   shortTitle?: order_by | null;
@@ -7586,6 +7591,7 @@ export interface Program_min_order_by {
   id?: order_by | null;
   lectureEnd?: order_by | null;
   lectureStart?: order_by | null;
+  matrixInstructorRoomId?: order_by | null;
   matrixSpaceId?: order_by | null;
   organizationId?: order_by | null;
   shortTitle?: order_by | null;
@@ -7632,6 +7638,7 @@ export interface Program_order_by {
   id?: order_by | null;
   lectureEnd?: order_by | null;
   lectureStart?: order_by | null;
+  matrixInstructorRoomId?: order_by | null;
   matrixSpaceId?: order_by | null;
   organizationId?: order_by | null;
   published?: order_by | null;

--- a/frontend-nx/apps/edu-hub/components/inputs/InputField.tsx
+++ b/frontend-nx/apps/edu-hub/components/inputs/InputField.tsx
@@ -124,9 +124,17 @@ type InputFieldProps = {
   /**
    * Applied to the debounced text before sending `text` to `updateValueMutation` (e.g. normalize URLs).
    * Does not change what the user sees in the field.
-   * Return `null` to persist an empty/cleared value when the mutation accepts nullable `String`.
+   * Return `null` for empty/cleared input to persist null when the mutation accepts nullable `String`.
+   * If the user entered non-empty text and you return `null`, the mutation is skipped and an error is shown
+   * (see `transformRejectedMessage`).
    */
   transformMutationText?: (text: string) => string | null;
+
+  /**
+   * Shown when `transformMutationText` returns `null` but the trimmed input is not empty (reject invalid paste).
+   * Falls back to `common.input_field.transform_rejected` when omitted.
+   */
+  transformRejectedMessage?: string;
 
   /**
    * Callback function called after successful text update.
@@ -213,6 +221,7 @@ const InputField: React.FC<InputFieldProps> = ({
   translationTabs,
   updateValueMutation,
   transformMutationText,
+  transformRejectedMessage,
   onValueUpdated,
   refetchQueries = [],
   helpText,
@@ -379,14 +388,34 @@ const InputField: React.FC<InputFieldProps> = ({
   const debouncedUpdateText = useDebouncedCallback((newText: string) => {
     if (validateInput(newText)) {
       if (updateValueMutation) {
-        const raw = type === 'number' ? Number.parseInt(newText, 10) : newText;
-        const asString = String(raw);
-        const transformed = transformMutationText ? transformMutationText(asString) : asString;
-        const textValue =
-          transformMutationText && (transformed === null || transformed === undefined)
-            ? null
-            : transformed ?? asString;
-        lastSentValueRef.current = textValue === null ? '' : String(textValue);
+        let textValue: string | number | null;
+        if (type === 'number') {
+          const parsed = newText === '' ? null : Number.parseInt(newText, 10);
+          const numericValue = parsed !== null && !Number.isNaN(parsed) ? parsed : null;
+          if (transformMutationText) {
+            const transformed = transformMutationText(numericValue === null ? '' : String(numericValue));
+            textValue = transformed ?? null;
+          } else {
+            textValue = numericValue;
+          }
+        } else {
+          const transformed = transformMutationText ? transformMutationText(newText) : newText;
+          textValue =
+            transformMutationText && (transformed === null || transformed === undefined)
+              ? null
+              : transformed ?? newText;
+        }
+
+        const transformRejected =
+          Boolean(transformMutationText) && newText.trim() !== '' && textValue === null;
+        if (transformRejected) {
+          const msg = transformRejectedMessage ?? t('input_field.transform_rejected');
+          setErrorMessage(msg);
+          setHasBlurred(true);
+          return;
+        }
+
+        lastSentValueRef.current = newText;
         updateText({ variables: { itemId: effectiveItemIdRef.current, text: textValue } });
       } else if (onValueUpdated) {
         onValueUpdated({ text: newText });

--- a/frontend-nx/apps/edu-hub/components/inputs/InputField.tsx
+++ b/frontend-nx/apps/edu-hub/components/inputs/InputField.tsx
@@ -122,6 +122,13 @@ type InputFieldProps = {
   updateValueMutation?: DocumentNode;
 
   /**
+   * Applied to the debounced text before sending `text` to `updateValueMutation` (e.g. normalize URLs).
+   * Does not change what the user sees in the field.
+   * Return `null` to persist an empty/cleared value when the mutation accepts nullable `String`.
+   */
+  transformMutationText?: (text: string) => string | null;
+
+  /**
    * Callback function called after successful text update.
    * @param data - The data returned from the mutation.
    */
@@ -205,6 +212,7 @@ const InputField: React.FC<InputFieldProps> = ({
   value,
   translationTabs,
   updateValueMutation,
+  transformMutationText,
   onValueUpdated,
   refetchQueries = [],
   helpText,
@@ -370,10 +378,16 @@ const InputField: React.FC<InputFieldProps> = ({
 
   const debouncedUpdateText = useDebouncedCallback((newText: string) => {
     if (validateInput(newText)) {
-      lastSentValueRef.current = newText;
       if (updateValueMutation) {
-        const textValue = type === 'number' ? Number.parseInt(newText, 10) : newText;
-        updateText({ variables: { itemId: effectiveItemIdRef.current, text: String(textValue) } });
+        const raw = type === 'number' ? Number.parseInt(newText, 10) : newText;
+        const asString = String(raw);
+        const transformed = transformMutationText ? transformMutationText(asString) : asString;
+        const textValue =
+          transformMutationText && (transformed === null || transformed === undefined)
+            ? null
+            : transformed ?? asString;
+        lastSentValueRef.current = textValue === null ? '' : String(textValue);
+        updateText({ variables: { itemId: effectiveItemIdRef.current, text: textValue } });
       } else if (onValueUpdated) {
         onValueUpdated({ text: newText });
       }

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/DescriptionTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/DescriptionTab/index.tsx
@@ -1,5 +1,5 @@
 import { QueryResult } from '@apollo/client';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import Tooltip from '@mui/material/Tooltip';
 import { HelpOutline } from '@mui/icons-material';
 import { useRoleMutation } from '../../../../hooks/authedMutation';
@@ -46,6 +46,7 @@ import {
   InsertSessionAddressVariables,
 } from '../../../../queries/__generated__/InsertSessionAddress';
 import InputField from '../../../inputs/InputField';
+import { Button as ChatLinkButton } from '../../../common/Button';
 interface IProps {
   course: ManagedCourse_Course_by_pk;
   qResult: QueryResult<any, any>;
@@ -54,6 +55,14 @@ interface IProps {
 export const DescriptionTab: FC<IProps> = ({ course, qResult }) => {
   const { error, handleError, resetError } = useErrorHandler();
   const t = useTranslations('manageCourse');
+  const tCourse = useTranslations('course');
+
+  const programInstructorRoomId = course.Program?.matrixInstructorRoomId?.trim();
+  const elementBaseUrl = process.env.NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL?.replace(/\/+$/, '');
+  const programOrganizerChatLink = useMemo(() => {
+    if (!programInstructorRoomId || !elementBaseUrl) return null;
+    return `${elementBaseUrl}/#/room/${programInstructorRoomId}`;
+  }, [programInstructorRoomId, elementBaseUrl]);
 
   const [insertCourseLocation] = useRoleMutation<InsertCourseLocation, InsertCourseLocationVariables>(
     INSERT_COURSE_LOCATION,
@@ -167,6 +176,19 @@ export const DescriptionTab: FC<IProps> = ({ course, qResult }) => {
 
   return (
     <div>
+      {programOrganizerChatLink ? (
+        <div className="mb-6 flex items-center justify-center gap-3 rounded-lg border border-border-primary bg-bg-secondary p-4">
+          <p className="text-sm text-label-primary">{t('element_program_instructor_chat_prompt')}</p>
+          <ChatLinkButton
+            className="!bg-brand !text-white !border-brand hover:!bg-brand-light hover:!border-brand-light whitespace-nowrap"
+            as="a"
+            href={programOrganizerChatLink}
+            filled
+          >
+            {tCourse('general.to_course_chat')}
+          </ChatLinkButton>
+        </div>
+      ) : null}
       <div className="grid grid-cols-1 md:grid-cols-2">
         <InputField
           variant="eduhub"

--- a/frontend-nx/apps/edu-hub/components/pages/ManageProgramsContent/ExpandableProgramRow.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageProgramsContent/ExpandableProgramRow.tsx
@@ -1,7 +1,8 @@
-import { FC } from 'react';
+import { FC, useCallback, useState } from 'react';
 import { CircularProgress } from '@mui/material';
 import { useTranslations } from 'next-intl';
 import { useLazyRoleQuery } from '../../../hooks/authedQuery';
+import { useAdminMutation } from '../../../hooks/authedMutation';
 import { ProgramList_Program } from '../../../queries/__generated__/ProgramList';
 import {
   SAVE_ACHIEVEMENT_CERTIFICATE_TEMPLATE,
@@ -16,7 +17,14 @@ import {
   UPDATE_ClOSING_QUESTIONAIRE,
   UPDATE_DEFAULT_ENROLLMENT_SURVEY,
   UPDATE_PROGRAM_SHORT_TITLE,
+  UPDATE_PROGRAM_MATRIX_INSTRUCTOR_ROOM,
 } from '../../../queries/updateProgram';
+import { SYNC_PROGRAM_INSTRUCTOR_MATRIX_ROOM } from '../../../queries/syncProgramInstructorMatrixRoom';
+import {
+  SyncProgramInstructorMatrixRoom,
+  SyncProgramInstructorMatrixRoomVariables,
+} from '../../../queries/__generated__/SyncProgramInstructorMatrixRoom';
+import { normalizeMatrixRoomId, isValidMatrixRoomId } from '../../../utils/matrixRoom';
 import {
   loadParticipationData,
   loadParticipationDataVariables,
@@ -24,13 +32,62 @@ import {
 import InputField from '../../inputs/InputField';
 import { Button } from '../../common/Button';
 import FileUploadField from '../../inputs/FileUploadField';
+import NotificationSnackbar from '../../common/dialogs/NotificationSnackbar';
 interface ExpandableProgramRowProps {
   program: ProgramList_Program;
 }
 
 const ExpandableProgramRow: FC<ExpandableProgramRowProps> = ({ program }) => {
   const t = useTranslations('managePrograms');
+  const [syncNotice, setSyncNotice] = useState<{ open: boolean; message: string }>({
+    open: false,
+    message: '',
+  });
 
+  const [syncProgramInstructorRoom, { loading: syncLoading }] = useAdminMutation<
+    SyncProgramInstructorMatrixRoom,
+    SyncProgramInstructorMatrixRoomVariables
+  >(SYNC_PROGRAM_INSTRUCTOR_MATRIX_ROOM);
+
+  const transformMatrixInstructorRoomInput = useCallback((raw: string): string | null => {
+    const trimmed = raw.trim();
+    if (!trimmed) return null;
+    const normalized = normalizeMatrixRoomId(trimmed);
+    return (normalized ?? trimmed).trim() || null;
+  }, []);
+
+  const handleMatrixInstructorRoomSaved = useCallback(
+    async (data: { update_Program_by_pk?: { matrixInstructorRoomId?: string | null } | null }) => {
+      const roomId = data?.update_Program_by_pk?.matrixInstructorRoomId?.trim() ?? '';
+      if (!roomId || !isValidMatrixRoomId(roomId)) {
+        return;
+      }
+      try {
+        const res = await syncProgramInstructorRoom({ variables: { programId: program.id } });
+        const payload = res.data?.syncProgramInstructorMatrixRoom;
+        if (payload?.success) {
+          setSyncNotice({
+            open: true,
+            message: t('instructor_element_room.sync_success', {
+              invited: payload.invitedCount ?? 0,
+              skipped: payload.skippedCount ?? 0,
+            }),
+          });
+        } else {
+          setSyncNotice({
+            open: true,
+            message: payload?.error || t('instructor_element_room.sync_error'),
+          });
+        }
+      } catch (e) {
+        setSyncNotice({
+          open: true,
+          message: e instanceof Error ? e.message : t('instructor_element_room.sync_error'),
+        });
+      }
+    },
+    [program.id, syncProgramInstructorRoom, t]
+  );
 
   const [
     loadParticipationData,
@@ -49,6 +106,12 @@ const ExpandableProgramRow: FC<ExpandableProgramRowProps> = ({ program }) => {
 
   return (
     <div className="w-full flex-1 min-w-0">
+      <NotificationSnackbar
+        open={syncNotice.open}
+        message={syncNotice.message}
+        duration={6000}
+        onClose={() => setSyncNotice((s) => ({ ...s, open: false }))}
+      />
       <div className="bg-fill-primary text-label-primary p-6 w-full">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
           {/* Left Column */}
@@ -66,6 +129,30 @@ const ExpandableProgramRow: FC<ExpandableProgramRowProps> = ({ program }) => {
                 updateValueMutation={UPDATE_PROGRAM_SHORT_TITLE}
                 refetchQueries={['ProgramList']}
               />
+            </div>
+
+            {/* Instructor Element room (program-wide) */}
+            <div className="bg-fill-primary border border-border-primary rounded-lg p-4">
+              <InputField
+                variant="material"
+                type="input"
+                maxLength={500}
+                label={t('instructor_element_room.label')}
+                placeholder={t('instructor_element_room.placeholder')}
+                helpText={t('instructor_element_room.help_text')}
+                itemId={program.id}
+                value={program.matrixInstructorRoomId ?? ''}
+                updateValueMutation={UPDATE_PROGRAM_MATRIX_INSTRUCTOR_ROOM}
+                transformMutationText={transformMatrixInstructorRoomInput}
+                onValueUpdated={handleMatrixInstructorRoomSaved}
+                refetchQueries={['ProgramList']}
+              />
+              {syncLoading ? (
+                <div className="mt-2 flex items-center gap-2 text-sm text-label-secondary">
+                  <CircularProgress size={18} />
+                  {t('instructor_element_room.sync_in_progress')}
+                </div>
+              ) : null}
             </div>
 
             {/* 1. Questionnaires Card */}

--- a/frontend-nx/apps/edu-hub/components/pages/ManageProgramsContent/ExpandableProgramRow.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageProgramsContent/ExpandableProgramRow.tsx
@@ -53,13 +53,21 @@ const ExpandableProgramRow: FC<ExpandableProgramRowProps> = ({ program }) => {
     const trimmed = raw.trim();
     if (!trimmed) return null;
     const normalized = normalizeMatrixRoomId(trimmed);
-    return (normalized ?? trimmed).trim() || null;
+    if (!normalized || !isValidMatrixRoomId(normalized)) return null;
+    return normalized;
   }, []);
 
   const handleMatrixInstructorRoomSaved = useCallback(
     async (data: { update_Program_by_pk?: { matrixInstructorRoomId?: string | null } | null }) => {
       const roomId = data?.update_Program_by_pk?.matrixInstructorRoomId?.trim() ?? '';
-      if (!roomId || !isValidMatrixRoomId(roomId)) {
+      if (!roomId) {
+        return;
+      }
+      if (!isValidMatrixRoomId(roomId)) {
+        setSyncNotice({
+          open: true,
+          message: t('instructor_element_room.invalid_room_id'),
+        });
         return;
       }
       try {
@@ -144,6 +152,7 @@ const ExpandableProgramRow: FC<ExpandableProgramRowProps> = ({ program }) => {
                 value={program.matrixInstructorRoomId ?? ''}
                 updateValueMutation={UPDATE_PROGRAM_MATRIX_INSTRUCTOR_ROOM}
                 transformMutationText={transformMatrixInstructorRoomInput}
+                transformRejectedMessage={t('instructor_element_room.invalid_room_id')}
                 onValueUpdated={handleMatrixInstructorRoomSaved}
                 refetchQueries={['ProgramList']}
               />

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -216,7 +216,8 @@
       "invalid_maximum_integer": "Der Wert muss höchstens {max} sein",
       "invalid_minimum_maximum_integer": "Der Wert muss mindestens {min} und höchstens {max} sein",
       "invalid_integer_format": "Der Wert muss eine ganze Zahl sein",
-      "invalid_input": "Ungültige Eingabe"
+      "invalid_input": "Ungültige Eingabe",
+      "transform_rejected": "Dieser Wert konnte nicht im erwarteten Format gespeichert werden."
     },
     "server_side_combobox": {
       "create_option": "\"{option}\" neu hinzufügen",
@@ -1417,7 +1418,8 @@
       "help_text": "Alle Instructor:innen der Kurse dieses Programms werden zu diesem Raum eingeladen. Du kannst einen vollen Element-Link oder die Raum-ID einfügen; sie wird normalisiert gespeichert.",
       "sync_in_progress": "Matrix-Einladungen werden gesendet…",
       "sync_success": "Einladungen verarbeitet: {invited} gesendet, {skipped} übersprungen (bereits im Raum oder kein Matrix-Handle).",
-      "sync_error": "Nicht alle Matrix-Einladungen konnten gesendet werden. Prüfe die Server-Logs und die Raum-ID."
+      "sync_error": "Nicht alle Matrix-Einladungen konnten gesendet werden. Prüfe die Server-Logs und die Raum-ID.",
+      "invalid_room_id": "Die Eingabe konnte nicht als gültige Matrix-Raum-ID erkannt werden (!raum:server). Bitte prüfe den Wert und versuche es erneut."
     },
     "notifications": {
       "programs_published_success_singular": "Programm wurde erfolgreich veröffentlicht",

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1047,6 +1047,7 @@
     "evaluation": "Beurteilung",
     "send_email_to_applicants": "E-Mail an Bewerber senden",
     "element_chat_welcome_prompt": "Bitte begrüße deine Teilnehmenden im Element-Chat.",
+    "element_program_instructor_chat_prompt": "Tritt dem Programm-Instructor-Raum in Element bei, um dich mit anderen Instructor:innen abzustimmen.",
     "select_applicants_first": "Bitte wähle zuerst Bewerber aus",
     "bulk_actions": {
       "expand_collapse_rows": "Zeilen aus-/einklappen",
@@ -1409,6 +1410,14 @@
     "bulk_action": {
       "publish": "Ausgewählte veröffentlichen",
       "unpublish": "Ausgewählte zurückziehen"
+    },
+    "instructor_element_room": {
+      "label": "Element-Raum für Instructor:innen",
+      "placeholder": "Element-Raum-Link oder Matrix-Raum-ID einfügen (!raum:server)",
+      "help_text": "Alle Instructor:innen der Kurse dieses Programms werden zu diesem Raum eingeladen. Du kannst einen vollen Element-Link oder die Raum-ID einfügen; sie wird normalisiert gespeichert.",
+      "sync_in_progress": "Matrix-Einladungen werden gesendet…",
+      "sync_success": "Einladungen verarbeitet: {invited} gesendet, {skipped} übersprungen (bereits im Raum oder kein Matrix-Handle).",
+      "sync_error": "Nicht alle Matrix-Einladungen konnten gesendet werden. Prüfe die Server-Logs und die Raum-ID."
     },
     "notifications": {
       "programs_published_success_singular": "Programm wurde erfolgreich veröffentlicht",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1065,6 +1065,7 @@
     "evaluation": "Evaluation",
     "send_email_to_applicants": "Send Email to Applicants",
     "element_chat_welcome_prompt": "Please enter the Element chat and welcome your course participants.",
+    "element_program_instructor_chat_prompt": "Join the program instructor room in Element to coordinate with other instructors.",
     "select_applicants_first": "Please select applicants first",
     "bulk_actions": {
       "expand_collapse_rows": "Expand/Collapse Rows",
@@ -1424,6 +1425,14 @@
     "bulk_action": {
       "publish": "Publish Selected",
       "unpublish": "Unpublish Selected"
+    },
+    "instructor_element_room": {
+      "label": "Instructor Element room",
+      "placeholder": "Paste Element room link or Matrix room id (!room:server)",
+      "help_text": "All instructors of courses in this program are invited to this room. Paste a full Element URL or the room id; it is stored in normalized form.",
+      "sync_in_progress": "Sending Matrix invites…",
+      "sync_success": "Invites processed: {invited} sent, {skipped} skipped (already in room or no Matrix handle).",
+      "sync_error": "Could not send all Matrix invites. Check server logs and room id."
     },
     "notifications": {
       "programs_published_success_singular": "Program was successfully published",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -216,7 +216,8 @@
       "invalid_maximum_integer": "The value must be at most {max}",
       "invalid_minimum_maximum_integer": "The value must be at least {min} and at most {max}",
       "invalid_integer_format": "The value must be an integer",
-      "invalid_input": "Invalid input"
+      "invalid_input": "Invalid input",
+      "transform_rejected": "This value could not be saved in the expected format."
     },
     "server_side_combobox": {
       "create_option": "Create new entry \"{option}\"",
@@ -1432,7 +1433,8 @@
       "help_text": "All instructors of courses in this program are invited to this room. Paste a full Element URL or the room id; it is stored in normalized form.",
       "sync_in_progress": "Sending Matrix invites…",
       "sync_success": "Invites processed: {invited} sent, {skipped} skipped (already in room or no Matrix handle).",
-      "sync_error": "Could not send all Matrix invites. Check server logs and room id."
+      "sync_error": "Could not send all Matrix invites. Check server logs and room id.",
+      "invalid_room_id": "The input could not be recognized as a valid Matrix room id (!room:server). Please check the value and try again."
     },
     "notifications": {
       "programs_published_success_singular": "Program was successfully published",

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseFragment.ts
@@ -190,6 +190,10 @@ export interface AdminCourseFragment_Program {
    */
   defaultFormbricksEnrollmentSurveyUrl: string | null;
   matrixSpaceId: string | null;
+  /**
+   * Matrix room id for the program-wide instructor Element chat (!room:server); invites are sent via admin API.
+   */
+  matrixInstructorRoomId: string | null;
 }
 
 export interface AdminCourseFragment_CourseGroups_CourseGroupOption {

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseList.ts
@@ -190,6 +190,10 @@ export interface AdminCourseList_Course_Program {
    */
   defaultFormbricksEnrollmentSurveyUrl: string | null;
   matrixSpaceId: string | null;
+  /**
+   * Matrix room id for the program-wide instructor Element chat (!room:server); invites are sent via admin API.
+   */
+  matrixInstructorRoomId: string | null;
 }
 
 export interface AdminCourseList_Course_CourseGroups_CourseGroupOption {

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminProgramFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminProgramFragment.ts
@@ -78,5 +78,8 @@ export interface AdminProgramFragment {
    */
   visibility: boolean;
   matrixSpaceId: string | null;
+  /**
+   * Matrix room id for the program-wide instructor Element chat (!room:server); invites are sent via admin API.
+   */
   matrixInstructorRoomId: string | null;
 }

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminProgramFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminProgramFragment.ts
@@ -78,4 +78,5 @@ export interface AdminProgramFragment {
    */
   visibility: boolean;
   matrixSpaceId: string | null;
+  matrixInstructorRoomId: string | null;
 }

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ManagedCourse.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ManagedCourse.ts
@@ -216,6 +216,7 @@ export interface ManagedCourse_Course_by_pk_Program {
    */
   defaultFormbricksEnrollmentSurveyUrl: string | null;
   matrixSpaceId: string | null;
+  matrixInstructorRoomId: string | null;
 }
 
 export interface ManagedCourse_Course_by_pk_CourseGroups_CourseGroupOption {

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ManagedCourse.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ManagedCourse.ts
@@ -216,6 +216,9 @@ export interface ManagedCourse_Course_by_pk_Program {
    */
   defaultFormbricksEnrollmentSurveyUrl: string | null;
   matrixSpaceId: string | null;
+  /**
+   * Matrix room id for the program-wide instructor Element chat (!room:server); invites are sent via admin API.
+   */
   matrixInstructorRoomId: string | null;
 }
 

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ProgramList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ProgramList.ts
@@ -83,6 +83,9 @@ export interface ProgramList_Program {
    */
   visibility: boolean;
   matrixSpaceId: string | null;
+  /**
+   * Matrix room id for the program-wide instructor Element chat (!room:server); invites are sent via admin API.
+   */
   matrixInstructorRoomId: string | null;
   /**
    * An array relationship

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ProgramList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ProgramList.ts
@@ -83,6 +83,7 @@ export interface ProgramList_Program {
    */
   visibility: boolean;
   matrixSpaceId: string | null;
+  matrixInstructorRoomId: string | null;
   /**
    * An array relationship
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ProgramStatistics.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ProgramStatistics.ts
@@ -144,6 +144,9 @@ export interface ProgramStatistics_Program {
    */
   visibility: boolean;
   matrixSpaceId: string | null;
+  /**
+   * Matrix room id for the program-wide instructor Element chat (!room:server); invites are sent via admin API.
+   */
   matrixInstructorRoomId: string | null;
   /**
    * An array relationship

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ProgramStatistics.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ProgramStatistics.ts
@@ -144,6 +144,7 @@ export interface ProgramStatistics_Program {
    */
   visibility: boolean;
   matrixSpaceId: string | null;
+  matrixInstructorRoomId: string | null;
   /**
    * An array relationship
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/SyncProgramInstructorMatrixRoom.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/SyncProgramInstructorMatrixRoom.ts
@@ -8,7 +8,7 @@
 // ====================================================
 
 export interface SyncProgramInstructorMatrixRoom_syncProgramInstructorMatrixRoom {
-  __typename: 'SyncProgramInstructorMatrixRoomResult';
+  __typename: "SyncProgramInstructorMatrixRoomResult";
   success: boolean;
   messageKey: string;
   invitedCount: number | null;
@@ -18,6 +18,9 @@ export interface SyncProgramInstructorMatrixRoom_syncProgramInstructorMatrixRoom
 }
 
 export interface SyncProgramInstructorMatrixRoom {
+  /**
+   * Invites all program course instructors to the configured Matrix instructor room
+   */
   syncProgramInstructorMatrixRoom: SyncProgramInstructorMatrixRoom_syncProgramInstructorMatrixRoom;
 }
 

--- a/frontend-nx/apps/edu-hub/queries/__generated__/SyncProgramInstructorMatrixRoom.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/SyncProgramInstructorMatrixRoom.ts
@@ -1,0 +1,26 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: SyncProgramInstructorMatrixRoom
+// ====================================================
+
+export interface SyncProgramInstructorMatrixRoom_syncProgramInstructorMatrixRoom {
+  __typename: 'SyncProgramInstructorMatrixRoomResult';
+  success: boolean;
+  messageKey: string;
+  invitedCount: number | null;
+  skippedCount: number | null;
+  details: string | null;
+  error: string | null;
+}
+
+export interface SyncProgramInstructorMatrixRoom {
+  syncProgramInstructorMatrixRoom: SyncProgramInstructorMatrixRoom_syncProgramInstructorMatrixRoom;
+}
+
+export interface SyncProgramInstructorMatrixRoomVariables {
+  programId: number;
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateProgramMatrixInstructorRoom.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateProgramMatrixInstructorRoom.ts
@@ -8,16 +8,22 @@
 // ====================================================
 
 export interface UpdateProgramMatrixInstructorRoom_update_Program_by_pk {
-  __typename: 'Program';
+  __typename: "Program";
   id: number;
+  /**
+   * Matrix room id for the program-wide instructor Element chat (!room:server); invites are sent via admin API.
+   */
   matrixInstructorRoomId: string | null;
 }
 
 export interface UpdateProgramMatrixInstructorRoom {
+  /**
+   * update single row of the table: "Program"
+   */
   update_Program_by_pk: UpdateProgramMatrixInstructorRoom_update_Program_by_pk | null;
 }
 
 export interface UpdateProgramMatrixInstructorRoomVariables {
   itemId: number;
-  text: string | null;
+  text?: string | null;
 }

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateProgramMatrixInstructorRoom.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateProgramMatrixInstructorRoom.ts
@@ -1,0 +1,23 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: UpdateProgramMatrixInstructorRoom
+// ====================================================
+
+export interface UpdateProgramMatrixInstructorRoom_update_Program_by_pk {
+  __typename: 'Program';
+  id: number;
+  matrixInstructorRoomId: string | null;
+}
+
+export interface UpdateProgramMatrixInstructorRoom {
+  update_Program_by_pk: UpdateProgramMatrixInstructorRoom_update_Program_by_pk | null;
+}
+
+export interface UpdateProgramMatrixInstructorRoomVariables {
+  itemId: number;
+  text: string | null;
+}

--- a/frontend-nx/apps/edu-hub/queries/courseFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/courseFragment.ts
@@ -138,6 +138,7 @@ export const ADMIN_COURSE_FRAGMENT = gql`
     Program {
       ...ProgramFragmentMinimumProperties
       matrixSpaceId
+      matrixInstructorRoomId
     }
   }
 `;

--- a/frontend-nx/apps/edu-hub/queries/programFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/programFragment.ts
@@ -55,5 +55,6 @@ export const ADMIN_PROGRAM_FRAGMENT = gql`
     visibility
     defaultFormbricksEnrollmentSurveyUrl
     matrixSpaceId
+    matrixInstructorRoomId
   }
 `;

--- a/frontend-nx/apps/edu-hub/queries/syncProgramInstructorMatrixRoom.ts
+++ b/frontend-nx/apps/edu-hub/queries/syncProgramInstructorMatrixRoom.ts
@@ -1,0 +1,14 @@
+import { gql } from '@apollo/client';
+
+export const SYNC_PROGRAM_INSTRUCTOR_MATRIX_ROOM = gql`
+  mutation SyncProgramInstructorMatrixRoom($programId: Int!) {
+    syncProgramInstructorMatrixRoom(programId: $programId) {
+      success
+      messageKey
+      invitedCount
+      skippedCount
+      details
+      error
+    }
+  }
+`;

--- a/frontend-nx/apps/edu-hub/queries/updateProgram.ts
+++ b/frontend-nx/apps/edu-hub/queries/updateProgram.ts
@@ -75,6 +75,18 @@ export const UPDATE_PROGRAM_SHORT_TITLE = gql`
   }
 `;
 
+export const UPDATE_PROGRAM_MATRIX_INSTRUCTOR_ROOM = gql`
+  mutation UpdateProgramMatrixInstructorRoom($itemId: Int!, $text: String) {
+    update_Program_by_pk(
+      pk_columns: { id: $itemId }
+      _set: { matrixInstructorRoomId: $text }
+    ) {
+      id
+      matrixInstructorRoomId
+    }
+  }
+`;
+
 export const UPDATE_ATTENDANCE_CERTIFICATE_TEMPLATE = gql`
   mutation UpdateProgramParticipationTemplate(
     $programId: Int!

--- a/frontend-nx/apps/edu-hub/utils/matrixRoom.ts
+++ b/frontend-nx/apps/edu-hub/utils/matrixRoom.ts
@@ -9,13 +9,31 @@ export function normalizeMatrixRoomId(input: string | null | undefined): string 
     try {
       const u = new URL(trimmed);
       const hash = u.hash || '';
-      const hashMatch = hash.match(/#\/room\/([^?#/]+)/);
-      if (hashMatch) {
-        return decodeURIComponent(hashMatch[1]);
+      const hashNoQuery = hash.split('?')[0];
+      const elementRoom = hashNoQuery.match(/^#\/room\/([^/#]+)/);
+      if (elementRoom) {
+        try {
+          return decodeURIComponent(elementRoom[1]);
+        } catch {
+          return elementRoom[1];
+        }
+      }
+      // matrix.to: https://matrix.to/#/!room:server?via=…
+      const matrixToRoom = hashNoQuery.match(/^#\/?(![^:#?]+:[^?#/]+)/);
+      if (matrixToRoom) {
+        try {
+          return decodeURIComponent(matrixToRoom[1]);
+        } catch {
+          return matrixToRoom[1];
+        }
       }
       const pathMatch = u.pathname.match(/\/room\/([^/?#]+)/);
       if (pathMatch) {
-        return decodeURIComponent(pathMatch[1]);
+        try {
+          return decodeURIComponent(pathMatch[1]);
+        } catch {
+          return pathMatch[1];
+        }
       }
     } catch {
       /* ignore */
@@ -31,7 +49,11 @@ export function normalizeMatrixRoomId(input: string | null | undefined): string 
 
   const slashRoom = withoutQuery.match(/(?:^|\/)room\/([^/?#]+)/i);
   if (slashRoom) {
-    return decodeURIComponent(slashRoom[1]);
+    try {
+      return decodeURIComponent(slashRoom[1]);
+    } catch {
+      return slashRoom[1];
+    }
   }
 
   return withoutQuery;

--- a/frontend-nx/apps/edu-hub/utils/matrixRoom.ts
+++ b/frontend-nx/apps/edu-hub/utils/matrixRoom.ts
@@ -1,0 +1,43 @@
+/**
+ * Normalize pasted Element/Matrix room input to a canonical room id (!opaque:server).
+ */
+export function normalizeMatrixRoomId(input: string | null | undefined): string | null {
+  const trimmed = input?.trim();
+  if (!trimmed) return null;
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const u = new URL(trimmed);
+      const hash = u.hash || '';
+      const hashMatch = hash.match(/#\/room\/([^?#/]+)/);
+      if (hashMatch) {
+        return decodeURIComponent(hashMatch[1]);
+      }
+      const pathMatch = u.pathname.match(/\/room\/([^/?#]+)/);
+      if (pathMatch) {
+        return decodeURIComponent(pathMatch[1]);
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  const noFragment = trimmed.split('#')[0];
+  const withoutQuery = noFragment.split('?')[0].trim();
+
+  if (withoutQuery.startsWith('!')) {
+    return withoutQuery;
+  }
+
+  const slashRoom = withoutQuery.match(/(?:^|\/)room\/([^/?#]+)/i);
+  if (slashRoom) {
+    return decodeURIComponent(slashRoom[1]);
+  }
+
+  return withoutQuery;
+}
+
+export function isValidMatrixRoomId(roomId: string | null | undefined): boolean {
+  if (!roomId?.trim()) return false;
+  return /^![^:]+:[^:]+$/.test(roomId.trim());
+}

--- a/functions/callNodeFunction/__tests__/matrixRoomUtils.test.js
+++ b/functions/callNodeFunction/__tests__/matrixRoomUtils.test.js
@@ -13,6 +13,22 @@ test("normalizeMatrixRoomId from raw id", () => {
   assert.equal(normalizeMatrixRoomId("!xyz:domain.tld"), "!xyz:domain.tld");
 });
 
+test("normalizeMatrixRoomId strips query params from Element URL", () => {
+  assert.equal(
+    normalizeMatrixRoomId("https://matrix.example.com/#/room/!abc:example.org?via=example.org"),
+    "!abc:example.org"
+  );
+});
+
+test("normalizeMatrixRoomId from matrix.to permalink", () => {
+  assert.equal(
+    normalizeMatrixRoomId(
+      "https://matrix.to/#/!uDGcWwlZAIdpXeaMsX:opencampus.sh?via=opencampus.sh"
+    ),
+    "!uDGcWwlZAIdpXeaMsX:opencampus.sh"
+  );
+});
+
 test("isValidMatrixRoomId", () => {
   assert.equal(isValidMatrixRoomId("!abc:example.org"), true);
   assert.equal(isValidMatrixRoomId("not-a-room"), false);

--- a/functions/callNodeFunction/__tests__/matrixRoomUtils.test.js
+++ b/functions/callNodeFunction/__tests__/matrixRoomUtils.test.js
@@ -1,0 +1,19 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { normalizeMatrixRoomId, isValidMatrixRoomId } from "../lib/matrixRoomUtils.js";
+
+test("normalizeMatrixRoomId from Element hash URL", () => {
+  assert.equal(
+    normalizeMatrixRoomId("https://matrix.example.com/#/room/!abc:example.org"),
+    "!abc:example.org"
+  );
+});
+
+test("normalizeMatrixRoomId from raw id", () => {
+  assert.equal(normalizeMatrixRoomId("!xyz:domain.tld"), "!xyz:domain.tld");
+});
+
+test("isValidMatrixRoomId", () => {
+  assert.equal(isValidMatrixRoomId("!abc:example.org"), true);
+  assert.equal(isValidMatrixRoomId("not-a-room"), false);
+});

--- a/functions/callNodeFunction/__tests__/matrixRoomUtils.test.js
+++ b/functions/callNodeFunction/__tests__/matrixRoomUtils.test.js
@@ -38,6 +38,13 @@ test("normalizeMatrixRoomId from percent-encoded matrix.to hash", () => {
   );
 });
 
+test("normalizeMatrixRoomId from matrix.to v12 local-only room in hash", () => {
+  assert.equal(
+    normalizeMatrixRoomId("https://matrix.to/#/!localopaque123?via=example.org"),
+    "!localopaque123"
+  );
+});
+
 test("isValidMatrixRoomId", () => {
   assert.equal(isValidMatrixRoomId("!abc:example.org"), true);
   assert.equal(isValidMatrixRoomId("!localopaque"), true);

--- a/functions/callNodeFunction/__tests__/matrixRoomUtils.test.js
+++ b/functions/callNodeFunction/__tests__/matrixRoomUtils.test.js
@@ -29,7 +29,20 @@ test("normalizeMatrixRoomId from matrix.to permalink", () => {
   );
 });
 
+test("normalizeMatrixRoomId from percent-encoded matrix.to hash", () => {
+  assert.equal(
+    normalizeMatrixRoomId(
+      "https://matrix.to/#/%21uDGcWwlZAIdpXeaMsX%3Aopencampus.sh?via=opencampus.sh"
+    ),
+    "!uDGcWwlZAIdpXeaMsX:opencampus.sh"
+  );
+});
+
 test("isValidMatrixRoomId", () => {
   assert.equal(isValidMatrixRoomId("!abc:example.org"), true);
+  assert.equal(isValidMatrixRoomId("!localopaque"), true);
+  assert.equal(isValidMatrixRoomId("!abc:example.org:443"), true);
+  assert.equal(isValidMatrixRoomId("!abc:[2001:db8::1]:8448"), true);
+  assert.equal(isValidMatrixRoomId("!abc:192.168.0.1"), true);
   assert.equal(isValidMatrixRoomId("not-a-room"), false);
 });

--- a/functions/callNodeFunction/createMatrixRoom/index.js
+++ b/functions/callNodeFunction/createMatrixRoom/index.js
@@ -73,7 +73,7 @@ const SET_COURSE_ROOM_IF_EMPTY = `
   }
 `;
 
-const ALLOWED_ROLES = new Set(["admin", "admin-ras", "instructor_access", "instructor"]);
+const ALLOWED_ROLES = new Set(["admin", "instructor_access", "instructor"]);
 
 const trimAndNull = (value) => {
   if (value == null) return null;
@@ -299,7 +299,7 @@ const buildInstructorUsersMap = async ({ hasuraClient, courseId, serverName, log
 
 const MATRIX_FETCH_TIMEOUT_MS = 30_000;
 
-const ADMIN_ROLES = new Set(["admin", "admin-ras"]);
+const ADMIN_ROLES = new Set(["admin"]);
 
 const CHECK_INSTRUCTOR_ASSIGNMENT = `
   query CheckInstructorAssignment($courseId: Int!, $userId: uuid!) {

--- a/functions/callNodeFunction/index.js
+++ b/functions/callNodeFunction/index.js
@@ -23,6 +23,7 @@ import createEnrollmentWithAddons from "./createEnrollmentWithAddons/index.js";
 import syncGhostNewsletterSubscription from "./syncGhostNewsletterSubscription/index.js";
 import createMatrixRoom from "./createMatrixRoom/index.js";
 import updateMatrixInstructorPowerLevel from "./updateMatrixInstructorPowerLevel/index.js";
+import syncProgramInstructorMatrixRoom from "./syncProgramInstructorMatrixRoom/index.js";
 
 const require = createRequire(import.meta.url);
 let constantTimeSecretsEqual;
@@ -73,6 +74,7 @@ const functionMap = {
   createEnrollmentWithAddons,
   createMatrixRoom,
   updateMatrixInstructorPowerLevel,
+  syncProgramInstructorMatrixRoom,
   syncGhostNewsletterSubscription
 };
 

--- a/functions/callNodeFunction/lib/matrixInvite.js
+++ b/functions/callNodeFunction/lib/matrixInvite.js
@@ -90,13 +90,13 @@ export const inviteUserToMatrixRoom = async ({ homeserverUrl, token, roomId, mat
   const errcode = payload?.errcode;
   const errMsg = (payload?.error || "").toString();
 
-  const ignorable =
-    errcode === "M_UNKNOWN" ||
-    errcode === "M_FORBIDDEN" ||
-    /already/i.test(errMsg) ||
-    /member/i.test(errMsg);
+  const alreadyInRoom =
+    /already invited/i.test(errMsg) ||
+    /already in the room/i.test(errMsg) ||
+    /already joined/i.test(errMsg) ||
+    errcode === "M_ALREADY_JOINED";
 
-  if (ignorable) {
+  if (alreadyInRoom) {
     return { invited: false, skipped: true };
   }
 

--- a/functions/callNodeFunction/lib/matrixInvite.js
+++ b/functions/callNodeFunction/lib/matrixInvite.js
@@ -1,0 +1,107 @@
+import { trimAndNull } from "./matrixRoomUtils.js";
+
+const normalizeBaseUrl = (url) => url.replace(/\/+$/, "");
+
+const deriveServerName = ({ explicitServerName, mainSpaceId, adminUserId }) => {
+  if (explicitServerName) return explicitServerName;
+  if (mainSpaceId && mainSpaceId.includes(":")) {
+    return mainSpaceId.split(":").slice(1).join(":");
+  }
+  if (adminUserId && adminUserId.includes(":")) {
+    return adminUserId.split(":").slice(1).join(":");
+  }
+  return null;
+};
+
+export const toMatrixUserId = (matrixUserHandle, serverName) => {
+  const trimmed = trimAndNull(matrixUserHandle);
+  if (!trimmed) return null;
+  const withoutSigil = trimmed.startsWith("@") ? trimmed.slice(1) : trimmed;
+  if (withoutSigil.includes(":")) {
+    const [localpartRaw, ...domainParts] = withoutSigil.split(":");
+    const localpart = trimAndNull(localpartRaw);
+    const domain = trimAndNull(domainParts.join(":"));
+    if (!localpart || !domain) return null;
+    return `@${localpart}:${domain}`;
+  }
+  const localpart = trimAndNull(withoutSigil);
+  if (!localpart) return null;
+  return `@${localpart}:${serverName}`;
+};
+
+const matrixHeaders = (token) => ({
+  Authorization: `Bearer ${token}`,
+  "Content-Type": "application/json",
+});
+
+const parseMatrixResponse = async (response) => {
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch (_error) {
+    payload = null;
+  }
+
+  if (response.ok) return payload;
+
+  const error = new Error(payload?.error || `Matrix request failed with HTTP ${response.status}`);
+  error.status = response.status;
+  error.errcode = payload?.errcode;
+  throw error;
+};
+
+export const getMatrixInviteConfig = () => {
+  const homeserverUrl = trimAndNull(process.env.MATRIX_HOMESERVER_URL);
+  const token = trimAndNull(process.env.MATRIX_ADMIN_ACCESS_TOKEN);
+  const mainSpaceId = trimAndNull(process.env.MATRIX_MAIN_SPACE_ID);
+  const adminUserId = trimAndNull(process.env.MATRIX_ADMIN_USER_ID);
+  const explicitServerName = trimAndNull(process.env.MATRIX_SERVER_NAME);
+  const serverName = deriveServerName({ explicitServerName, mainSpaceId, adminUserId });
+
+  if (!homeserverUrl || !token || !serverName) return null;
+
+  return {
+    homeserverUrl: normalizeBaseUrl(homeserverUrl),
+    token,
+    serverName,
+  };
+};
+
+/**
+ * POST /_matrix/client/v3/rooms/{roomId}/invite — returns true if invite sent or redundant.
+ */
+export const inviteUserToMatrixRoom = async ({ homeserverUrl, token, roomId, matrixUserId, signal }) => {
+  const url = `${homeserverUrl}/_matrix/client/v3/rooms/${encodeURIComponent(roomId)}/invite`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: matrixHeaders(token),
+    body: JSON.stringify({ user_id: matrixUserId }),
+    signal,
+  });
+
+  if (response.ok) return { invited: true };
+
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch (_e) {
+    payload = null;
+  }
+  const errcode = payload?.errcode;
+  const errMsg = (payload?.error || "").toString();
+
+  const ignorable =
+    errcode === "M_UNKNOWN" ||
+    errcode === "M_FORBIDDEN" ||
+    /already/i.test(errMsg) ||
+    /member/i.test(errMsg);
+
+  if (ignorable) {
+    return { invited: false, skipped: true };
+  }
+
+  const error = new Error(payload?.error || `Matrix invite failed with HTTP ${response.status}`);
+  error.status = response.status;
+  error.errcode = errcode;
+  throw error;
+};

--- a/functions/callNodeFunction/lib/matrixRoomUtils.js
+++ b/functions/callNodeFunction/lib/matrixRoomUtils.js
@@ -16,13 +16,31 @@ export const normalizeMatrixRoomId = (input) => {
     try {
       const u = new URL(trimmed);
       const hash = u.hash || "";
-      const hashMatch = hash.match(/#\/room\/([^?#/]+)/);
-      if (hashMatch) {
-        return decodeURIComponent(hashMatch[1]);
+      const hashNoQuery = hash.split("?")[0];
+      const elementRoom = hashNoQuery.match(/^#\/room\/([^/#]+)/);
+      if (elementRoom) {
+        try {
+          return decodeURIComponent(elementRoom[1]);
+        } catch (_e) {
+          return elementRoom[1];
+        }
+      }
+      // matrix.to: https://matrix.to/#/!room:server?via=…
+      const matrixToRoom = hashNoQuery.match(/^#\/?(![^:#?]+:[^?#/]+)/);
+      if (matrixToRoom) {
+        try {
+          return decodeURIComponent(matrixToRoom[1]);
+        } catch (_e) {
+          return matrixToRoom[1];
+        }
       }
       const pathMatch = u.pathname.match(/\/room\/([^/?#]+)/);
       if (pathMatch) {
-        return decodeURIComponent(pathMatch[1]);
+        try {
+          return decodeURIComponent(pathMatch[1]);
+        } catch (_e) {
+          return pathMatch[1];
+        }
       }
     } catch (_e) {
       /* fall through */
@@ -38,7 +56,11 @@ export const normalizeMatrixRoomId = (input) => {
 
   const slashRoom = withoutQuery.match(/(?:^|\/)room\/([^/?#]+)/i);
   if (slashRoom) {
-    return decodeURIComponent(slashRoom[1]);
+    try {
+      return decodeURIComponent(slashRoom[1]);
+    } catch (_e) {
+      return slashRoom[1];
+    }
   }
 
   return withoutQuery;

--- a/functions/callNodeFunction/lib/matrixRoomUtils.js
+++ b/functions/callNodeFunction/lib/matrixRoomUtils.js
@@ -34,8 +34,8 @@ export const normalizeMatrixRoomId = (input) => {
           return elementRoom[1];
         }
       }
-      // matrix.to: https://matrix.to/#/!room:server?via=… (fragment may be percent-encoded)
-      const matrixToRoom = decodedHash.match(/^#\/?(![^:#?]+:[^?#/]+)/);
+      // matrix.to: https://matrix.to/#/!room?via=… or !room:server (fragment may be percent-encoded)
+      const matrixToRoom = decodedHash.match(/^#\/?(![^:#?]+(?::[^?#/]+)?)/);
       if (matrixToRoom) {
         try {
           return decodeURIComponent(matrixToRoom[1]);

--- a/functions/callNodeFunction/lib/matrixRoomUtils.js
+++ b/functions/callNodeFunction/lib/matrixRoomUtils.js
@@ -1,3 +1,5 @@
+import net from "node:net";
+
 /**
  * Normalize pasted Element/Matrix room input to a canonical room id (!opaque:server).
  * Accepts: full Element URLs, paths containing /room/, or raw !room:server ids.
@@ -17,7 +19,14 @@ export const normalizeMatrixRoomId = (input) => {
       const u = new URL(trimmed);
       const hash = u.hash || "";
       const hashNoQuery = hash.split("?")[0];
-      const elementRoom = hashNoQuery.match(/^#\/room\/([^/#]+)/);
+      const decodedHash = (() => {
+        try {
+          return decodeURIComponent(hashNoQuery);
+        } catch (_) {
+          return hashNoQuery;
+        }
+      })();
+      const elementRoom = decodedHash.match(/^#\/room\/([^/#]+)/);
       if (elementRoom) {
         try {
           return decodeURIComponent(elementRoom[1]);
@@ -25,8 +34,8 @@ export const normalizeMatrixRoomId = (input) => {
           return elementRoom[1];
         }
       }
-      // matrix.to: https://matrix.to/#/!room:server?via=…
-      const matrixToRoom = hashNoQuery.match(/^#\/?(![^:#?]+:[^?#/]+)/);
+      // matrix.to: https://matrix.to/#/!room:server?via=… (fragment may be percent-encoded)
+      const matrixToRoom = decodedHash.match(/^#\/?(![^:#?]+:[^?#/]+)/);
       if (matrixToRoom) {
         try {
           return decodeURIComponent(matrixToRoom[1]);
@@ -66,8 +75,63 @@ export const normalizeMatrixRoomId = (input) => {
   return withoutQuery;
 };
 
-/** Basic sanity check for Matrix room id shape */
+/** Matrix DNS-style hostname labels (RFC 1123 relaxed). */
+const isMatrixHostname = (host) => {
+  if (!host || host.length > 253) return false;
+  const labels = host.split(".");
+  return labels.every((label) => {
+    if (label.length < 1 || label.length > 63) return false;
+    return /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test(label);
+  });
+};
+
+/** Server part after !localpart: — hostname, host:port, IPv4, IPv4:port, [IPv6], [IPv6]:port */
+const isValidMatrixServerPart = (server) => {
+  if (!server) return false;
+  if (server.startsWith("[")) {
+    const close = server.indexOf("]");
+    if (close === -1) return false;
+    const addr = server.slice(1, close);
+    if (!net.isIPv6(addr)) return false;
+    const rest = server.slice(close + 1);
+    if (rest === "") return true;
+    const portMatch = rest.match(/^:(\d{1,5})$/);
+    if (!portMatch) return false;
+    const p = Number(portMatch[1]);
+    return p >= 1 && p <= 65535;
+  }
+  const lastColon = server.lastIndexOf(":");
+  if (lastColon !== -1) {
+    const maybePort = server.slice(lastColon + 1);
+    if (/^\d{1,5}$/.test(maybePort)) {
+      const p = Number(maybePort);
+      if (p >= 1 && p <= 65535) {
+        const hostOnly = server.slice(0, lastColon);
+        return net.isIPv4(hostOnly) || isMatrixHostname(hostOnly);
+      }
+    }
+  }
+  return net.isIPv4(server) || isMatrixHostname(server);
+};
+
+/**
+ * Basic sanity check for Matrix room id shape.
+ * Accepts v12 local-only ids (!opaque) or full ids (!opaque:server) with server as
+ * hostname, hostname:port, IPv4, or bracketed IPv6 (+ optional port).
+ */
 export const isValidMatrixRoomId = (roomId) => {
   if (!roomId || typeof roomId !== "string") return false;
-  return /^![^:]+:[^:]+$/.test(roomId.trim());
+  const trimmed = roomId.trim();
+  if (!trimmed.startsWith("!")) return false;
+  const rest = trimmed.slice(1);
+  if (!rest) return false;
+  // v12 / local-only: no server segment
+  if (!rest.includes(":")) {
+    return !/[\s#/?]/.test(rest);
+  }
+  const colonIdx = rest.indexOf(":");
+  const localpart = rest.slice(0, colonIdx);
+  const server = rest.slice(colonIdx + 1);
+  if (!localpart || !server || /[\s#/?]/.test(localpart)) return false;
+  return isValidMatrixServerPart(server);
 };

--- a/functions/callNodeFunction/lib/matrixRoomUtils.js
+++ b/functions/callNodeFunction/lib/matrixRoomUtils.js
@@ -1,0 +1,51 @@
+/**
+ * Normalize pasted Element/Matrix room input to a canonical room id (!opaque:server).
+ * Accepts: full Element URLs, paths containing /room/, or raw !room:server ids.
+ */
+export const trimAndNull = (value) => {
+  if (value == null) return null;
+  const trimmed = String(value).trim();
+  return trimmed.length === 0 ? null : trimmed;
+};
+
+export const normalizeMatrixRoomId = (input) => {
+  const trimmed = trimAndNull(input);
+  if (!trimmed) return null;
+
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      const u = new URL(trimmed);
+      const hash = u.hash || "";
+      const hashMatch = hash.match(/#\/room\/([^?#/]+)/);
+      if (hashMatch) {
+        return decodeURIComponent(hashMatch[1]);
+      }
+      const pathMatch = u.pathname.match(/\/room\/([^/?#]+)/);
+      if (pathMatch) {
+        return decodeURIComponent(pathMatch[1]);
+      }
+    } catch (_e) {
+      /* fall through */
+    }
+  }
+
+  const noFragment = trimmed.split("#")[0];
+  const withoutQuery = noFragment.split("?")[0].trim();
+
+  if (withoutQuery.startsWith("!")) {
+    return withoutQuery;
+  }
+
+  const slashRoom = withoutQuery.match(/(?:^|\/)room\/([^/?#]+)/i);
+  if (slashRoom) {
+    return decodeURIComponent(slashRoom[1]);
+  }
+
+  return withoutQuery;
+};
+
+/** Basic sanity check for Matrix room id shape */
+export const isValidMatrixRoomId = (roomId) => {
+  if (!roomId || typeof roomId !== "string") return false;
+  return /^![^:]+:[^:]+$/.test(roomId.trim());
+};

--- a/functions/callNodeFunction/syncProgramInstructorMatrixRoom/index.js
+++ b/functions/callNodeFunction/syncProgramInstructorMatrixRoom/index.js
@@ -79,18 +79,27 @@ export default async function syncProgramInstructorMatrixRoom(req, logger) {
     };
   }
 
-  const hasuraClient = ensureHasuraClient();
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), MATRIX_TIMEOUT_MS);
-
+  let timeout;
   try {
+    const hasuraClient = ensureHasuraClient();
+    const controller = new AbortController();
+    timeout = setTimeout(() => controller.abort(), MATRIX_TIMEOUT_MS);
+
     const programResult = await hasuraClient.request({
       document: GET_PROGRAM_INSTRUCTOR_ROOM,
       variables: { programId },
       signal: controller.signal,
     });
 
-    const rawRoom = trimAndNull(programResult?.Program_by_pk?.matrixInstructorRoomId);
+    if (programResult?.Program_by_pk == null) {
+      return {
+        success: false,
+        messageKey: "PROGRAM_NOT_FOUND",
+        error: "Program not found",
+      };
+    }
+
+    const rawRoom = trimAndNull(programResult.Program_by_pk.matrixInstructorRoomId);
     const roomId = normalizeMatrixRoomId(rawRoom);
 
     if (!roomId) {

--- a/functions/callNodeFunction/syncProgramInstructorMatrixRoom/index.js
+++ b/functions/callNodeFunction/syncProgramInstructorMatrixRoom/index.js
@@ -138,6 +138,8 @@ export default async function syncProgramInstructorMatrixRoom(req, logger) {
 
     let invitedCount = 0;
     let skippedCount = userIds.length - userHandleMap.size;
+    let failedCount = 0;
+    const failures = [];
 
     const CONCURRENCY = 5;
     const entries = [...userHandleMap.entries()];
@@ -154,13 +156,18 @@ export default async function syncProgramInstructorMatrixRoom(req, logger) {
         if (inv.skipped) skippedCount += 1;
         else invitedCount += 1;
       } catch (err) {
+        failedCount += 1;
+        failures.push({
+          userId: uid,
+          message: err.message,
+          errcode: err.errcode,
+        });
         logger.warn("Matrix invite failed for program instructor", {
           programId,
           userId: uid,
           errcode: err.errcode,
           message: err.message,
         });
-        skippedCount += 1;
       }
     };
 
@@ -169,20 +176,29 @@ export default async function syncProgramInstructorMatrixRoom(req, logger) {
       await Promise.all(batch.map(processInvite));
     }
 
+    const success = failedCount === 0;
+
     logger.info("Program instructor Matrix sync completed", {
       programId,
       roomId,
       invitedCount,
       skippedCount,
+      failedCount,
       userCount: userIds.length,
     });
 
     return {
-      success: true,
-      messageKey: "MATRIX_PROGRAM_INSTRUCTOR_SYNC_DONE",
+      success,
+      messageKey: success
+        ? "MATRIX_PROGRAM_INSTRUCTOR_SYNC_DONE"
+        : "MATRIX_PROGRAM_INSTRUCTOR_SYNC_INVITES_FAILED",
       invitedCount,
       skippedCount,
-      details: `Processed ${userIds.length} instructor(s)`,
+      failedCount,
+      ...(failures.length ? { failures } : {}),
+      details: success
+        ? `Processed ${userIds.length} instructor(s)`
+        : `${failedCount} Matrix invite(s) failed`,
     };
   } catch (error) {
     logger.error("syncProgramInstructorMatrixRoom failed", {

--- a/functions/callNodeFunction/syncProgramInstructorMatrixRoom/index.js
+++ b/functions/callNodeFunction/syncProgramInstructorMatrixRoom/index.js
@@ -25,9 +25,9 @@ const GET_PROGRAM_INSTRUCTOR_ROWS = `
   }
 `;
 
-const GET_USER_MATRIX_HANDLE = `
-  query GetUserMatrixHandle($userId: uuid!) {
-    User_by_pk(id: $userId) {
+const GET_USERS_MATRIX_HANDLES = `
+  query GetUsersMatrixHandles($userIds: [uuid!]!) {
+    User(where: { id: { _in: $userIds } }) {
       id
       matrixUserHandle
     }
@@ -121,27 +121,28 @@ export default async function syncProgramInstructorMatrixRoom(req, logger) {
       ...new Set((rows?.CourseInstructor || []).map((r) => r?.userId).filter(Boolean)),
     ];
 
+    const usersResult = await hasuraClient.request({
+      document: GET_USERS_MATRIX_HANDLES,
+      variables: { userIds },
+      signal: controller.signal,
+    });
+
+    const userHandleMap = new Map();
+    for (const u of usersResult?.User || []) {
+      const handle = trimAndNull(u?.matrixUserHandle);
+      if (handle) {
+        const matrixUserId = toMatrixUserId(handle, matrixConfig.serverName);
+        if (matrixUserId) userHandleMap.set(u.id, matrixUserId);
+      }
+    }
+
     let invitedCount = 0;
-    let skippedCount = 0;
+    let skippedCount = userIds.length - userHandleMap.size;
 
-    for (const uid of userIds) {
-      const userResult = await hasuraClient.request({
-        document: GET_USER_MATRIX_HANDLE,
-        variables: { userId: uid },
-        signal: controller.signal,
-      });
-      const matrixUserHandle = trimAndNull(userResult?.User_by_pk?.matrixUserHandle);
-      if (!matrixUserHandle) {
-        skippedCount += 1;
-        continue;
-      }
+    const CONCURRENCY = 5;
+    const entries = [...userHandleMap.entries()];
 
-      const matrixUserId = toMatrixUserId(matrixUserHandle, matrixConfig.serverName);
-      if (!matrixUserId) {
-        skippedCount += 1;
-        continue;
-      }
-
+    const processInvite = async ([uid, matrixUserId]) => {
       try {
         const inv = await inviteUserToMatrixRoom({
           homeserverUrl: matrixConfig.homeserverUrl,
@@ -161,6 +162,11 @@ export default async function syncProgramInstructorMatrixRoom(req, logger) {
         });
         skippedCount += 1;
       }
+    };
+
+    for (let i = 0; i < entries.length; i += CONCURRENCY) {
+      const batch = entries.slice(i, i + CONCURRENCY);
+      await Promise.all(batch.map(processInvite));
     }
 
     logger.info("Program instructor Matrix sync completed", {

--- a/functions/callNodeFunction/syncProgramInstructorMatrixRoom/index.js
+++ b/functions/callNodeFunction/syncProgramInstructorMatrixRoom/index.js
@@ -1,0 +1,195 @@
+import { GraphQLClient } from "graphql-request";
+import { trimAndNull, normalizeMatrixRoomId, isValidMatrixRoomId } from "../lib/matrixRoomUtils.js";
+import {
+  getMatrixInviteConfig,
+  inviteUserToMatrixRoom,
+  toMatrixUserId,
+} from "../lib/matrixInvite.js";
+
+const MATRIX_TIMEOUT_MS = 30_000;
+
+const GET_PROGRAM_INSTRUCTOR_ROOM = `
+  query GetProgramInstructorRoom($programId: Int!) {
+    Program_by_pk(id: $programId) {
+      id
+      matrixInstructorRoomId
+    }
+  }
+`;
+
+const GET_PROGRAM_INSTRUCTOR_ROWS = `
+  query GetProgramInstructorRows($programId: Int!) {
+    CourseInstructor(where: { Course: { programId: { _eq: $programId } } }) {
+      userId
+    }
+  }
+`;
+
+const GET_USER_MATRIX_HANDLE = `
+  query GetUserMatrixHandle($userId: uuid!) {
+    User_by_pk(id: $userId) {
+      id
+      matrixUserHandle
+    }
+  }
+`;
+
+const ensureHasuraClient = () => {
+  if (!process.env.HASURA_ENDPOINT || !process.env.HASURA_ADMIN_SECRET) {
+    throw new Error("HASURA_ENDPOINT or HASURA_ADMIN_SECRET not configured");
+  }
+  return new GraphQLClient(process.env.HASURA_ENDPOINT, {
+    headers: {
+      "x-hasura-admin-secret": process.env.HASURA_ADMIN_SECRET,
+    },
+  });
+};
+
+const ALLOWED_ROLES = new Set(["admin"]);
+
+export default async function syncProgramInstructorMatrixRoom(req, logger) {
+  logger.info("########## Sync Program Instructor Matrix Room ##########");
+
+  const role = req.body?.session_variables?.["x-hasura-role"];
+  if (!ALLOWED_ROLES.has(role)) {
+    return {
+      success: false,
+      messageKey: "MATRIX_UNAUTHORIZED",
+      error: "Insufficient permissions to sync program instructor room invites",
+    };
+  }
+
+  const input = req.body?.input || req.body || {};
+  const programId = Number(input.programId);
+
+  if (!Number.isInteger(programId) || programId <= 0) {
+    return {
+      success: false,
+      messageKey: "MATRIX_INVALID_INPUT",
+      error: "programId must be a positive integer",
+    };
+  }
+
+  const matrixConfig = getMatrixInviteConfig();
+  if (!matrixConfig) {
+    return {
+      success: false,
+      messageKey: "MATRIX_CONFIG_MISSING",
+      error: "Matrix configuration is incomplete",
+    };
+  }
+
+  const hasuraClient = ensureHasuraClient();
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), MATRIX_TIMEOUT_MS);
+
+  try {
+    const programResult = await hasuraClient.request({
+      document: GET_PROGRAM_INSTRUCTOR_ROOM,
+      variables: { programId },
+      signal: controller.signal,
+    });
+
+    const rawRoom = trimAndNull(programResult?.Program_by_pk?.matrixInstructorRoomId);
+    const roomId = normalizeMatrixRoomId(rawRoom);
+
+    if (!roomId) {
+      return {
+        success: true,
+        messageKey: "MATRIX_PROGRAM_ROOM_NOT_SET",
+        invitedCount: 0,
+        skippedCount: 0,
+        details: "Program has no matrixInstructorRoomId",
+      };
+    }
+
+    if (!isValidMatrixRoomId(roomId)) {
+      return {
+        success: false,
+        messageKey: "MATRIX_INVALID_ROOM_ID",
+        error: "matrixInstructorRoomId is not a valid Matrix room id",
+      };
+    }
+
+    const rows = await hasuraClient.request({
+      document: GET_PROGRAM_INSTRUCTOR_ROWS,
+      variables: { programId },
+      signal: controller.signal,
+    });
+
+    const userIds = [
+      ...new Set((rows?.CourseInstructor || []).map((r) => r?.userId).filter(Boolean)),
+    ];
+
+    let invitedCount = 0;
+    let skippedCount = 0;
+
+    for (const uid of userIds) {
+      const userResult = await hasuraClient.request({
+        document: GET_USER_MATRIX_HANDLE,
+        variables: { userId: uid },
+        signal: controller.signal,
+      });
+      const matrixUserHandle = trimAndNull(userResult?.User_by_pk?.matrixUserHandle);
+      if (!matrixUserHandle) {
+        skippedCount += 1;
+        continue;
+      }
+
+      const matrixUserId = toMatrixUserId(matrixUserHandle, matrixConfig.serverName);
+      if (!matrixUserId) {
+        skippedCount += 1;
+        continue;
+      }
+
+      try {
+        const inv = await inviteUserToMatrixRoom({
+          homeserverUrl: matrixConfig.homeserverUrl,
+          token: matrixConfig.token,
+          roomId,
+          matrixUserId,
+          signal: controller.signal,
+        });
+        if (inv.skipped) skippedCount += 1;
+        else invitedCount += 1;
+      } catch (err) {
+        logger.warn("Matrix invite failed for program instructor", {
+          programId,
+          userId: uid,
+          errcode: err.errcode,
+          message: err.message,
+        });
+        skippedCount += 1;
+      }
+    }
+
+    logger.info("Program instructor Matrix sync completed", {
+      programId,
+      roomId,
+      invitedCount,
+      skippedCount,
+      userCount: userIds.length,
+    });
+
+    return {
+      success: true,
+      messageKey: "MATRIX_PROGRAM_INSTRUCTOR_SYNC_DONE",
+      invitedCount,
+      skippedCount,
+      details: `Processed ${userIds.length} instructor(s)`,
+    };
+  } catch (error) {
+    logger.error("syncProgramInstructorMatrixRoom failed", {
+      programId,
+      error: error.message,
+      errcode: error.errcode,
+    });
+    return {
+      success: false,
+      messageKey: error.name === "AbortError" ? "MATRIX_TIMEOUT" : "MATRIX_SYNC_FAILED",
+      error: error.name === "AbortError" ? "Matrix request timed out" : error.message,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/functions/callNodeFunction/updateMatrixInstructorPowerLevel/index.js
+++ b/functions/callNodeFunction/updateMatrixInstructorPowerLevel/index.js
@@ -1,4 +1,10 @@
 import { GraphQLClient } from "graphql-request";
+import { trimAndNull, normalizeMatrixRoomId, isValidMatrixRoomId } from "../lib/matrixRoomUtils.js";
+import {
+  getMatrixInviteConfig,
+  inviteUserToMatrixRoom,
+  toMatrixUserId,
+} from "../lib/matrixInvite.js";
 
 const GRAPHQL_TIMEOUT_MS = 30_000;
 const MATRIX_TIMEOUT_MS = 30_000;
@@ -18,11 +24,15 @@ const withRoomLock = (roomId, fn) => {
 // Tracks previous power levels we displaced so DELETE can restore them.
 const prevInstructorPowerLevels = new Map();
 
-const GET_COURSE_MATRIX_ROOM = `
-  query GetCourseMatrixRoom($courseId: Int!) {
+const GET_COURSE_MATRIX_AND_PROGRAM = `
+  query GetCourseMatrixAndProgram($courseId: Int!) {
     Course_by_pk(id: $courseId) {
       id
       matrixRoomId
+      Program {
+        id
+        matrixInstructorRoomId
+      }
     }
   }
 `;
@@ -35,41 +45,6 @@ const GET_USER_MATRIX_HANDLE = `
     }
   }
 `;
-
-const trimAndNull = (value) => {
-  if (value == null) return null;
-  const trimmed = String(value).trim();
-  return trimmed.length === 0 ? null : trimmed;
-};
-
-const normalizeBaseUrl = (url) => url.replace(/\/+$/, "");
-
-const deriveServerName = ({ explicitServerName, mainSpaceId, adminUserId }) => {
-  if (explicitServerName) return explicitServerName;
-  if (mainSpaceId && mainSpaceId.includes(":")) {
-    return mainSpaceId.split(":").slice(1).join(":");
-  }
-  if (adminUserId && adminUserId.includes(":")) {
-    return adminUserId.split(":").slice(1).join(":");
-  }
-  return null;
-};
-
-const toMatrixUserId = (matrixUserHandle, serverName) => {
-  const trimmed = trimAndNull(matrixUserHandle);
-  if (!trimmed) return null;
-  const withoutSigil = trimmed.startsWith("@") ? trimmed.slice(1) : trimmed;
-  if (withoutSigil.includes(":")) {
-    const [localpartRaw, ...domainParts] = withoutSigil.split(":");
-    const localpart = trimAndNull(localpartRaw);
-    const domain = trimAndNull(domainParts.join(":"));
-    if (!localpart || !domain) return null;
-    return `@${localpart}:${domain}`;
-  }
-  const localpart = trimAndNull(withoutSigil);
-  if (!localpart) return null;
-  return `@${localpart}:${serverName}`;
-};
 
 const matrixHeaders = (token) => ({
   Authorization: `Bearer ${token}`,
@@ -101,23 +76,6 @@ const ensureHasuraClient = () => {
       "x-hasura-admin-secret": process.env.HASURA_ADMIN_SECRET,
     },
   });
-};
-
-const getMatrixConfig = () => {
-  const homeserverUrl = trimAndNull(process.env.MATRIX_HOMESERVER_URL);
-  const token = trimAndNull(process.env.MATRIX_ADMIN_ACCESS_TOKEN);
-  const mainSpaceId = trimAndNull(process.env.MATRIX_MAIN_SPACE_ID);
-  const adminUserId = trimAndNull(process.env.MATRIX_ADMIN_USER_ID);
-  const explicitServerName = trimAndNull(process.env.MATRIX_SERVER_NAME);
-  const serverName = deriveServerName({ explicitServerName, mainSpaceId, adminUserId });
-
-  if (!homeserverUrl || !token || !serverName) return null;
-
-  return {
-    homeserverUrl: normalizeBaseUrl(homeserverUrl),
-    token,
-    serverName,
-  };
 };
 
 const getCurrentPowerLevels = async ({ roomId, matrixConfig, signal }) => {
@@ -182,18 +140,12 @@ export default async function updateMatrixInstructorPowerLevel(req, logger) {
 
   try {
     const courseResult = await hasuraClient.request({
-      document: GET_COURSE_MATRIX_ROOM,
+      document: GET_COURSE_MATRIX_AND_PROGRAM,
       variables: { courseId },
       signal: gqlController.signal,
     });
-    const roomId = trimAndNull(courseResult?.Course_by_pk?.matrixRoomId);
-    if (!roomId) {
-      return {
-        success: true,
-        messageKey: "MATRIX_ROOM_NOT_FOUND",
-        details: "Course has no matrixRoomId yet. Skipping power-level update.",
-      };
-    }
+    const course = courseResult?.Course_by_pk;
+    const roomId = trimAndNull(course?.matrixRoomId);
 
     const userResult = await hasuraClient.request({
       document: GET_USER_MATRIX_HANDLE,
@@ -209,7 +161,7 @@ export default async function updateMatrixInstructorPowerLevel(req, logger) {
       };
     }
 
-    const matrixConfig = getMatrixConfig();
+    const matrixConfig = getMatrixInviteConfig();
     if (!matrixConfig) {
       return {
         success: false,
@@ -224,6 +176,38 @@ export default async function updateMatrixInstructorPowerLevel(req, logger) {
         success: true,
         messageKey: "MATRIX_USER_HANDLE_INVALID",
         details: "Could not derive a valid Matrix user ID from matrixUserHandle",
+      };
+    }
+
+    if (op === "INSERT") {
+      const rawProgRoom = trimAndNull(course?.Program?.matrixInstructorRoomId);
+      const programRoomId = normalizeMatrixRoomId(rawProgRoom);
+      if (programRoomId && isValidMatrixRoomId(programRoomId)) {
+        try {
+          await inviteUserToMatrixRoom({
+            homeserverUrl: matrixConfig.homeserverUrl,
+            token: matrixConfig.token,
+            roomId: programRoomId,
+            matrixUserId,
+            signal: gqlController.signal,
+          });
+        } catch (inviteErr) {
+          logger.warn("Program instructor Matrix room invite failed", {
+            courseId,
+            userId,
+            programRoomId,
+            message: inviteErr.message,
+            errcode: inviteErr.errcode,
+          });
+        }
+      }
+    }
+
+    if (!roomId) {
+      return {
+        success: true,
+        messageKey: "MATRIX_ROOM_NOT_FOUND",
+        details: "Course has no matrixRoomId yet. Skipping power-level update.",
       };
     }
 

--- a/keycloak/imports-dev/edu-hub.json
+++ b/keycloak/imports-dev/edu-hub.json
@@ -333,14 +333,6 @@
           "clientRole": true,
           "containerId": "56fe245f-6424-48b3-9118-936e3cc30671",
           "attributes": {}
-        },
-        {
-          "id": "d8e9bdab-3621-416c-97b9-2ea395d6b714",
-          "name": "admin-ras",
-          "composite": false,
-          "clientRole": true,
-          "containerId": "56fe245f-6424-48b3-9118-936e3cc30671",
-          "attributes": {}
         }
       ],
       "security-admin-console": [],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **program-wide Matrix/Element room** for instructors: admins set a normalized room id (or paste an Element URL) on **Manage programs**; all instructors of courses in that program are **invited** via the Matrix API. New instructors are **auto-invited** when added to any course (via existing `CourseInstructor` webhook). Removing an instructor from a course does **not** remove them from the program room.

## Changes

- **DB**: `Program.matrixInstructorRoomId` (migration `1775488481066_add_column_matrixInstructorRoomId_to_Program`).
- **Hasura**: `syncProgramInstructorMatrixRoom` action (admin-only); `instructor_access` can **select** the new column for manage-course UI.
- **Backend**: `syncProgramInstructorMatrixRoom` node function (bulk invite); `updateMatrixInstructorPowerLevel` invites to program room on **INSERT**; shared `lib/matrixRoomUtils.js` + `lib/matrixInvite.js`.
- **Frontend**: Manage programs expandable row field with normalization + sync after save; **Description** tab banner (Applications tab unchanged).
- **Cleanup**: Removed `admin-ras` from `createMatrixRoom`, Keycloak dev import, and docs snippet; docs `FORMBRICKS_INTEGRATION_PLAN` updated.
- **Codegen**: Apollo types regenerated against Hasura (commit `chore(graphql): regenerate Apollo types after Hasura schema sync`).

## E2E verification (local agent)

1. Started `db_hasura`, `keycloak`, `hasura`, `node_functions` via Docker Compose.
2. Confirmed DB column `Program.matrixInstructorRoomId` exists.
3. Ran `GRAPHQL_URI=http://127.0.0.1:8080/v1/graphql yarn apollo` (one pre-existing validation warning for `formbricks.ts`).
4. With a **mock Matrix homeserver** on the host (`172.18.0.1:8765`) and `MATRIX_*` env on `node_functions`, called `syncProgramInstructorMatrixRoom(programId: 5)` → `success: true`, `invitedCount: 1` after setting a user `matrixUserHandle` and program room id. Test DB values reverted afterward.

## Manual follow-up

If your Apollo run reports `Unknown argument "acceptTerms"` on `formbricks.ts`, that is a pre-existing query/schema mismatch to fix separately.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2c4efe8d-e4dc-42f3-bbf4-21a58c2d8e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2c4efe8d-e4dc-42f3-bbf4-21a58c2d8e88"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can set a program-wide Element/Matrix instructor chat room from the program UI and trigger a manual sync to invite all course instructors; UI shows progress and success/error notifications with invited/skipped counts.
  * Improved room-ID input: normalization, validation, and a clear rejection message when input is not acceptable.

* **Documentation**
  * Updated Hasura/metadata guidance regarding admin-role permission handling and deployment notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->