### PR TITLE
fix(hasura): allow instructors to update termsAcceptedAt on enrollment

### DIFF
--- a/backend/metadata/databases/default/tables/public_CourseEnrollment.yaml
+++ b/backend/metadata/databases/default/tables/public_CourseEnrollment.yaml
@@ -108,6 +108,7 @@ update_permissions:
         - motivationRating
         - status
         - location
+        - termsAcceptedAt
       filter:
         _or:
           - Course:
@@ -138,6 +139,7 @@ update_permissions:
         - motivationRating
         - status
         - location
+        - termsAcceptedAt
       filter:
         _or:
           - Course:


### PR DESCRIPTION
## Problem

Course registration fails for users with `instructor_access` or `instructor` roles with:

```
expected one of the values ['motivationRating', 'invitationExpirationDate', 'status', 'location', 'billingOrganizationId'] for type 'CourseEnrollment_update_column', but found 'termsAcceptedAt'
```

The `UPDATE_ENROLLMENT` mutation uses `insert_CourseEnrollment` with `on_conflict.update_columns: [status, termsAcceptedAt]`. Hasura intersects allowed update columns with role permissions; those roles did not include `termsAcceptedAt`.

## Solution

Add `termsAcceptedAt` to `update_permissions` for `instructor_access` and `instructor` on `CourseEnrollment`, matching `user_access`.

## Deployment

Reload Hasura metadata (or apply via CI) after merge.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated permission settings for the CourseEnrollment system to allow instructors to modify term acceptance tracking information. This extends instructor capabilities within existing role-based access controls without altering filter conditions or other permission configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->