### PR TITLE
fix(matrix): join bot to instructor room before inviting users

### DIFF
--- a/functions/callNodeFunction/lib/matrixInvite.js
+++ b/functions/callNodeFunction/lib/matrixInvite.js
@@ -64,7 +64,51 @@ export const getMatrixInviteConfig = () => {
     homeserverUrl: normalizeBaseUrl(homeserverUrl),
     token,
     serverName,
+    botUserId: adminUserId,
   };
+};
+
+/**
+ * POST /_matrix/client/v3/join/{roomId} as the token user (MATRIX_ADMIN_ACCESS_TOKEN, usually the EduHub bot).
+ * Required before inviteUserToMatrixRoom: Synapse rejects invites with "not in room" if the bot is not a member.
+ * Succeeds for public / otherwise-joinable rooms; private rooms need a one-time manual invite in Element first.
+ */
+export const ensureBotJoinedMatrixRoom = async ({ homeserverUrl, token, roomId, signal }) => {
+  const url = `${homeserverUrl}/_matrix/client/v3/join/${encodeURIComponent(roomId)}`;
+  const response = await fetch(url, {
+    method: "POST",
+    headers: matrixHeaders(token),
+    body: JSON.stringify({}),
+    signal,
+  });
+
+  if (response.ok) return { joined: true };
+
+  let payload = null;
+  try {
+    payload = await response.json();
+  } catch (_e) {
+    payload = null;
+  }
+
+  const errcode = payload?.errcode;
+  const errMsg = (payload?.error || "").toString();
+
+  const alreadyInRoom =
+    /already in the room/i.test(errMsg) ||
+    /already joined/i.test(errMsg) ||
+    errcode === "M_ALREADY_JOINED";
+
+  if (alreadyInRoom) {
+    return { joined: false, skipped: true };
+  }
+
+  const error = new Error(
+    payload?.error || `Matrix join failed with HTTP ${response.status}`
+  );
+  error.status = response.status;
+  error.errcode = errcode;
+  throw error;
 };
 
 /**

--- a/functions/callNodeFunction/syncProgramInstructorMatrixRoom/index.js
+++ b/functions/callNodeFunction/syncProgramInstructorMatrixRoom/index.js
@@ -1,6 +1,7 @@
 import { GraphQLClient } from "graphql-request";
 import { trimAndNull, normalizeMatrixRoomId, isValidMatrixRoomId } from "../lib/matrixRoomUtils.js";
 import {
+  ensureBotJoinedMatrixRoom,
   getMatrixInviteConfig,
   inviteUserToMatrixRoom,
   toMatrixUserId,
@@ -117,6 +118,28 @@ export default async function syncProgramInstructorMatrixRoom(req, logger) {
         success: false,
         messageKey: "MATRIX_INVALID_ROOM_ID",
         error: "matrixInstructorRoomId is not a valid Matrix room id",
+      };
+    }
+
+    try {
+      await ensureBotJoinedMatrixRoom({
+        homeserverUrl: matrixConfig.homeserverUrl,
+        token: matrixConfig.token,
+        roomId,
+        signal: controller.signal,
+      });
+    } catch (joinErr) {
+      const who = matrixConfig.botUserId || "the Matrix bot account (MATRIX_ADMIN_USER_ID)";
+      logger.warn("Matrix bot could not join instructor room before sync", {
+        programId,
+        roomId,
+        message: joinErr.message,
+        errcode: joinErr.errcode,
+      });
+      return {
+        success: false,
+        messageKey: "MATRIX_BOT_NOT_IN_ROOM",
+        error: `${joinErr.message} Invite ${who} to this room in Element (members list → Invite), give it permission to invite others if needed, then retry sync.`,
       };
     }
 

--- a/functions/callNodeFunction/updateMatrixInstructorPowerLevel/index.js
+++ b/functions/callNodeFunction/updateMatrixInstructorPowerLevel/index.js
@@ -1,6 +1,7 @@
 import { GraphQLClient } from "graphql-request";
 import { trimAndNull, normalizeMatrixRoomId, isValidMatrixRoomId } from "../lib/matrixRoomUtils.js";
 import {
+  ensureBotJoinedMatrixRoom,
   getMatrixInviteConfig,
   inviteUserToMatrixRoom,
   toMatrixUserId,
@@ -184,6 +185,12 @@ export default async function updateMatrixInstructorPowerLevel(req, logger) {
       const programRoomId = normalizeMatrixRoomId(rawProgRoom);
       if (programRoomId && isValidMatrixRoomId(programRoomId)) {
         try {
+          await ensureBotJoinedMatrixRoom({
+            homeserverUrl: matrixConfig.homeserverUrl,
+            token: matrixConfig.token,
+            roomId: programRoomId,
+            signal: gqlController.signal,
+          });
           await inviteUserToMatrixRoom({
             homeserverUrl: matrixConfig.homeserverUrl,
             token: matrixConfig.token,


### PR DESCRIPTION
Ensure MATRIX_ADMIN user joins via Client API so Synapse no longer rejects invites with 'not in room'. Public joinable rooms work automatically; private rooms still need a one-time manual invite. Surface MATRIX_BOT_NOT_IN_ROOM with guidance when join fails.

Made-with: Cursor