### PR TITLE
feat(program): extended application period banner on course tiles

### DIFF
--- a/backend/metadata/databases/default/tables/public_Program.yaml
+++ b/backend/metadata/databases/default/tables/public_Program.yaml
@@ -40,6 +40,7 @@ select_permissions:
         - type
         - visibility
         - defaultFormbricksEnrollmentSurveyUrl
+        - showExtendedApplicationBanner
       filter: {}
   - role: instructor_access
     permission:
@@ -64,5 +65,12 @@ select_permissions:
         - defaultFormbricksEnrollmentSurveyUrl
         - matrixSpaceId
         - matrixInstructorRoomId
+        - showExtendedApplicationBanner
       filter: {}
 update_permissions:
+  - role: admin
+    permission:
+      columns:
+        - showExtendedApplicationBanner
+      filter: {}
+      check: null

--- a/backend/migrations/default/1775813415417_add_column_showExtendedApplicationBanner_to_Program/down.sql
+++ b/backend/migrations/default/1775813415417_add_column_showExtendedApplicationBanner_to_Program/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."Program" DROP COLUMN "showExtendedApplicationBanner";

--- a/backend/migrations/default/1775813415417_add_column_showExtendedApplicationBanner_to_Program/up.sql
+++ b/backend/migrations/default/1775813415417_add_column_showExtendedApplicationBanner_to_Program/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "public"."Program"
+  ADD COLUMN "showExtendedApplicationBanner" boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN "public"."Program"."showExtendedApplicationBanner" IS 'When true, course tiles may show a banner when the program default application end has passed but a course still accepts applications.';

--- a/frontend-nx/.gitignore
+++ b/frontend-nx/.gitignore
@@ -48,6 +48,10 @@ testem.log
 .DS_Store
 Thumbs.db
 
+# Playwright (local e2e)
+/e2e/e2e-output
+/test-results
+
 # Next.js
 .next
 

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/Tile.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/Tile.tsx
@@ -8,6 +8,7 @@ import { CourseTiles_Course } from '../../../queries/__generated__/CourseTiles';
 import {
   useWeekdayStartAndEndString,
 } from '../../../helpers/dateTimeHelpers';
+import { shouldShowExtendedApplicationBanner } from '../../../helpers/courseTileExtendedApplication';
 import React from 'react';
 import { TileBase } from './TileBase';
 
@@ -22,9 +23,26 @@ export const Tile: FC<TileProps> = ({ course, isManage }) => {
   const t = useTranslations('common');
   const getWeekdayStartAndEndString = useWeekdayStartAndEndString();
 
+  const showExtendedBanner = shouldShowExtendedApplicationBanner(course);
+
+  const extendedBannerOverlay = showExtendedBanner ? (
+    <div
+      className="rounded-full border-2 border-[var(--eduhub-label-primary,#111)] bg-[#ffd6dc] px-2.5 py-1 text-center shadow-sm"
+      role="status"
+      aria-label={`${t('course_tile.extended_application_banner_en')} / ${t('course_tile.extended_application_banner_de')}`}
+    >
+      <span className="block text-[10px] font-semibold uppercase leading-tight tracking-wide text-[#b00020]">
+        {t('course_tile.extended_application_banner_en')}
+      </span>
+      <span className="mt-0.5 block text-[10px] font-semibold uppercase leading-tight tracking-wide text-[#b00020]">
+        {t('course_tile.extended_application_banner_de')}
+      </span>
+    </div>
+  ) : null;
+
   return (
     <Link href={isManage ? `/manage/course/${course.id}` : `/course/${course.id}`}>
-      <TileBase coverImage={course?.coverImage ?? null} title={course.title}>
+      <TileBase coverImage={course?.coverImage ?? null} title={course.title} imageOverlay={extendedBannerOverlay}>
         <div className="flex justify-between mb-3 text-sm tracking-wider text-label-primary">
           {course.weekDay !== 'NONE' && course.startTime && course.endTime
             ? getWeekdayStartAndEndString(course, t)

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/Tile.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/Tile.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { FC } from 'react';
-import { useTranslations } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 import { CourseList_Course } from '../../../queries/__generated__/CourseList';
 import { CoursesEnrolledByUser_Course } from '../../../queries/__generated__/CoursesEnrolledByUser';
 import { CourseTiles_Course } from '../../../queries/__generated__/CourseTiles';
@@ -21,21 +21,22 @@ interface TileProps {
 
 export const Tile: FC<TileProps> = ({ course, isManage }) => {
   const t = useTranslations('common');
+  const locale = useLocale();
   const getWeekdayStartAndEndString = useWeekdayStartAndEndString();
 
   const showExtendedBanner = shouldShowExtendedApplicationBanner(course);
+
+  const extendedBannerLabel = t('course_tile.extended_application_period');
 
   const extendedBannerOverlay = showExtendedBanner ? (
     <div
       className="rounded-full border-2 border-[var(--eduhub-label-primary,#111)] bg-[#ffd6dc] px-2.5 py-1 text-center shadow-sm"
       role="status"
-      aria-label={`${t('course_tile.extended_application_banner_en')} / ${t('course_tile.extended_application_banner_de')}`}
+      lang={locale}
+      aria-label={extendedBannerLabel}
     >
       <span className="block text-[10px] font-semibold uppercase leading-tight tracking-wide text-[#b00020]">
-        {t('course_tile.extended_application_banner_en')}
-      </span>
-      <span className="mt-0.5 block text-[10px] font-semibold uppercase leading-tight tracking-wide text-[#b00020]">
-        {t('course_tile.extended_application_banner_de')}
+        {extendedBannerLabel}
       </span>
     </div>
   ) : null;

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/TileBase.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/TileBase.tsx
@@ -5,12 +5,22 @@ interface TileBaseProps {
   coverImage: string | null;
   title: string;
   children: ReactNode;
+  /** Optional overlay on the image area (e.g. deadline notice) */
+  imageOverlay?: ReactNode;
   onClick?: () => void;
   className?: string;
   style?: React.CSSProperties;
 }
 
-const TileBaseComponent: FC<TileBaseProps> = ({ coverImage: coverImageProp, title, children, onClick, className = '', style }) => {
+const TileBaseComponent: FC<TileBaseProps> = ({
+  coverImage: coverImageProp,
+  title,
+  children,
+  imageOverlay,
+  onClick,
+  className = '',
+  style,
+}) => {
   // Initialize with placeholder immediately to prevent layout shifts
   const [coverImage, setCoverImage] = useState<string>('https://picsum.photos/240/144');
 
@@ -57,6 +67,11 @@ const TileBaseComponent: FC<TileBaseProps> = ({ coverImage: coverImageProp, titl
             background: 'linear-gradient(51.32deg, rgba(0, 0, 0, 0.7) 17.57%, rgba(0, 0, 0, 0) 85.36%)',
           }}
         ></div>
+        {imageOverlay ? (
+          <div className="absolute top-3 right-3 z-[1] max-w-[min(100%-1.5rem,14rem)] pointer-events-none">
+            {imageOverlay}
+          </div>
+        ) : null}
         <div className="absolute inset-0 flex justify-start items-end p-3">
           <span className="text-3xl text-white">{title}</span>
         </div>

--- a/frontend-nx/apps/edu-hub/components/pages/ManageProgramsContent/ExpandableProgramRow.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageProgramsContent/ExpandableProgramRow.tsx
@@ -18,7 +18,9 @@ import {
   UPDATE_DEFAULT_ENROLLMENT_SURVEY,
   UPDATE_PROGRAM_SHORT_TITLE,
   UPDATE_PROGRAM_MATRIX_INSTRUCTOR_ROOM,
+  UPDATE_PROGRAM_SHOW_EXTENDED_APPLICATION_BANNER,
 } from '../../../queries/updateProgram';
+import CheckboxSelector from '../../inputs/CheckboxSelector';
 import { SYNC_PROGRAM_INSTRUCTOR_MATRIX_ROOM } from '../../../queries/syncProgramInstructorMatrixRoom';
 import {
   SyncProgramInstructorMatrixRoom,
@@ -124,6 +126,19 @@ const ExpandableProgramRow: FC<ExpandableProgramRowProps> = ({ program }) => {
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6 w-full">
           {/* Left Column */}
           <div className="space-y-4 w-full min-w-0">
+            {/* Extended application banner (course tiles) */}
+            <div className="bg-fill-primary border border-border-primary rounded-lg p-4">
+              <CheckboxSelector
+                variant="material"
+                label={t('extended_application_banner.label')}
+                helpText={t('extended_application_banner.help_text')}
+                checked={program.showExtendedApplicationBanner ?? false}
+                updateValueMutation={UPDATE_PROGRAM_SHOW_EXTENDED_APPLICATION_BANNER}
+                identifierVariables={{ programId: program.id }}
+                refetchQueries={['ProgramList']}
+              />
+            </div>
+
             {/* 0. Short Title */}
             <div className="bg-fill-primary border border-border-primary rounded-lg p-4">
               <InputField

--- a/frontend-nx/apps/edu-hub/helpers/courseTileExtendedApplication.ts
+++ b/frontend-nx/apps/edu-hub/helpers/courseTileExtendedApplication.ts
@@ -1,0 +1,34 @@
+/**
+ * Whether to show the "extended application period" pill on a course tile.
+ * Requires the program opt-in and that the program default application end is in the past
+ * while the course application end is still open (same date logic as RegistrationButton).
+ */
+export function shouldShowExtendedApplicationBanner(course: {
+  applicationEnd: string | null | undefined;
+  Program: {
+    defaultApplicationEnd: string | null | undefined;
+    showExtendedApplicationBanner: boolean;
+  };
+}): boolean {
+  if (!course.Program.showExtendedApplicationBanner) {
+    return false;
+  }
+  const programEndRaw = course.Program.defaultApplicationEnd;
+  const courseEndRaw = course.applicationEnd;
+  if (!programEndRaw || !courseEndRaw) {
+    return false;
+  }
+
+  const now = new Date();
+  now.setHours(0, 0, 0, 0);
+
+  const programEnd = new Date(programEndRaw);
+  programEnd.setHours(0, 0, 0, 0);
+  const courseEnd = new Date(courseEndRaw);
+  courseEnd.setHours(0, 0, 0, 0);
+
+  const programDeadlinePassed = programEnd < now;
+  const courseDeadlineStillOpen = courseEnd > now;
+
+  return programDeadlinePassed && courseDeadlineStillOpen;
+}

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -26,8 +26,7 @@
     "SUNDAY": "SONNTAG",
     "place": "Ort",
     "course_tile": {
-      "extended_application_banner_en": "Extended application period",
-      "extended_application_banner_de": "Verlängerte Bewerbungsfrist"
+      "extended_application_period": "Verlängerte Bewerbungsfrist"
     },
     "addresses": "Adressen",
     "date": "Datum",

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -25,6 +25,10 @@
     "SATURDAY": "SAMSTAG",
     "SUNDAY": "SONNTAG",
     "place": "Ort",
+    "course_tile": {
+      "extended_application_banner_en": "Extended application period",
+      "extended_application_banner_de": "Verlängerte Bewerbungsfrist"
+    },
     "addresses": "Adressen",
     "date": "Datum",
     "start-time": "Startzeit",
@@ -1426,6 +1430,10 @@
     "bulk_action": {
       "publish": "Ausgewählte veröffentlichen",
       "unpublish": "Ausgewählte zurückziehen"
+    },
+    "extended_application_banner": {
+      "label": "Verlängerte Kurs-Bewerbungsfristen hervorheben",
+      "help_text": "Wenn aktiviert, erscheint auf Kurskacheln ein zweisprachiger Hinweis, solange die Standard-Bewerbungsfrist des Programms vorbei ist, der Kurs aber noch eine spätere Bewerbungsfrist hat."
     },
     "instructor_element_room": {
       "label": "Element-Raum für Kursleitungen",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -25,6 +25,10 @@
     "SATURDAY": "SATURDAY",
     "SUNDAY": "SUNDAY",
     "place": "Location",
+    "course_tile": {
+      "extended_application_banner_en": "Extended application period",
+      "extended_application_banner_de": "Verlängerte Bewerbungsfrist"
+    },
     "addresses": "Addresses",
     "date": "Date",
     "start-time": "Start time",
@@ -1441,6 +1445,10 @@
     "bulk_action": {
       "publish": "Publish Selected",
       "unpublish": "Unpublish Selected"
+    },
+    "extended_application_banner": {
+      "label": "Highlight extended course application periods",
+      "help_text": "When enabled, a bilingual notice appears on course tiles while the program’s default application deadline has passed but a course still has a later application deadline."
     },
     "instructor_element_room": {
       "label": "Instructor Element room",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -26,8 +26,7 @@
     "SUNDAY": "SUNDAY",
     "place": "Location",
     "course_tile": {
-      "extended_application_banner_en": "Extended application period",
-      "extended_application_banner_de": "Verlängerte Bewerbungsfrist"
+      "extended_application_period": "Extended application period"
     },
     "addresses": "Addresses",
     "date": "Date",

--- a/frontend-nx/apps/edu-hub/pages/dev/tile-banner-preview.tsx
+++ b/frontend-nx/apps/edu-hub/pages/dev/tile-banner-preview.tsx
@@ -1,0 +1,77 @@
+/**
+ * Visual / E2E preview for the extended-application banner on course tiles.
+ * Only available when NEXT_PUBLIC_ENABLE_TILE_BANNER_PREVIEW=true (e.g. local dev).
+ */
+import Head from 'next/head';
+import { FC } from 'react';
+import { GetServerSideProps } from 'next';
+
+import { Tile } from '../../components/common/TileSlider/Tile';
+import { CourseTiles_Course } from '../../queries/__generated__/CourseTiles';
+import { LocationOption_enum, Weekday_enum } from '../../__generated__/globalTypes';
+
+type Props = { enabled: boolean };
+
+const SAMPLE_COURSE: CourseTiles_Course = {
+  __typename: 'Course',
+  id: -1,
+  title: 'Introduction to Web Development',
+  tagline: 'In the summer semester, we focus on HTML and CSS. This beginner friendly course…',
+  coverImage: null,
+  language: 'EN',
+  weekDay: Weekday_enum.WEDNESDAY,
+  startTime: '19:00:00',
+  endTime: '20:30:00',
+  applicationEnd: '2099-12-31',
+  published: true,
+  Program: {
+    __typename: 'Program',
+    published: true,
+    title: 'Preview Program',
+    defaultApplicationEnd: '2020-01-01',
+    showExtendedApplicationBanner: true,
+  },
+  CourseLocations: [
+    {
+      __typename: 'CourseLocation',
+      locationOption: LocationOption_enum.KIEL,
+    },
+  ],
+  CourseGroups: [],
+};
+
+const TileBannerPreviewPage: FC<Props> = ({ enabled }) => {
+  if (!enabled) {
+    return (
+      <>
+        <Head>
+          <title>Not available</title>
+        </Head>
+        <p className="p-8 text-label-primary">This preview is disabled.</p>
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>Tile banner preview</title>
+      </Head>
+      <div className="p-8 bg-fill-secondary min-h-screen" data-testid="tile-banner-preview-root">
+        <p className="mb-4 text-sm text-label-secondary">
+          Preview only (set NEXT_PUBLIC_ENABLE_TILE_BANNER_PREVIEW=true). Switch locale with /de/… or /en/…
+        </p>
+        <div className="max-w-sm">
+          <Tile course={SAMPLE_COURSE} isManage={false} />
+        </div>
+      </div>
+    </>
+  );
+};
+
+export const getServerSideProps: GetServerSideProps<Props> = async () => {
+  const enabled = process.env.NEXT_PUBLIC_ENABLE_TILE_BANNER_PREVIEW === 'true';
+  return { props: { enabled } };
+};
+
+export default TileBannerPreviewPage;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminProgramFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminProgramFragment.ts
@@ -82,4 +82,8 @@ export interface AdminProgramFragment {
    * Matrix room id for the program-wide instructor Element chat (!room:server); invites are sent via admin API.
    */
   matrixInstructorRoomId: string | null;
+  /**
+   * When true, course tiles may show a notice when the program default application end has passed but a course still accepts applications.
+   */
+  showExtendedApplicationBanner: boolean;
 }

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseTileFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseTileFragment.ts
@@ -19,6 +19,14 @@ export interface CourseTileFragment_Program {
    * The title of the program
    */
   title: string;
+  /**
+   * The default application deadline for a course. It can be changed on the course level.
+   */
+  defaultApplicationEnd: any | null;
+  /**
+   * When true, course tiles may show a notice when the program default application end has passed but a course still accepts applications.
+   */
+  showExtendedApplicationBanner: boolean;
 }
 
 export interface CourseTileFragment_CourseLocations {
@@ -60,6 +68,10 @@ export interface CourseTileFragment {
    * The time the course ends each week.
    */
   endTime: any | null;
+  /**
+   * Last day before applications are closed. (Set to the program's default value when the course is created.)
+   */
+  applicationEnd: any | null;
   /**
    * Decides whether the course is published for all users or not.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseTiles.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseTiles.ts
@@ -19,6 +19,14 @@ export interface CourseTiles_Course_Program {
    * The title of the program
    */
   title: string;
+  /**
+   * The default application deadline for a course. It can be changed on the course level.
+   */
+  defaultApplicationEnd: any | null;
+  /**
+   * When true, course tiles may show a notice when the program default application end has passed but a course still accepts applications.
+   */
+  showExtendedApplicationBanner: boolean;
 }
 
 export interface CourseTiles_Course_CourseLocations {
@@ -74,6 +82,10 @@ export interface CourseTiles_Course {
    * The time the course ends each week.
    */
   endTime: any | null;
+  /**
+   * Last day before applications are closed. (Set to the program's default value when the course is created.)
+   */
+  applicationEnd: any | null;
   /**
    * Decides whether the course is published for all users or not.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseTilesByOrganization.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseTilesByOrganization.ts
@@ -19,6 +19,14 @@ export interface CourseTilesByOrganization_Course_Program {
    * The title of the program
    */
   title: string;
+  /**
+   * The default application deadline for a course. It can be changed on the course level.
+   */
+  defaultApplicationEnd: any | null;
+  /**
+   * When true, course tiles may show a notice when the program default application end has passed but a course still accepts applications.
+   */
+  showExtendedApplicationBanner: boolean;
 }
 
 export interface CourseTilesByOrganization_Course_CourseLocations {
@@ -74,6 +82,10 @@ export interface CourseTilesByOrganization_Course {
    * The time the course ends each week.
    */
   endTime: any | null;
+  /**
+   * Last day before applications are closed. (Set to the program's default value when the course is created.)
+   */
+  applicationEnd: any | null;
   /**
    * Decides whether the course is published for all users or not.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CoursesByInstructor.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CoursesByInstructor.ts
@@ -19,6 +19,14 @@ export interface CoursesByInstructor_Course_Program {
    * The title of the program
    */
   title: string;
+  /**
+   * The default application deadline for a course. It can be changed on the course level.
+   */
+  defaultApplicationEnd: any | null;
+  /**
+   * When true, course tiles may show a notice when the program default application end has passed but a course still accepts applications.
+   */
+  showExtendedApplicationBanner: boolean;
 }
 
 export interface CoursesByInstructor_Course_CourseLocations {
@@ -60,6 +68,10 @@ export interface CoursesByInstructor_Course {
    * The time the course ends each week.
    */
   endTime: any | null;
+  /**
+   * Last day before applications are closed. (Set to the program's default value when the course is created.)
+   */
+  applicationEnd: any | null;
   /**
    * Decides whether the course is published for all users or not.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CoursesEnrolledByUser.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CoursesEnrolledByUser.ts
@@ -19,6 +19,14 @@ export interface CoursesEnrolledByUser_Course_Program {
    * The title of the program
    */
   title: string;
+  /**
+   * The default application deadline for a course. It can be changed on the course level.
+   */
+  defaultApplicationEnd: any | null;
+  /**
+   * When true, course tiles may show a notice when the program default application end has passed but a course still accepts applications.
+   */
+  showExtendedApplicationBanner: boolean;
 }
 
 export interface CoursesEnrolledByUser_Course_CourseLocations {
@@ -60,6 +68,10 @@ export interface CoursesEnrolledByUser_Course {
    * The time the course ends each week.
    */
   endTime: any | null;
+  /**
+   * Last day before applications are closed. (Set to the program's default value when the course is created.)
+   */
+  applicationEnd: any | null;
   /**
    * Decides whether the course is published for all users or not.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ProgramList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ProgramList.ts
@@ -88,6 +88,10 @@ export interface ProgramList_Program {
    */
   matrixInstructorRoomId: string | null;
   /**
+   * When true, course tiles may show a notice when the program default application end has passed but a course still accepts applications.
+   */
+  showExtendedApplicationBanner: boolean;
+  /**
    * An array relationship
    */
   Courses: ProgramList_Program_Courses[];

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateProgramShowExtendedApplicationBanner.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateProgramShowExtendedApplicationBanner.ts
@@ -1,0 +1,26 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: UpdateProgramShowExtendedApplicationBanner
+// ====================================================
+
+export interface UpdateProgramShowExtendedApplicationBanner {
+  /**
+   * update data of the table: "Program"
+   */
+  update_Program_by_pk: UpdateProgramShowExtendedApplicationBanner_update_Program_by_pk | null;
+}
+
+export interface UpdateProgramShowExtendedApplicationBanner_update_Program_by_pk {
+  __typename: "Program";
+  id: number;
+  showExtendedApplicationBanner: boolean;
+}
+
+export interface UpdateProgramShowExtendedApplicationBannerVariables {
+  programId: number;
+  value: boolean;
+}

--- a/frontend-nx/apps/edu-hub/queries/courseFragements.ts
+++ b/frontend-nx/apps/edu-hub/queries/courseFragements.ts
@@ -10,10 +10,13 @@ export const COURSE_TILE_FRAGMENT = gql`
     weekDay
     startTime
     endTime
+    applicationEnd
     published
     Program {
       published
       title
+      defaultApplicationEnd
+      showExtendedApplicationBanner
     }
     CourseLocations {
       locationOption

--- a/frontend-nx/apps/edu-hub/queries/programFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/programFragment.ts
@@ -44,6 +44,7 @@ export const ADMIN_PROGRAM_FRAGMENT = gql`
   ${PROGRAM_FRAGMENT_MINIMUM_PROPERTIES}
   fragment AdminProgramFragment on Program {
     ...ProgramFragmentMinimumProperties
+    showExtendedApplicationBanner
     applicationStart
     closingQuestionnaire
     defaultApplicationEnd

--- a/frontend-nx/apps/edu-hub/queries/updateProgram.ts
+++ b/frontend-nx/apps/edu-hub/queries/updateProgram.ts
@@ -41,6 +41,15 @@ export const UPDATE_PROGRAM_VISIBILITY = gql`
   }
 `;
 
+export const UPDATE_PROGRAM_SHOW_EXTENDED_APPLICATION_BANNER = gql`
+  mutation UpdateProgramShowExtendedApplicationBanner($programId: Int!, $value: Boolean!) {
+    update_Program_by_pk(pk_columns: { id: $programId }, _set: { showExtendedApplicationBanner: $value }) {
+      id
+      showExtendedApplicationBanner
+    }
+  }
+`;
+
 export const UPDATE_PROGRAM_PUBLISHED = gql`
   mutation UpdateProgramPublished($programId: Int!, $published: Boolean!) {
     update_Program_by_pk(

--- a/frontend-nx/e2e/tile-extended-application-banner.spec.ts
+++ b/frontend-nx/e2e/tile-extended-application-banner.spec.ts
@@ -1,0 +1,42 @@
+import { test, expect } from '@playwright/test';
+import path from 'path';
+
+/**
+ * Visual regression for the course tile "extended application period" pill.
+ * Requires NEXT_PUBLIC_ENABLE_TILE_BANNER_PREVIEW=true (set in playwright.config webServer).
+ *
+ * Run from frontend-nx: `yarn test:e2e`
+ * Screenshots are written to e2e-output/ (gitignored).
+ */
+
+const outputDir = path.join(__dirname, 'e2e-output');
+
+test.describe('Extended application banner on course tile', () => {
+  test('German locale shows German label only', async ({ page }) => {
+    await page.goto('/de/dev/tile-banner-preview');
+    await expect(page.getByTestId('tile-banner-preview-root')).toBeVisible();
+    const banner = page.getByRole('status', { name: 'Verlängerte Bewerbungsfrist' });
+    await expect(banner).toBeVisible();
+    await expect(banner).toHaveAttribute('lang', 'de');
+    await expect(banner).toContainText('Verlängerte Bewerbungsfrist');
+    await expect(banner).not.toContainText('Extended application period');
+    await page.screenshot({
+      path: path.join(outputDir, 'tile-banner-de.png'),
+      fullPage: true,
+    });
+  });
+
+  test('English locale shows English label only', async ({ page }) => {
+    await page.goto('/en/dev/tile-banner-preview');
+    await expect(page.getByTestId('tile-banner-preview-root')).toBeVisible();
+    const banner = page.getByRole('status', { name: 'Extended application period' });
+    await expect(banner).toBeVisible();
+    await expect(banner).toHaveAttribute('lang', 'en');
+    await expect(banner).toContainText('Extended application period');
+    await expect(banner).not.toContainText('Verlängerte');
+    await page.screenshot({
+      path: path.join(outputDir, 'tile-banner-en.png'),
+      fullPage: true,
+    });
+  });
+});

--- a/frontend-nx/package.json
+++ b/frontend-nx/package.json
@@ -7,6 +7,7 @@
     "build": "next build apps/edu-hub",
     "start:prod": "next start apps/edu-hub -p 5000 -H 0.0.0.0",
     "test": "jest --config apps/edu-hub/jest.config.ts",
+    "test:e2e": "playwright test",
     "test:watch": "jest --config apps/edu-hub/jest.config.ts --watch",
     "lint": "eslint \"apps/edu-hub/**/*.{ts,tsx,js,jsx}\"",
     "apollo": "cd apps/edu-hub && rm -rf queries/__generated__ && mkdir -p queries/__generated__ && ../../node_modules/apollo/bin/run client:codegen --includes \"./queries/**/*.ts\" --target typescript",
@@ -89,6 +90,7 @@
   },
   "devDependencies": {
     "@eslint/compat": "^1.1.1",
+    "@playwright/test": "^1.55.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
@@ -135,7 +137,6 @@
     "jest": "29.7.0",
     "jest-environment-jsdom": "^30.2.0",
     "jest-worker": "^29.7.0",
-    "playwright": "^1.55.0",
     "postcss": "8.4.44",
     "prettier": "^3.3.3",
     "semantic-release": "^21.1.2",

--- a/frontend-nx/playwright.config.ts
+++ b/frontend-nx/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:5000',
+    trace: 'on-first-retry',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    command: 'NEXT_PUBLIC_ENABLE_TILE_BANNER_PREVIEW=true yarn start',
+    url: 'http://127.0.0.1:5000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 180_000,
+  },
+});

--- a/frontend-nx/yarn.lock
+++ b/frontend-nx/yarn.lock
@@ -3721,6 +3721,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.55.0":
+  version: 1.59.1
+  resolution: "@playwright/test@npm:1.59.1"
+  dependencies:
+    playwright: 1.59.1
+  bin:
+    playwright: cli.js
+  checksum: ce2920786b79985b255991b77af3927ba3f7b41545a4486d1893153ec5e95dffb734871935753c90eb62c8ec3c2159e434d17bda9a609a41af18e8f3f7bdc6f3
+  languageName: node
+  linkType: hard
+
 "@pnpm/config.env-replace@npm:^1.1.0":
   version: 1.1.0
   resolution: "@pnpm/config.env-replace@npm:1.1.0"
@@ -16804,6 +16815,7 @@ __metadata:
     "@mui/material-nextjs": ^7.0.0
     "@mui/styles": ^6.0.2
     "@mui/x-date-pickers": ^7.21.0
+    "@playwright/test": ^1.55.0
     "@radix-ui/react-label": ^2.1.0
     "@radix-ui/react-popover": ^1.1.2
     "@radix-ui/react-select": ^2.1.2
@@ -16882,7 +16894,6 @@ __metadata:
     next-auth: ^4.24.7
     next-intl: ^4.5.8
     papaparse: ^5.4.1
-    playwright: ^1.55.0
     postcss: 8.4.44
     prettier: ^3.3.3
     raw-body: ^2.5.2
@@ -17527,27 +17538,27 @@ __metadata:
   languageName: node
   linkType: hard
 
-"playwright-core@npm:1.55.1":
-  version: 1.55.1
-  resolution: "playwright-core@npm:1.55.1"
+"playwright-core@npm:1.59.1":
+  version: 1.59.1
+  resolution: "playwright-core@npm:1.59.1"
   bin:
     playwright-core: cli.js
-  checksum: a2b981223fd8f5c50a4e0b6cc36a3ce40b41919d418b564561f085bcd6c8ce9df2354e687fbc76e662fddb9f2b28d0bc1f0124c085958406fcab6c6cf3b8228f
+  checksum: 5835e24d181098b5cd4ee1b65dfc583bbab5724bab6af729ec79b3c24b1d02867010f355b23b1953387bf22bad03230243c4a3e5a52d7c46e8c3305dd9419a8f
   languageName: node
   linkType: hard
 
-"playwright@npm:^1.55.0":
-  version: 1.55.1
-  resolution: "playwright@npm:1.55.1"
+"playwright@npm:1.59.1":
+  version: 1.59.1
+  resolution: "playwright@npm:1.59.1"
   dependencies:
     fsevents: 2.3.2
-    playwright-core: 1.55.1
+    playwright-core: 1.59.1
   dependenciesMeta:
     fsevents:
       optional: true
   bin:
     playwright: cli.js
-  checksum: 4935122ed687cd14861d64e6fdc79613d36d45f1363e911213a338da9993525d3872d7379300471f70209e1ad68ec91c0d65f0136e6c09c0775477943aaf7fb3
+  checksum: 71ee1b525536411389860c7077d3757be25965645eb1830a0534da5ae3bf46f286730e3bf023d4ad6510c091c9333510139432d3c9a164531fdf2b81ef1aedfa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a program-level option to show a notice on course tiles when the **program default application end** (`Program.defaultApplicationEnd`) is already in the past but the **course application end** (`Course.applicationEnd`) is still in the future—aligned with the same midnight date logic used on the course registration button.

The pill shows **one language** (active UI locale): EN or DE via `common.course_tile.extended_application_period`.

## Changes

- **Database**: New boolean column `Program.showExtendedApplicationBanner` (default `false`) with migration.
- **Hasura**: Column exposed to `anonymous` and `instructor_access` for reads; `admin` role can update it.
- **Manage Programs**: Checkbox with help text in the expandable program row; persists via `UpdateProgramShowExtendedApplicationBanner`.
- **Course tiles**: Pill overlay on the cover image; `COURSE_TILE_FRAGMENT` extended with `applicationEnd` and program fields needed for the check.
- **E2E / screenshots**: Opt-in dev preview at `/[locale]/dev/tile-banner-preview` when `NEXT_PUBLIC_ENABLE_TILE_BANNER_PREVIEW=true`. Run `cd frontend-nx && yarn playwright install && yarn test:e2e` — writes `e2e/e2e-output/tile-banner-de.png` and `tile-banner-en.png`.

## Follow-up

After deploying migrations, run Apollo codegen so generated types stay in sync with the live schema:

`cd frontend-nx && GRAPHQL_URI=http://localhost:8080/v1/graphql yarn apollo`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3760a8bd-66dc-4dd2-9c81-452abf080c6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3760a8bd-66dc-4dd2-9c81-452abf080c6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

