### PR TITLE
Add program-level extended application banner on course tiles

### DIFF
--- a/backend/metadata/databases/default/tables/public_Program.yaml
+++ b/backend/metadata/databases/default/tables/public_Program.yaml
@@ -30,6 +30,7 @@ select_permissions:
         - achievementRecordUploadDeadline
         - applicationStart
         - defaultApplicationEnd
+        - showExtendedApplicationPeriodBanner
         - id
         - lectureEnd
         - organizationId
@@ -64,5 +65,6 @@ select_permissions:
         - defaultFormbricksEnrollmentSurveyUrl
         - matrixSpaceId
         - matrixInstructorRoomId
+        - showExtendedApplicationPeriodBanner
       filter: {}
 update_permissions:

--- a/backend/migrations/default/1775816398380_add_column_show_extended_application_period_banner_to_program/down.sql
+++ b/backend/migrations/default/1775816398380_add_column_show_extended_application_period_banner_to_program/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "public"."Program"
+DROP COLUMN IF EXISTS "showExtendedApplicationPeriodBanner";

--- a/backend/migrations/default/1775816398380_add_column_show_extended_application_period_banner_to_program/up.sql
+++ b/backend/migrations/default/1775816398380_add_column_show_extended_application_period_banner_to_program/up.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "public"."Program"
+ADD COLUMN "showExtendedApplicationPeriodBanner" boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN "public"."Program"."showExtendedApplicationPeriodBanner" IS
+'Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.';

--- a/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
+++ b/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
@@ -1383,6 +1383,7 @@ export enum Program_select_column {
   organizationId = "organizationId",
   published = "published",
   shortTitle = "shortTitle",
+  showExtendedApplicationPeriodBanner = "showExtendedApplicationPeriodBanner",
   speakerQuestionnaire = "speakerQuestionnaire",
   startQuestionnaire = "startQuestionnaire",
   title = "title",
@@ -1395,6 +1396,7 @@ export enum Program_select_column {
  */
 export enum Program_select_column_Program_aggregate_bool_exp_bool_and_arguments_columns {
   published = "published",
+  showExtendedApplicationPeriodBanner = "showExtendedApplicationPeriodBanner",
   visibility = "visibility",
 }
 
@@ -1403,6 +1405,7 @@ export enum Program_select_column_Program_aggregate_bool_exp_bool_and_arguments_
  */
 export enum Program_select_column_Program_aggregate_bool_exp_bool_or_arguments_columns {
   published = "published",
+  showExtendedApplicationPeriodBanner = "showExtendedApplicationPeriodBanner",
   visibility = "visibility",
 }
 
@@ -1428,6 +1431,7 @@ export enum Program_update_column {
   organizationId = "organizationId",
   published = "published",
   shortTitle = "shortTitle",
+  showExtendedApplicationPeriodBanner = "showExtendedApplicationPeriodBanner",
   speakerQuestionnaire = "speakerQuestionnaire",
   startQuestionnaire = "startQuestionnaire",
   title = "title",
@@ -7508,6 +7512,7 @@ export interface Program_bool_exp {
   organizationId?: Int_comparison_exp | null;
   published?: Boolean_comparison_exp | null;
   shortTitle?: String_comparison_exp | null;
+  showExtendedApplicationPeriodBanner?: Boolean_comparison_exp | null;
   speakerQuestionnaire?: String_comparison_exp | null;
   startQuestionnaire?: String_comparison_exp | null;
   title?: String_comparison_exp | null;
@@ -7541,6 +7546,7 @@ export interface Program_insert_input {
   organizationId?: number | null;
   published?: boolean | null;
   shortTitle?: string | null;
+  showExtendedApplicationPeriodBanner?: boolean | null;
   speakerQuestionnaire?: string | null;
   startQuestionnaire?: string | null;
   title?: string | null;
@@ -7643,6 +7649,7 @@ export interface Program_order_by {
   organizationId?: order_by | null;
   published?: order_by | null;
   shortTitle?: order_by | null;
+  showExtendedApplicationPeriodBanner?: order_by | null;
   speakerQuestionnaire?: order_by | null;
   startQuestionnaire?: order_by | null;
   title?: order_by | null;

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/Tile.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/Tile.tsx
@@ -10,6 +10,7 @@ import {
 } from '../../../helpers/dateTimeHelpers';
 import React from 'react';
 import { TileBase } from './TileBase';
+import { shouldShowExtendedApplicationBanner } from './extendedApplicationBanner';
 
 type CourseType = CourseList_Course | CoursesEnrolledByUser_Course | CourseTiles_Course;
 
@@ -21,10 +22,19 @@ interface TileProps {
 export const Tile: FC<TileProps> = ({ course, isManage }) => {
   const t = useTranslations('common');
   const getWeekdayStartAndEndString = useWeekdayStartAndEndString();
+  const showExtendedApplicationBanner = shouldShowExtendedApplicationBanner(
+    course.applicationEnd ? new Date(course.applicationEnd) : null,
+    course.Program.defaultApplicationEnd ? new Date(course.Program.defaultApplicationEnd) : null,
+    Boolean(course.Program.showExtendedApplicationPeriodBanner)
+  );
 
   return (
     <Link href={isManage ? `/manage/course/${course.id}` : `/course/${course.id}`}>
-      <TileBase coverImage={course?.coverImage ?? null} title={course.title}>
+      <TileBase
+        coverImage={course?.coverImage ?? null}
+        title={course.title}
+        bannerText={showExtendedApplicationBanner ? t('course_tile.extended_application_period_badge') : null}
+      >
         <div className="flex justify-between mb-3 text-sm tracking-wider text-label-primary">
           {course.weekDay !== 'NONE' && course.startTime && course.endTime
             ? getWeekdayStartAndEndString(course, t)

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/TileBase.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/TileBase.tsx
@@ -5,12 +5,21 @@ interface TileBaseProps {
   coverImage: string | null;
   title: string;
   children: ReactNode;
+  bannerText?: string | null;
   onClick?: () => void;
   className?: string;
   style?: React.CSSProperties;
 }
 
-const TileBaseComponent: FC<TileBaseProps> = ({ coverImage: coverImageProp, title, children, onClick, className = '', style }) => {
+const TileBaseComponent: FC<TileBaseProps> = ({
+  coverImage: coverImageProp,
+  title,
+  children,
+  bannerText,
+  onClick,
+  className = '',
+  style,
+}) => {
   // Initialize with placeholder immediately to prevent layout shifts
   const [coverImage, setCoverImage] = useState<string>('https://picsum.photos/240/144');
 
@@ -51,6 +60,11 @@ const TileBaseComponent: FC<TileBaseProps> = ({ coverImage: coverImageProp, titl
             backgroundImage: `url("${coverImage}")`,
           }}
         ></div>
+        {bannerText ? (
+          <div className="absolute right-3 top-3 z-20 max-w-[80%] rounded-full border border-[#222222] bg-warning px-3 py-1 text-xs font-semibold text-[#222222] shadow-sm">
+            {bannerText}
+          </div>
+        ) : null}
         <div
           className="absolute inset-0"
           style={{

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/TileBase.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/TileBase.tsx
@@ -61,7 +61,7 @@ const TileBaseComponent: FC<TileBaseProps> = ({
           }}
         ></div>
         {bannerText ? (
-          <div className="absolute right-3 top-3 z-20 max-w-[80%] rounded-full border border-[#222222] bg-warning px-3 py-1 text-xs font-semibold text-[#222222] shadow-sm">
+          <div className="absolute right-3 top-3 z-20 max-w-[80%] rounded-full border border-border-primary bg-warning px-3 py-1 text-xs font-semibold text-label-primary shadow-sm">
             {bannerText}
           </div>
         ) : null}

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/TileWidget.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/TileWidget.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../../helpers/dateTimeHelpers';
 import React from 'react';
 import { TileBase } from './TileBase';
+import { shouldShowExtendedApplicationBanner } from './extendedApplicationBanner';
 
 type CourseType = CourseList_Course | CoursesEnrolledByUser_Course | CourseTiles_Course;
 
@@ -40,6 +41,11 @@ const getBaseUrl = (): string => {
 export const TileWidget: FC<TileWidgetProps> = ({ course }) => {
   const t = useTranslations('common');
   const getWeekdayStartAndEndString = useWeekdayStartAndEndString();
+  const showExtendedApplicationBanner = shouldShowExtendedApplicationBanner(
+    course.applicationEnd ? new Date(course.applicationEnd) : null,
+    course.Program.defaultApplicationEnd ? new Date(course.Program.defaultApplicationEnd) : null,
+    Boolean(course.Program.showExtendedApplicationPeriodBanner)
+  );
 
   const baseUrl = getBaseUrl();
   const courseUrl = `${baseUrl}/course/${course.id}`;
@@ -49,6 +55,7 @@ export const TileWidget: FC<TileWidgetProps> = ({ course }) => {
       <TileBase 
         coverImage={course?.coverImage ?? null} 
         title={course.title} 
+        bannerText={showExtendedApplicationBanner ? t('course_tile.extended_application_period_badge') : null}
         className="shadow-lg"
         style={{ boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15), 0 2px 4px rgba(0, 0, 0, 0.1)' }}
       >

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/extendedApplicationBanner.ts
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/extendedApplicationBanner.ts
@@ -1,0 +1,20 @@
+export const shouldShowExtendedApplicationBanner = (
+  applicationEnd: Date | null,
+  programApplicationEnd: Date | null,
+  programBannerEnabled: boolean
+): boolean => {
+  if (!programBannerEnabled || !applicationEnd || !programApplicationEnd) {
+    return false;
+  }
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const normalizedCourseEnd = new Date(applicationEnd);
+  normalizedCourseEnd.setHours(0, 0, 0, 0);
+
+  const normalizedProgramEnd = new Date(programApplicationEnd);
+  normalizedProgramEnd.setHours(0, 0, 0, 0);
+
+  return normalizedProgramEnd <= today && normalizedCourseEnd > today;
+};

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/extendedApplicationBanner.ts
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/extendedApplicationBanner.ts
@@ -7,14 +7,12 @@ export const shouldShowExtendedApplicationBanner = (
     return false;
   }
 
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  const toUtcDayStart = (date: Date): number =>
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
 
-  const normalizedCourseEnd = new Date(applicationEnd);
-  normalizedCourseEnd.setHours(0, 0, 0, 0);
+  const todayUtc = toUtcDayStart(new Date());
+  const normalizedCourseEndUtc = toUtcDayStart(new Date(applicationEnd));
+  const normalizedProgramEndUtc = toUtcDayStart(new Date(programApplicationEnd));
 
-  const normalizedProgramEnd = new Date(programApplicationEnd);
-  normalizedProgramEnd.setHours(0, 0, 0, 0);
-
-  return normalizedProgramEnd <= today && normalizedCourseEnd > today;
+  return normalizedProgramEndUtc <= todayUtc && normalizedCourseEndUtc > todayUtc;
 };

--- a/frontend-nx/apps/edu-hub/components/pages/ManageProgramsContent/ExpandableProgramRow.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageProgramsContent/ExpandableProgramRow.tsx
@@ -18,7 +18,9 @@ import {
   UPDATE_DEFAULT_ENROLLMENT_SURVEY,
   UPDATE_PROGRAM_SHORT_TITLE,
   UPDATE_PROGRAM_MATRIX_INSTRUCTOR_ROOM,
+  UPDATE_PROGRAM_SHOW_EXTENDED_APPLICATION_PERIOD_BANNER,
 } from '../../../queries/updateProgram';
+import CheckboxSelector from '../../inputs/CheckboxSelector';
 import { SYNC_PROGRAM_INSTRUCTOR_MATRIX_ROOM } from '../../../queries/syncProgramInstructorMatrixRoom';
 import {
   SyncProgramInstructorMatrixRoom,
@@ -162,6 +164,19 @@ const ExpandableProgramRow: FC<ExpandableProgramRowProps> = ({ program }) => {
                   {t('instructor_element_room.sync_in_progress')}
                 </div>
               ) : null}
+            </div>
+
+            {/* Extended application period banner */}
+            <div className="bg-fill-primary border border-border-primary rounded-lg p-4">
+              <CheckboxSelector
+                variant="material"
+                label={t('extended_application_banner.label')}
+                helpText={t('extended_application_banner.help_text')}
+                checked={Boolean(program.showExtendedApplicationPeriodBanner)}
+                updateValueMutation={UPDATE_PROGRAM_SHOW_EXTENDED_APPLICATION_PERIOD_BANNER}
+                identifierVariables={{ programId: program.id }}
+                refetchQueries={['ProgramList']}
+              />
             </div>
 
             {/* 1. Questionnaires Card */}

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -244,6 +244,9 @@
     },
     "session_expired_notification": "Deine Sitzung ist abgelaufen. Bitte melde dich erneut an, um fortzufahren.",
     "tile_slider_unavailable": "Kachel-Slider vorübergehend nicht verfügbar",
+    "course_tile": {
+      "extended_application_period_badge": "Verlängerte Anmeldefrist"
+    },
     "no_description_available": "Keine Beschreibung verfügbar",
     "error_handling": {
       "certificate_generation_failed": "Fehler beim Erstellen der Leistungsnachweise. Bitte versuche es erneut.",
@@ -1435,6 +1438,10 @@
       "sync_success": "Einladungen verarbeitet: {invited} gesendet, {skipped} übersprungen (bereits im Raum oder kein Matrix-Handle).",
       "sync_error": "Nicht alle Matrix-Einladungen konnten gesendet werden. Prüfe die Server-Logs und die Raum-ID.",
       "invalid_room_id": "Die Eingabe konnte nicht als gültige Matrix-Raum-ID erkannt werden (!raum:server). Bitte prüfe den Wert und versuche es erneut."
+    },
+    "extended_application_banner": {
+      "label": "Badge „Verlängerte Anmeldefrist“ auf Kurskacheln anzeigen",
+      "help_text": "Wenn diese Option aktiv ist, wird auf allen Kurskacheln dieses Programms ein Badge angezeigt, sobald das Bewerbungsende des Programms überschritten ist – aber nur solange das individuelle Bewerbungsende des jeweiligen Kurses noch in der Zukunft liegt."
     },
     "notifications": {
       "programs_published_success_singular": "Programm wurde erfolgreich veröffentlicht",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -244,6 +244,9 @@
     },
     "session_expired_notification": "Your session has expired. Please log in again to continue.",
     "tile_slider_unavailable": "Tile slider temporarily unavailable",
+    "course_tile": {
+      "extended_application_period_badge": "Extended application period"
+    },
     "no_description_available": "No description available",
     "error_handling": {
       "certificate_generation_failed": "Failed to generate achievement certificates. Please try again.",
@@ -1450,6 +1453,10 @@
       "sync_success": "Invites processed: {invited} sent, {skipped} skipped (already in room or no Matrix handle).",
       "sync_error": "Could not send all Matrix invites. Check server logs and room id.",
       "invalid_room_id": "The input could not be recognized as a valid Matrix room id (!room:server). Please check the value and try again."
+    },
+    "extended_application_banner": {
+      "label": "Show 'Extended application period' badge on course tiles",
+      "help_text": "When enabled, a badge is shown on all course tiles in this program after the program application deadline has passed, but only while the individual course application deadline is still in the future."
     },
     "notifications": {
       "programs_published_success_singular": "Program was successfully published",

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AchievementOptionList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AchievementOptionList.ts
@@ -39,6 +39,10 @@ export interface AchievementOptionList_AchievementOption_AchievementOptionCourse
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseFragment.ts
@@ -177,6 +177,10 @@ export interface AdminCourseFragment_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseList.ts
@@ -177,6 +177,10 @@ export interface AdminCourseList_Course_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminProgramFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminProgramFragment.ts
@@ -33,6 +33,10 @@ export interface AdminProgramFragment {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/Course.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/Course.ts
@@ -177,6 +177,10 @@ export interface Course_Course_by_pk_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseAnonymous.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseAnonymous.ts
@@ -173,6 +173,10 @@ export interface CourseAnonymous_Course_by_pk_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseFragment.ts
@@ -177,6 +177,10 @@ export interface CourseFragment_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseFragmentAnonymous.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseFragmentAnonymous.ts
@@ -173,6 +173,10 @@ export interface CourseFragmentAnonymous_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseList.ts
@@ -177,6 +177,10 @@ export interface CourseList_Course_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseMinimum.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseMinimum.ts
@@ -33,6 +33,10 @@ export interface CourseMinimum_Course_by_pk_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseTileFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseTileFragment.ts
@@ -19,6 +19,14 @@ export interface CourseTileFragment_Program {
    * The title of the program
    */
   title: string;
+  /**
+   * The default application deadline for a course. It can be changed on the course level.
+   */
+  defaultApplicationEnd: any | null;
+  /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
 }
 
 export interface CourseTileFragment_CourseLocations {
@@ -60,6 +68,10 @@ export interface CourseTileFragment {
    * The time the course ends each week.
    */
   endTime: any | null;
+  /**
+   * Last day before applications are closed. (Set to the program's default value when the course is created.)
+   */
+  applicationEnd: any;
   /**
    * Decides whether the course is published for all users or not.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseTiles.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseTiles.ts
@@ -19,6 +19,14 @@ export interface CourseTiles_Course_Program {
    * The title of the program
    */
   title: string;
+  /**
+   * The default application deadline for a course. It can be changed on the course level.
+   */
+  defaultApplicationEnd: any | null;
+  /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
 }
 
 export interface CourseTiles_Course_CourseLocations {
@@ -74,6 +82,10 @@ export interface CourseTiles_Course {
    * The time the course ends each week.
    */
   endTime: any | null;
+  /**
+   * Last day before applications are closed. (Set to the program's default value when the course is created.)
+   */
+  applicationEnd: any;
   /**
    * Decides whether the course is published for all users or not.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseTilesByOrganization.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseTilesByOrganization.ts
@@ -19,6 +19,14 @@ export interface CourseTilesByOrganization_Course_Program {
    * The title of the program
    */
   title: string;
+  /**
+   * The default application deadline for a course. It can be changed on the course level.
+   */
+  defaultApplicationEnd: any | null;
+  /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
 }
 
 export interface CourseTilesByOrganization_Course_CourseLocations {
@@ -74,6 +82,10 @@ export interface CourseTilesByOrganization_Course {
    * The time the course ends each week.
    */
   endTime: any | null;
+  /**
+   * Last day before applications are closed. (Set to the program's default value when the course is created.)
+   */
+  applicationEnd: any;
   /**
    * Decides whether the course is published for all users or not.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseWithEnrollment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseWithEnrollment.ts
@@ -221,6 +221,10 @@ export interface CourseWithEnrollment_Course_by_pk_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CoursesByInstructor.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CoursesByInstructor.ts
@@ -19,6 +19,14 @@ export interface CoursesByInstructor_Course_Program {
    * The title of the program
    */
   title: string;
+  /**
+   * The default application deadline for a course. It can be changed on the course level.
+   */
+  defaultApplicationEnd: any | null;
+  /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
 }
 
 export interface CoursesByInstructor_Course_CourseLocations {
@@ -60,6 +68,10 @@ export interface CoursesByInstructor_Course {
    * The time the course ends each week.
    */
   endTime: any | null;
+  /**
+   * Last day before applications are closed. (Set to the program's default value when the course is created.)
+   */
+  applicationEnd: any;
   /**
    * Decides whether the course is published for all users or not.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CoursesEnrolledByUser.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CoursesEnrolledByUser.ts
@@ -19,6 +19,14 @@ export interface CoursesEnrolledByUser_Course_Program {
    * The title of the program
    */
   title: string;
+  /**
+   * The default application deadline for a course. It can be changed on the course level.
+   */
+  defaultApplicationEnd: any | null;
+  /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
 }
 
 export interface CoursesEnrolledByUser_Course_CourseLocations {
@@ -60,6 +68,10 @@ export interface CoursesEnrolledByUser_Course {
    * The time the course ends each week.
    */
   endTime: any | null;
+  /**
+   * Last day before applications are closed. (Set to the program's default value when the course is created.)
+   */
+  applicationEnd: any;
   /**
    * Decides whether the course is published for all users or not.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/InsertEnrollment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/InsertEnrollment.ts
@@ -194,6 +194,10 @@ export interface InsertEnrollment_insert_CourseEnrollment_returning_Course_Progr
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ManagedCourse.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ManagedCourse.ts
@@ -203,6 +203,10 @@ export interface ManagedCourse_Course_by_pk_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MyCertificates.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MyCertificates.ts
@@ -50,6 +50,10 @@ export interface MyCertificates_CourseEnrollment_Course_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MyCourses.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MyCourses.ts
@@ -224,6 +224,10 @@ export interface MyCourses_User_by_pk_CourseEnrollments_Course_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MyEnrollmentsForCourseQuery.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MyEnrollmentsForCourseQuery.ts
@@ -194,6 +194,10 @@ export interface MyEnrollmentsForCourseQuery_CourseEnrollment_Course_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ProgramFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ProgramFragment.ts
@@ -63,6 +63,10 @@ export interface ProgramFragment {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ProgramFragmentMinimumProperties.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ProgramFragmentMinimumProperties.ts
@@ -33,6 +33,10 @@ export interface ProgramFragmentMinimumProperties {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ProgramList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ProgramList.ts
@@ -38,6 +38,10 @@ export interface ProgramList_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ProgramStatistics.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ProgramStatistics.ts
@@ -99,6 +99,10 @@ export interface ProgramStatistics_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/Programs.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/Programs.ts
@@ -33,6 +33,10 @@ export interface Programs_Program {
    */
   defaultApplicationEnd: any | null;
   /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+  /**
    * The deadline for the achievement record uploads.
    */
   achievementRecordUploadDeadline: any | null;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateProgramShowExtendedApplicationPeriodBanner.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateProgramShowExtendedApplicationPeriodBanner.ts
@@ -1,0 +1,29 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: UpdateProgramShowExtendedApplicationPeriodBanner
+// ====================================================
+
+export interface UpdateProgramShowExtendedApplicationPeriodBanner_update_Program_by_pk {
+  __typename: "Program";
+  id: number;
+  /**
+   * Controls whether course tiles should show an extended application period banner after the program deadline has passed while individual course deadlines are still open.
+   */
+  showExtendedApplicationPeriodBanner: boolean;
+}
+
+export interface UpdateProgramShowExtendedApplicationPeriodBanner {
+  /**
+   * update single row of the table: "Program"
+   */
+  update_Program_by_pk: UpdateProgramShowExtendedApplicationPeriodBanner_update_Program_by_pk | null;
+}
+
+export interface UpdateProgramShowExtendedApplicationPeriodBannerVariables {
+  programId: number;
+  value: boolean;
+}

--- a/frontend-nx/apps/edu-hub/queries/courseFragements.ts
+++ b/frontend-nx/apps/edu-hub/queries/courseFragements.ts
@@ -10,10 +10,13 @@ export const COURSE_TILE_FRAGMENT = gql`
     weekDay
     startTime
     endTime
+    applicationEnd
     published
     Program {
       published
       title
+      defaultApplicationEnd
+      showExtendedApplicationPeriodBanner
     }
     CourseLocations {
       locationOption

--- a/frontend-nx/apps/edu-hub/queries/programFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/programFragment.ts
@@ -8,6 +8,7 @@ export const PROGRAM_FRAGMENT_MINIMUM_PROPERTIES = gql`
     lectureStart
     lectureEnd
     defaultApplicationEnd
+    showExtendedApplicationPeriodBanner
     achievementRecordUploadDeadline
     published
     type
@@ -56,5 +57,6 @@ export const ADMIN_PROGRAM_FRAGMENT = gql`
     defaultFormbricksEnrollmentSurveyUrl
     matrixSpaceId
     matrixInstructorRoomId
+    showExtendedApplicationPeriodBanner
   }
 `;

--- a/frontend-nx/apps/edu-hub/queries/updateProgram.ts
+++ b/frontend-nx/apps/edu-hub/queries/updateProgram.ts
@@ -52,6 +52,18 @@ export const UPDATE_PROGRAM_PUBLISHED = gql`
   }
 `;
 
+export const UPDATE_PROGRAM_SHOW_EXTENDED_APPLICATION_PERIOD_BANNER = gql`
+  mutation UpdateProgramShowExtendedApplicationPeriodBanner($programId: Int!, $value: Boolean!) {
+    update_Program_by_pk(
+      pk_columns: { id: $programId }
+      _set: { showExtendedApplicationPeriodBanner: $value }
+    ) {
+      id
+      showExtendedApplicationPeriodBanner
+    }
+  }
+`;
+
 
 export const UPDATE_PROGRAM_TITLE = gql`
   mutation UpdateProgramTitle($itemId: Int!, $text: String!) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a new `Program.showExtendedApplicationPeriodBanner` boolean with migration + Hasura metadata permissions
- add a checkbox in the Manage Programs expandable row to control this flag
- show a bilingual badge on course tiles (home + widget) when:
  - the program-level setting is enabled
  - the program application deadline has passed
  - the course application deadline is still in the future
- extend GraphQL fragments/mutations and regenerate generated types
- follow-up fix: use UTC day normalization for banner date comparison and semantic design tokens for badge border/text colors

## Details
- New migration:
  - `backend/migrations/default/1775816398380_add_column_show_extended_application_period_banner_to_program/`
- Metadata update:
  - `backend/metadata/databases/default/tables/public_Program.yaml`
- Manage Programs UI:
  - `frontend-nx/apps/edu-hub/components/pages/ManageProgramsContent/ExpandableProgramRow.tsx`
- Tile badge logic/UI:
  - `frontend-nx/apps/edu-hub/components/common/TileSlider/extendedApplicationBanner.ts`
  - `frontend-nx/apps/edu-hub/components/common/TileSlider/TileBase.tsx`
  - `frontend-nx/apps/edu-hub/components/common/TileSlider/Tile.tsx`
  - `frontend-nx/apps/edu-hub/components/common/TileSlider/TileWidget.tsx`
- GraphQL docs:
  - `frontend-nx/apps/edu-hub/queries/programFragment.ts`
  - `frontend-nx/apps/edu-hub/queries/updateProgram.ts`
  - `frontend-nx/apps/edu-hub/queries/courseFragements.ts`
- i18n updates:
  - `frontend-nx/apps/edu-hub/locales/en.json`
  - `frontend-nx/apps/edu-hub/locales/de.json`

## Walkthrough Artifacts
[extended_application_banner_demo.mp4](https://cursor.com/agents/bc-6f91576a-f7f6-407c-801d-97dbf84bd969/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fextended_application_banner_demo.mp4)
[Manage Programs expandable row with checkbox](https://cursor.com/agents/bc-6f91576a-f7f6-407c-801d-97dbf84bd969/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmanage_programs_checkbox_visible.png)
[Extended application badge (DE)](https://cursor.com/agents/bc-6f91576a-f7f6-407c-801d-97dbf84bd969/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fextended_application_badge_de.webp)
[Extended application badge (EN)](https://cursor.com/agents/bc-6f91576a-f7f6-407c-801d-97dbf84bd969/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fextended_application_badge_en.webp)
[Course detail page still loads](https://cursor.com/agents/bc-6f91576a-f7f6-407c-801d-97dbf84bd969/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcurrent_course_b_detail_page.webp)

## Notes
- Apollo codegen reports a pre-existing validation warning in `queries/formbricks.ts` (`acceptTerms` argument), but codegen still generated updated files needed for this change.
- `yarn lint` passes with two existing warnings unrelated to this feature (`TableGrid/hooks.ts` and `InputField.tsx`).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f91576a-f7f6-407c-801d-97dbf84bd969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f91576a-f7f6-407c-801d-97dbf84bd969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended application period banner on course tiles when a program deadline has passed but course deadlines remain open.
  * New program setting (checkbox) to enable/disable the banner.
* **Chores**
  * Database migration adding a new boolean column to programs.
  * API/data updates so listings and admin screens surface the new banner flag.
* **Documentation**
  * Added English and German translations for the feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->