### PR TITLE
fix: keep table action column visible when rows overflow

### DIFF
--- a/frontend-nx/apps/edu-hub/components/common/TableGrid/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TableGrid/index.tsx
@@ -308,7 +308,12 @@ const TableGrid = <T extends BaseRow,>({
   const getDataColumnStyle = (columnId: string, size: number): React.CSSProperties =>
     columnId === 'selection'
       ? { width: `${size}px`, flexShrink: 0 }
-      : { flex: '1 1 0%', minWidth: `${size}px`, flexShrink: 0 };
+      : {
+          flex: '1 1 0%',
+          minWidth: `${size}px`,
+          flexShrink: 0,
+          overflow: 'hidden',
+        };
 
   return (
     <div>
@@ -453,7 +458,7 @@ const TableGrid = <T extends BaseRow,>({
           {/* Header row */}
           <div className="flex items-center mb-1 bg-bg-primary text-label-primary py-2">
         <div
-          className={`flex-grow flex gap-3 ${!showCheckbox ? 'pl-3' : ''}`}
+          className={`flex-grow min-w-0 flex gap-3 ${!showCheckbox ? 'pl-3' : ''}`}
           style={{
             minWidth: `${mainRowContentWidth - (expandableRowComponent != null ? 40 : 0) - (deleteMutation != null ? 80 : 0)}px`,
             width: '100%',
@@ -513,7 +518,7 @@ const TableGrid = <T extends BaseRow,>({
           if (rowsToDisplay.length === 0) {
             return (
               <div className="flex items-stretch mb-1">
-                <div className={`flex-grow bg-bg-secondary text-label-primary light ${compactRows ? 'py-1' : 'py-2'}`}>
+                <div className={`flex-grow min-w-0 overflow-hidden bg-bg-secondary text-label-primary light ${compactRows ? 'py-1' : 'py-2'}`}>
                   <div
                     className={`flex items-center gap-3 ${!showCheckbox ? 'pl-3' : ''}`}
                     style={{
@@ -545,7 +550,7 @@ const TableGrid = <T extends BaseRow,>({
             <React.Fragment key={row.id}>
               {/* Primary Row */}
               <div className={`flex items-stretch ${expandedRows.has(row.original.id) ? 'mb-0' : 'mb-1'}`}>
-                <div className={`flex-grow bg-bg-secondary text-label-primary light ${compactRows ? 'py-1' : 'py-2'}`}>
+                <div className={`flex-grow min-w-0 overflow-hidden bg-bg-secondary text-label-primary light ${compactRows ? 'py-1' : 'py-2'}`}>
                   <div
                     className={`flex items-center gap-3 ${!showCheckbox ? 'pl-3' : ''}`}
                     style={{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What changed
- Hardened `TableGrid` row/cell layout to prevent per-row intrinsic-content overflow from pushing the right-side action/expand column outside the visible table row.
- Added `min-w-0` and `overflow-hidden` constraints on the main row content containers and data cells so long or non-wrapping content cannot break row width allocation.

## Why
After introducing an additional date column, some rows could exceed expected row width and visually hide the dropdown/expand arrow. This makes the behavior robust for all rows regardless of content shape.

## Scope
- `frontend-nx/apps/edu-hub/components/common/TableGrid/index.tsx`

## Validation
- `yarn eslint apps/edu-hub/components/common/TableGrid/index.tsx` passes.
- Manual UI verification on Applications table confirms rightmost expand controls remain visible and clickable across rows, including long organization values.

## Walkthrough artifacts
[tablegrid_arrow_visibility_fix_demo.mp4](https://cursor.com/agents/bc-b2bb657a-04d7-4b68-9a92-fc6031d96472/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftablegrid_arrow_visibility_fix_demo.mp4)
[Row hover control visible](https://cursor.com/agents/bc-b2bb657a-04d7-4b68-9a92-fc6031d96472/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftablegrid_row_hover_control_visible.webp)
[Rows expanded controls work](https://cursor.com/agents/bc-b2bb657a-04d7-4b68-9a92-fc6031d96472/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftablegrid_rows_expanded_controls_work.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b2bb657a-04d7-4b68-9a92-fc6031d96472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2bb657a-04d7-4b68-9a92-fc6031d96472"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table grid styling to refine how content overflows and displays within table columns and rows, improving layout consistency in compact table cells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->