### PR TITLE
fix: align createEnrollmentWithAddons schema and persist termsAcceptedAt before Stripe

### DIFF
--- a/backend/metadata/actions.graphql
+++ b/backend/metadata/actions.graphql
@@ -50,7 +50,6 @@ type Mutation {
     userId: uuid!
     motivationLetter: String
     formbricksSurveyUrl: String
-    termsAcceptedAt: timestamptz
   ): CreateEnrollmentWithAddonsResult!
 }
 

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/RegistrationModal.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/RegistrationModal.tsx
@@ -258,14 +258,16 @@ export const RegistrationModal: FC<RegistrationModalProps> = ({
     if (config.requiresPayment && effectiveSurveyUrl && userId) {
       setIsFetchingAddons(true);
       try {
+        // Terms acceptance is intentionally not part of this call: the
+        // user has only completed the survey at this point. Acceptance
+        // (with its authoritative timestamp) is recorded in the summary
+        // step right before Stripe checkout via UPDATE_ENROLLMENT_TERMS_ACCEPTED.
         const result = await createEnrollmentWithAddons({
           variables: {
             courseId: course.id,
             userId: userId,
             motivationLetter: '[Formbricks Survey Completed]',
             formbricksSurveyUrl: effectiveSurveyUrl,
-            // Terms not accepted yet - will be accepted in summary step
-            // termsAcceptedAt is set when user accepts terms in handleSubmit
           },
         });
 

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
@@ -5,8 +5,12 @@ import { CourseRegistrationType_enum, CourseEnrollmentStatus_enum } from '../../
 import { Course_Course_by_pk } from '../../../../../queries/__generated__/Course';
 import { useAuthedMutation } from '../../../../../hooks/authedMutation';
 import { useUserId } from '../../../../../hooks/user';
-import { UPDATE_ENROLLMENT } from '../../../../../queries/insertEnrollment';
+import { UPDATE_ENROLLMENT, UPDATE_ENROLLMENT_TERMS_ACCEPTED } from '../../../../../queries/insertEnrollment';
 import { UpdateEnrollment, UpdateEnrollmentVariables } from '../../../../../queries/__generated__/UpdateEnrollment';
+import {
+  UpdateEnrollmentTermsAccepted,
+  UpdateEnrollmentTermsAcceptedVariables,
+} from '../../../../../queries/__generated__/UpdateEnrollmentTermsAccepted';
 import { CREATE_STRIPE_CHECKOUT } from '../../../../../queries/stripe';
 import { CreateStripeCheckout, CreateStripeCheckoutVariables } from '../../../../../queries/__generated__/CreateStripeCheckout';
 import { getRegistrationTypeConfig, RegistrationFormData, RegistrationResult } from '../types';
@@ -67,6 +71,11 @@ export const useRegistrationHandler = ({
   const [createStripeCheckoutMutation] = useAuthedMutation<CreateStripeCheckout, CreateStripeCheckoutVariables>(
     CREATE_STRIPE_CHECKOUT
   );
+
+  const [updateEnrollmentTermsAcceptedMutation] = useAuthedMutation<
+    UpdateEnrollmentTermsAccepted,
+    UpdateEnrollmentTermsAcceptedVariables
+  >(UPDATE_ENROLLMENT_TERMS_ACCEPTED);
 
   const registrationType = course.registrationType || CourseRegistrationType_enum.APPROVAL_WITH_INPUT;
   const config = getRegistrationTypeConfig(registrationType);
@@ -144,8 +153,35 @@ export const useRegistrationHandler = ({
         return { success: false, error: 'Enrollment ID is required. Enrollment should be created before payment.' };
       }
 
+      // Terms & Conditions / Privacy Policy must be accepted before we
+      // initiate the paid checkout. We require this at the application
+      // boundary so the legal record is captured even if Stripe redirect
+      // fails afterwards.
+      if (!formData?.acceptTerms) {
+        return { success: false, error: 'Terms & Conditions must be accepted before payment.' };
+      }
+
       setIsLoading(true);
       try {
+        // Persist terms acceptance with a timestamp BEFORE creating the
+        // Stripe Checkout session. The Hasura mutation only writes when
+        // termsAcceptedAt is currently NULL, so re-running this for a
+        // retry never overwrites the original acceptance timestamp.
+        try {
+          await updateEnrollmentTermsAcceptedMutation({
+            variables: {
+              enrollmentId,
+              termsAcceptedAt: new Date().toISOString(),
+            },
+          });
+        } catch (termsError) {
+          console.error('Failed to record terms acceptance:', termsError);
+          return {
+            success: false,
+            error: 'Could not record terms acceptance. Please try again.',
+          };
+        }
+
         // Create Stripe Checkout session
         // Server will read addons from CourseEnrollmentAddon table using enrollmentId
         // URLs are built server-side from FRONTEND_URL for security
@@ -185,7 +221,7 @@ export const useRegistrationHandler = ({
         setIsLoading(false);
       }
     },
-    [course?.id, userId, createStripeCheckoutMutation]
+    [course?.id, userId, createStripeCheckoutMutation, updateEnrollmentTermsAcceptedMutation]
   );
 
   const handleRegistration = useCallback(() => {

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Registration/hooks/useRegistrationHandler.ts
@@ -1,16 +1,28 @@
 import { useCallback, useState } from 'react';
-import { signIn } from 'next-auth/react';
+import { signIn, useSession } from 'next-auth/react';
+import { useApolloClient } from '@apollo/client';
+import { useTranslations } from 'next-intl';
 
 import { CourseRegistrationType_enum, CourseEnrollmentStatus_enum } from '../../../../../__generated__/globalTypes';
 import { Course_Course_by_pk } from '../../../../../queries/__generated__/Course';
 import { useAuthedMutation } from '../../../../../hooks/authedMutation';
+import { useCurrentRole } from '../../../../../hooks/authentication';
 import { useUserId } from '../../../../../hooks/user';
-import { UPDATE_ENROLLMENT, UPDATE_ENROLLMENT_TERMS_ACCEPTED } from '../../../../../queries/insertEnrollment';
+import { AuthRoles } from '../../../../../types/enums';
+import {
+  UPDATE_ENROLLMENT,
+  UPDATE_ENROLLMENT_TERMS_ACCEPTED,
+  GET_ENROLLMENT_TERMS_ACCEPTED_AT,
+} from '../../../../../queries/insertEnrollment';
 import { UpdateEnrollment, UpdateEnrollmentVariables } from '../../../../../queries/__generated__/UpdateEnrollment';
 import {
   UpdateEnrollmentTermsAccepted,
   UpdateEnrollmentTermsAcceptedVariables,
 } from '../../../../../queries/__generated__/UpdateEnrollmentTermsAccepted';
+import {
+  GetEnrollmentTermsAcceptedAt,
+  GetEnrollmentTermsAcceptedAtVariables,
+} from '../../../../../queries/__generated__/GetEnrollmentTermsAcceptedAt';
 import { CREATE_STRIPE_CHECKOUT } from '../../../../../queries/stripe';
 import { CreateStripeCheckout, CreateStripeCheckoutVariables } from '../../../../../queries/__generated__/CreateStripeCheckout';
 import { getRegistrationTypeConfig, RegistrationFormData, RegistrationResult } from '../types';
@@ -63,7 +75,11 @@ export const useRegistrationHandler = ({
   const [isLoading, setIsLoading] = useState(false);
   const [retryEnrollmentId, setRetryEnrollmentId] = useState<number | null>(null);
   const userId = useUserId();
-  
+  const t = useTranslations('course');
+  const apolloClient = useApolloClient();
+  const { data: sessionData } = useSession();
+  const currentRole = useCurrentRole();
+
   const [updateEnrollmentMutation] = useAuthedMutation<UpdateEnrollment, UpdateEnrollmentVariables>(
     UPDATE_ENROLLMENT
   );
@@ -76,6 +92,79 @@ export const useRegistrationHandler = ({
     UpdateEnrollmentTermsAccepted,
     UpdateEnrollmentTermsAcceptedVariables
   >(UPDATE_ENROLLMENT_TERMS_ACCEPTED);
+
+  /**
+   * Persists the user's acceptance of the Terms & Conditions / Privacy
+   * Policy against an existing enrollment and confirms it landed in the
+   * database before the caller proceeds to checkout.
+   *
+   * Because UPDATE_ENROLLMENT_TERMS_ACCEPTED only writes when the column
+   * is currently NULL, `affected_rows: 0` is the *expected* response on
+   * a legitimate retry where consent is already on record. We therefore
+   * disambiguate the zero-rows case with an authoritative network read
+   * and treat a still-null value as a hard failure.
+   *
+   * @returns true when the database holds a non-null termsAcceptedAt for
+   *          this enrollment, false otherwise (callers must abort).
+   */
+  const recordTermsAcceptance = useCallback(
+    async (enrollmentId: number, termsAcceptedAt: string): Promise<boolean> => {
+      try {
+        const updateResult = await updateEnrollmentTermsAcceptedMutation({
+          variables: { enrollmentId, termsAcceptedAt },
+        });
+
+        const affectedRows =
+          updateResult.data?.update_CourseEnrollment?.affected_rows ?? 0;
+
+        if (affectedRows > 0) {
+          return true;
+        }
+
+        const accessToken = sessionData?.accessToken;
+        const role =
+          currentRole === AuthRoles.anonymous ? AuthRoles.user : currentRole;
+        const verifyResult = await apolloClient.query<
+          GetEnrollmentTermsAcceptedAt,
+          GetEnrollmentTermsAcceptedAtVariables
+        >({
+          query: GET_ENROLLMENT_TERMS_ACCEPTED_AT,
+          variables: { enrollmentId },
+          fetchPolicy: 'network-only',
+          context: accessToken
+            ? {
+                headers: {
+                  'x-hasura-role': role,
+                  Authorization: `Bearer ${accessToken}`,
+                },
+              }
+            : undefined,
+        });
+
+        const recordedAt =
+          verifyResult.data?.CourseEnrollment_by_pk?.termsAcceptedAt ?? null;
+
+        if (!recordedAt) {
+          console.error(
+            'Terms acceptance verification failed: enrollment has no termsAcceptedAt on record',
+            { enrollmentId }
+          );
+          return false;
+        }
+
+        return true;
+      } catch (termsError) {
+        console.error('Failed to record terms acceptance:', termsError);
+        return false;
+      }
+    },
+    [
+      updateEnrollmentTermsAcceptedMutation,
+      apolloClient,
+      sessionData?.accessToken,
+      currentRole,
+    ]
+  );
 
   const registrationType = course.registrationType || CourseRegistrationType_enum.APPROVAL_WITH_INPUT;
   const config = getRegistrationTypeConfig(registrationType);
@@ -163,23 +252,14 @@ export const useRegistrationHandler = ({
 
       setIsLoading(true);
       try {
-        // Persist terms acceptance with a timestamp BEFORE creating the
-        // Stripe Checkout session. The Hasura mutation only writes when
-        // termsAcceptedAt is currently NULL, so re-running this for a
-        // retry never overwrites the original acceptance timestamp.
-        try {
-          await updateEnrollmentTermsAcceptedMutation({
-            variables: {
-              enrollmentId,
-              termsAcceptedAt: new Date().toISOString(),
-            },
-          });
-        } catch (termsError) {
-          console.error('Failed to record terms acceptance:', termsError);
-          return {
-            success: false,
-            error: 'Could not record terms acceptance. Please try again.',
-          };
+        // Persist terms acceptance with a server-verified timestamp BEFORE
+        // creating the Stripe Checkout session. recordTermsAcceptance handles
+        // the idempotency / verification semantics; we only need to abort
+        // with a localized error if it returns false.
+        const termsAcceptedAt = new Date().toISOString();
+        const consentRecorded = await recordTermsAcceptance(enrollmentId, termsAcceptedAt);
+        if (!consentRecorded) {
+          return { success: false, error: t('errors.terms_record_failed') };
         }
 
         // Create Stripe Checkout session
@@ -221,7 +301,13 @@ export const useRegistrationHandler = ({
         setIsLoading(false);
       }
     },
-    [course?.id, userId, createStripeCheckoutMutation, updateEnrollmentTermsAcceptedMutation]
+    [
+      course?.id,
+      userId,
+      createStripeCheckoutMutation,
+      recordTermsAcceptance,
+      t,
+    ]
   );
 
   const handleRegistration = useCallback(() => {

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -459,6 +459,7 @@
     "errors": {
       "motivation_letter_required": "Bitte schreib uns, warum du an diesem Kurs teilnehmen möchtest",
       "terms_required": "Bitte akzeptiere die Allgemeinen Geschäftsbedingungen",
+      "terms_record_failed": "Deine Zustimmung zu den Allgemeinen Geschäftsbedingungen konnte nicht gespeichert werden. Bitte versuche es erneut.",
       "registration_failed": "Registrierung fehlgeschlagen. Bitte versuche es erneut.",
       "complete_survey_first": "Bitte fülle zuerst den Fragebogen vollständig aus.",
       "failed_to_load_organization_options": "Organisationsoptionen konnten nicht geladen werden."

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -459,6 +459,7 @@
     "errors": {
       "motivation_letter_required": "Please provide a motivation letter",
       "terms_required": "Please accept the Terms and Conditions",
+      "terms_record_failed": "We could not record your acceptance of the Terms and Conditions. Please try again.",
       "registration_failed": "Registration failed. Please try again.",
       "complete_survey_first": "Please complete the questionnaire first.",
       "failed_to_load_organization_options": "Failed to load organization options."

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CreateEnrollmentWithAddons.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CreateEnrollmentWithAddons.ts
@@ -38,5 +38,4 @@ export interface CreateEnrollmentWithAddonsVariables {
   userId: any;
   motivationLetter?: string | null;
   formbricksSurveyUrl?: string | null;
-  acceptTerms?: boolean | null;
 }

--- a/frontend-nx/apps/edu-hub/queries/__generated__/GetEnrollmentTermsAcceptedAt.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/GetEnrollmentTermsAcceptedAt.ts
@@ -1,0 +1,28 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: GetEnrollmentTermsAcceptedAt
+// ====================================================
+
+export interface GetEnrollmentTermsAcceptedAt_CourseEnrollment_by_pk {
+  __typename: "CourseEnrollment";
+  id: number;
+  /**
+   * Timestamp when user accepted Terms & Conditions and Privacy Policy during registration
+   */
+  termsAcceptedAt: any | null;
+}
+
+export interface GetEnrollmentTermsAcceptedAt {
+  /**
+   * fetch data from the table: "CourseEnrollment" using primary key columns
+   */
+  CourseEnrollment_by_pk: GetEnrollmentTermsAcceptedAt_CourseEnrollment_by_pk | null;
+}
+
+export interface GetEnrollmentTermsAcceptedAtVariables {
+  enrollmentId: number;
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateEnrollmentTermsAccepted.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateEnrollmentTermsAccepted.ts
@@ -1,0 +1,41 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: UpdateEnrollmentTermsAccepted
+// ====================================================
+
+export interface UpdateEnrollmentTermsAccepted_update_CourseEnrollment_returning {
+  __typename: "CourseEnrollment";
+  id: number;
+  /**
+   * Timestamp when user accepted Terms & Conditions and Privacy Policy during registration
+   */
+  termsAcceptedAt: any | null;
+}
+
+export interface UpdateEnrollmentTermsAccepted_update_CourseEnrollment {
+  __typename: "CourseEnrollment_mutation_response";
+  /**
+   * number of rows affected by the mutation
+   */
+  affected_rows: number;
+  /**
+   * data from the rows affected by the mutation
+   */
+  returning: UpdateEnrollmentTermsAccepted_update_CourseEnrollment_returning[];
+}
+
+export interface UpdateEnrollmentTermsAccepted {
+  /**
+   * update data of the table: "CourseEnrollment"
+   */
+  update_CourseEnrollment: UpdateEnrollmentTermsAccepted_update_CourseEnrollment | null;
+}
+
+export interface UpdateEnrollmentTermsAcceptedVariables {
+  enrollmentId: number;
+  termsAcceptedAt: any;
+}

--- a/frontend-nx/apps/edu-hub/queries/formbricks.ts
+++ b/frontend-nx/apps/edu-hub/queries/formbricks.ts
@@ -60,20 +60,23 @@ export const GET_FORMBRICKS_ADDON_SELECTIONS = gql`
   }
 `;
 
+// Terms & Conditions / Privacy Policy acceptance is intentionally NOT a
+// parameter of this mutation: at this point in the registration flow the
+// user has only completed the Formbricks survey and has not yet seen or
+// accepted the terms (that happens in the summary step before Stripe
+// checkout). Acceptance is recorded separately via UPDATE_ENROLLMENT_TERMS_ACCEPTED.
 export const CREATE_ENROLLMENT_WITH_ADDONS = gql`
   mutation CreateEnrollmentWithAddons(
     $courseId: Int!
     $userId: uuid!
     $motivationLetter: String
     $formbricksSurveyUrl: String
-    $acceptTerms: Boolean
   ) {
     createEnrollmentWithAddons(
       courseId: $courseId
       userId: $userId
       motivationLetter: $motivationLetter
       formbricksSurveyUrl: $formbricksSurveyUrl
-      acceptTerms: $acceptTerms
     ) {
       success
       error

--- a/frontend-nx/apps/edu-hub/queries/insertEnrollment.ts
+++ b/frontend-nx/apps/edu-hub/queries/insertEnrollment.ts
@@ -61,6 +61,38 @@ export const INSERT_ENROLLMENT = gql`
   }
 `;
 
+/**
+ * Records the user's acceptance of Terms & Conditions and Privacy Policy
+ * for an existing enrollment. The timestamp is captured client-side at the
+ * exact moment the user clicks the consent control.
+ *
+ * Legal note: the column is only set when it is currently NULL — once an
+ * acceptance is recorded it is immutable from this mutation, which prevents
+ * the audit trail from being overwritten on retries.
+ */
+export const UPDATE_ENROLLMENT_TERMS_ACCEPTED = gql`
+  mutation UpdateEnrollmentTermsAccepted(
+    $enrollmentId: Int!
+    $termsAcceptedAt: timestamptz!
+  ) {
+    update_CourseEnrollment(
+      where: {
+        _and: [
+          { id: { _eq: $enrollmentId } }
+          { termsAcceptedAt: { _is_null: true } }
+        ]
+      }
+      _set: { termsAcceptedAt: $termsAcceptedAt }
+    ) {
+      affected_rows
+      returning {
+        id
+        termsAcceptedAt
+      }
+    }
+  }
+`;
+
 export const UPDATE_ENROLLMENT_RATING = gql`
   mutation UpdateEnrollmentRating(
     $enrollmentId: Int!

--- a/frontend-nx/apps/edu-hub/queries/insertEnrollment.ts
+++ b/frontend-nx/apps/edu-hub/queries/insertEnrollment.ts
@@ -63,12 +63,21 @@ export const INSERT_ENROLLMENT = gql`
 
 /**
  * Records the user's acceptance of Terms & Conditions and Privacy Policy
- * for an existing enrollment. The timestamp is captured client-side at the
- * exact moment the user clicks the consent control.
+ * for an existing enrollment.
+ *
+ * Timestamp semantics: callers pass a client-generated ISO timestamp that
+ * is captured at summary submission, immediately before the Stripe
+ * checkout session is created. The user must have ticked the consent
+ * checkbox earlier in the same submit handler; this mutation records the
+ * moment that consent is acted upon.
  *
  * Legal note: the column is only set when it is currently NULL — once an
  * acceptance is recorded it is immutable from this mutation, which prevents
- * the audit trail from being overwritten on retries.
+ * the audit trail from being overwritten on retries. As a consequence,
+ * `affected_rows: 0` is the *expected* response for an idempotent retry
+ * after the row already has a value; callers must therefore distinguish
+ * "no-op because already recorded" from "no row matched at all" by
+ * issuing GET_ENROLLMENT_TERMS_ACCEPTED_AT as a follow-up read.
  */
 export const UPDATE_ENROLLMENT_TERMS_ACCEPTED = gql`
   mutation UpdateEnrollmentTermsAccepted(
@@ -89,6 +98,21 @@ export const UPDATE_ENROLLMENT_TERMS_ACCEPTED = gql`
         id
         termsAcceptedAt
       }
+    }
+  }
+`;
+
+/**
+ * Verification read used after UPDATE_ENROLLMENT_TERMS_ACCEPTED reports
+ * `affected_rows: 0`. A null value means we must NOT proceed to checkout
+ * (no consent on record); a non-null value means consent was already
+ * recorded on a previous attempt and it is safe to proceed.
+ */
+export const GET_ENROLLMENT_TERMS_ACCEPTED_AT = gql`
+  query GetEnrollmentTermsAcceptedAt($enrollmentId: Int!) {
+    CourseEnrollment_by_pk(id: $enrollmentId) {
+      id
+      termsAcceptedAt
     }
   }
 `;

--- a/functions/callNodeFunction/createEnrollmentWithAddons/index.js
+++ b/functions/callNodeFunction/createEnrollmentWithAddons/index.js
@@ -18,11 +18,23 @@ const GET_COURSE_ADDONS = `
   }
 `;
 
-// NOTE: termsAcceptedAt is intentionally NOT set here and NOT included in
-// on_conflict.update_columns. Terms acceptance happens later in the UI
-// (summary step before Stripe checkout) and is recorded by a dedicated
-// mutation. Excluding it from update_columns guarantees that a retry of
-// createEnrollmentWithAddons cannot clear a previously recorded acceptance.
+// IMPORTANT — on_conflict.update_columns intentionally only contains
+// motivationLetter:
+//
+// - status / paymentStatus are state-machine fields. If the user already
+//   has a CONFIRMED + PAID enrollment and somehow re-triggers this action
+//   (stale UI, retried network call, direct API call), upserting them
+//   back to APPLIED + PENDING would silently regress a paid enrollment.
+//   Excluding them from update_columns makes this mutation a true no-op
+//   for the state of an existing row and lets the dedicated status /
+//   payment-status workflows remain the single source of truth.
+// - termsAcceptedAt is excluded because terms are accepted later in the
+//   UI (summary step before Stripe checkout) and recorded by a dedicated
+//   mutation; excluding it here guarantees that a retry of
+//   createEnrollmentWithAddons cannot clear a previously recorded
+//   acceptance timestamp.
+// - motivationLetter is the only field that may legitimately change on a
+//   retry of this same flow.
 const CREATE_ENROLLMENT = `
   mutation CreateEnrollment(
     $courseId: Int!
@@ -41,7 +53,7 @@ const CREATE_ENROLLMENT = `
       }
       on_conflict: {
         constraint: uniqueUserCourse
-        update_columns: [status, motivationLetter, paymentStatus]
+        update_columns: [motivationLetter]
       }
     ) {
       affected_rows

--- a/functions/callNodeFunction/createEnrollmentWithAddons/index.js
+++ b/functions/callNodeFunction/createEnrollmentWithAddons/index.js
@@ -18,13 +18,17 @@ const GET_COURSE_ADDONS = `
   }
 `;
 
+// NOTE: termsAcceptedAt is intentionally NOT set here and NOT included in
+// on_conflict.update_columns. Terms acceptance happens later in the UI
+// (summary step before Stripe checkout) and is recorded by a dedicated
+// mutation. Excluding it from update_columns guarantees that a retry of
+// createEnrollmentWithAddons cannot clear a previously recorded acceptance.
 const CREATE_ENROLLMENT = `
   mutation CreateEnrollment(
     $courseId: Int!
     $userId: uuid!
     $motivationLetter: String!
     $status: CourseEnrollmentStatus_enum!
-    $termsAcceptedAt: timestamptz
     $paymentStatus: PaymentStatus_enum
   ) {
     insert_CourseEnrollment(
@@ -33,12 +37,11 @@ const CREATE_ENROLLMENT = `
         userId: $userId
         motivationLetter: $motivationLetter
         status: $status
-        termsAcceptedAt: $termsAcceptedAt
         paymentStatus: $paymentStatus
       }
       on_conflict: {
         constraint: uniqueUserCourse
-        update_columns: [status, termsAcceptedAt, motivationLetter, paymentStatus]
+        update_columns: [status, motivationLetter, paymentStatus]
       }
     ) {
       affected_rows
@@ -307,7 +310,7 @@ async function fetchFormbricksResponseWithRetry(
  * Creates a course enrollment and saves selected addons from Formbricks survey to the database.
  * Handles Formbricks timing issues with retry logic.
  * 
- * @param {Object} req - Request object containing body with courseId, userId, motivationLetter, formbricksSurveyUrl, acceptTerms
+ * @param {Object} req - Request object containing body with courseId, userId, motivationLetter, formbricksSurveyUrl
  * @param {Object} logger - Winston logger instance
  * @returns {Object} Result with success, enrollmentId, selectedAddons, or error
  */
@@ -322,7 +325,6 @@ export default async function createEnrollmentWithAddons(req, logger) {
       userId,
       motivationLetter,
       formbricksSurveyUrl,
-      acceptTerms
     } = req.body.input || req.body;
 
     // Validate required inputs
@@ -367,18 +369,16 @@ export default async function createEnrollmentWithAddons(req, logger) {
       },
     });
 
-    // Step 1: Create CourseEnrollment with status APPLIED and paymentStatus PENDING
+    // Step 1: Create CourseEnrollment with status APPLIED and paymentStatus PENDING.
+    // termsAcceptedAt is set later, by a separate mutation, when the user
+    // explicitly accepts terms in the summary step before Stripe checkout.
     logger.info('Creating enrollment', { courseId, userId: effectiveUserId });
-    
-    // Set termsAcceptedAt server-side when acceptTerms is true (authoritative timestamp)
-    const termsAcceptedAt = acceptTerms === true ? new Date().toISOString() : null;
-    
+
     const enrollmentResult = await client.request(CREATE_ENROLLMENT, {
       courseId,
       userId: effectiveUserId,
       motivationLetter: motivationLetter || '[Formbricks Survey Completed]',
       status: 'APPLIED',
-      termsAcceptedAt: termsAcceptedAt,
       paymentStatus: 'PENDING' // Set to PENDING for payment flows - will be updated by webhook on success/failure
     });
 


### PR DESCRIPTION
- Remove termsAcceptedAt from Hasura action signature; match createEnrollmentWithAddons handler
- Stop setting terms on initial Formbricks enrollment; exclude termsAcceptedAt from upsert update_columns
- Add UPDATE_ENROLLMENT_TERMS_ACCEPTED mutation; record timestamp before checkout
- Regenerate Apollo types

Made-with: Cursor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where terms acceptance timestamp could be overwritten during enrollment retries. Terms acceptance is now recorded separately at the payment/checkout stage, ensuring authoritative and persistent recording.

* **Refactor**
  * Reorganized the terms acceptance flow to validate acceptance before payment processing, improving the reliability of enrollment with payment workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->