### PR TITLE
Add repo-owned workflow skills under .codex

### DIFF
--- a/.codex/skills/conventional-commits/SKILL.md
+++ b/.codex/skills/conventional-commits/SKILL.md
@@ -10,6 +10,7 @@ Use this skill when the task involves commit messages, release impact, or merge-
 
 - Produce a conventional-commit subject line that matches the actual change.
 - Add a useful body for non-trivial changes.
+- Keep every commit-message line under 80 characters.
 - Avoid merge messages that hide release intent.
 - Keep guidance aligned with the repo's real semantic-release configuration.
 
@@ -29,6 +30,12 @@ Use:
 ```text
 <type>[optional scope]: <description>
 ```
+
+Length rule:
+
+- every line in the commit message must be fewer than 80 characters
+- this includes the subject, body paragraphs, bullets, and footers
+- wrap body text manually instead of leaving long prose on one line
 
 Examples:
 
@@ -125,6 +132,13 @@ Good body styles in this repo include:
 - one short explanatory paragraph plus one short fix paragraph
 - a compact bullet list for several coordinated changes
 - numbered sections when describing multiple related bugs in one fix
+- wrapped prose with each line kept under 80 characters
+
+If a body is present:
+
+- leave exactly one blank line between the subject and the body
+- keep every body line under 80 characters
+- wrap explanatory paragraphs rather than using one long line
 
 Avoid filler. The body should add debugging or review value, not restate the title.
 
@@ -135,6 +149,8 @@ Use footers for formal metadata:
 - `BREAKING CHANGE: ...`
 - `Co-authored-by: ...`
 - other standard trailers when needed
+
+Keep footer lines under 80 characters too.
 
 Do not put ordinary explanation into footers.
 
@@ -165,6 +181,9 @@ When the user asks for a commit message, return:
 1. the proposed subject line
 2. an optional body if the change is non-trivial
 3. a one-line note on release impact when relevant
+
+Before finalizing a commit message, check that every line is under 80
+characters.
 
 When the diff is ambiguous, explain the tradeoff briefly, then recommend one message.
 

--- a/.codex/skills/conventional-commits/SKILL.md
+++ b/.codex/skills/conventional-commits/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: conventional-commits
+description: Draft and review EduHub commit messages using the repository's conventional-commit and semantic-release workflow. Use when writing commit messages, choosing feat vs fix vs chore, deciding whether a body is needed, preparing merge commit messages, or explaining release impact.
+---
+# Conventional Commits
+
+Use this skill when the task involves commit messages, release impact, or merge-message wording for EduHub.
+
+## Goals
+
+- Produce a conventional-commit subject line that matches the actual change.
+- Add a useful body for non-trivial changes.
+- Avoid merge messages that hide release intent.
+- Keep guidance aligned with the repo's real semantic-release configuration.
+
+## Source Of Truth
+
+When commit or release guidance conflicts, prefer the actual release configuration over stale prose docs:
+
+- `frontend-nx/.releaserc.json`
+- `.github/workflows/release.yml`
+
+For this repo, semantic-release currently runs only on pushes to `production`.
+
+## Subject Format
+
+Use:
+
+```text
+<type>[optional scope]: <description>
+```
+
+Examples:
+
+```text
+feat(sessions): add AttendanceData review dialog
+fix(i18n): add missing remove_external_speaker translation
+chore(deps): bump dompurify in frontend-nx
+docs(cursor): document Karpathy behavioral guidelines
+```
+
+## Allowed Types
+
+Use these commit types:
+
+- `feat`: user-visible feature or capability
+- `fix`: bug fix or correctness fix
+- `docs`: documentation-only change
+- `style`: formatting or presentation-only change
+- `refactor`: internal restructuring without behavior change
+- `perf`: measurable performance improvement
+- `test`: add or update tests
+- `build`: build tooling, packaging, dependency/build-system wiring
+- `ci`: CI/CD workflow changes
+- `chore`: maintenance or repo housekeeping that is not better described by another type
+
+## Common Scopes
+
+Prefer an existing product or subsystem term when it makes the subject clearer.
+
+Common scopes seen in this repo include:
+
+- `sessions`
+- `attendance`
+- `i18n`
+- `edu-hub`
+- `functions`
+- `zoom`
+- `tablegrid`
+- `auth`
+- `backend`
+- `frontend`
+- `db`
+- `infra`
+- `deps`
+- `release`
+- `cursor`
+
+Do not force a scope if the message is clearer without one.
+
+## How To Choose The Type
+
+- Use `feat` when behavior is added, exposed, or expanded for users or operators.
+- Use `fix` when correcting broken behavior, invalid data flow, crashes, bad queries, wrong permissions, or misleading UI behavior.
+- Use `refactor` only when behavior is intentionally unchanged.
+- Use `chore` for generated type updates, dependency bumps, cleanup, or release plumbing unless another type is more accurate.
+- Use `docs` for docs-only changes, including repo instructions and agent guidance.
+
+If the diff includes both feature work and follow-up cleanup, classify by the primary user-facing outcome.
+
+## Release Impact
+
+For EduHub semantic-release:
+
+- `feat` -> minor release
+- `fix` -> patch release
+- `perf` -> patch release
+- `BREAKING CHANGE` or `!` -> major release
+- `docs`, `style`, `refactor`, `test`, `build`, `ci`, `chore` -> no version bump by themselves
+
+Do not mark a change as breaking unless an existing user, integrator, or operator must change behavior, code, config, or expectations to keep working.
+
+## Commit Bodies
+
+In this repository, many strong commits include a body, and the skill should preserve that pattern.
+
+Add a body when the change is not trivial, especially for:
+
+- bug fixes with a real failure mode
+- features with behavioral nuance
+- schema, permissions, or GraphQL changes
+- auth or security-sensitive changes
+- release, migration, or operational changes
+- fixes where the title alone would not explain the risk
+
+For non-trivial commits, the body should usually cover:
+
+1. What was broken, risky, or missing.
+2. Why it happened.
+3. What changed to fix it.
+4. Important side effects, follow-up regeneration, retries, tests, or compatibility notes.
+
+Good body styles in this repo include:
+
+- one short explanatory paragraph plus one short fix paragraph
+- a compact bullet list for several coordinated changes
+- numbered sections when describing multiple related bugs in one fix
+
+Avoid filler. The body should add debugging or review value, not restate the title.
+
+## Footers
+
+Use footers for formal metadata:
+
+- `BREAKING CHANGE: ...`
+- `Co-authored-by: ...`
+- other standard trailers when needed
+
+Do not put ordinary explanation into footers.
+
+## Merge Commits
+
+Repo history currently diverges from the written ideal:
+
+- many individual commits already use conventional subjects
+- many merge commits still use GitHub's default `Merge pull request #...` subject
+
+When you are asked to draft or perform a merge commit, prefer an explicit conventional message instead of the GitHub default.
+
+Recommended merge subjects:
+
+```text
+chore: merge develop into staging for release candidate
+chore: promote staging to production release
+fix(release): prepare staging release candidate from develop
+feat(release): promote staging to production
+```
+
+Use `chore` for pure branch-promotion merge commits when the underlying feature/fix commits already describe the real changes.
+
+## Output Style For This Skill
+
+When the user asks for a commit message, return:
+
+1. the proposed subject line
+2. an optional body if the change is non-trivial
+3. a one-line note on release impact when relevant
+
+When the diff is ambiguous, explain the tradeoff briefly, then recommend one message.
+
+## Examples
+
+### Small fix without body
+
+```text
+fix(i18n): add missing coursePage.remove_external_speaker translation
+```
+
+### Bug fix with body
+
+```text
+fix(sessions): protect AttendanceRow synthetic id from data overwrite
+
+parseAttendanceData seeded each row with a synthetic id and then copied
+every key from the imported dataset, which allowed a nullable source id
+column to overwrite the row identifier used by TableGrid.
+
+Skip imported id and _idx keys when building the row object so the
+synthetic identifier remains stable and the attendance review dialog no
+longer crashes on datasets that include their own id column.
+```
+
+### Coordinated feature commit
+
+```text
+feat(attendance): aggregate Zoom attendance across session-scoped instances
+
+Attendance processing previously relied on Zoom's last-call semantics,
+which could attach participants to the wrong session after reconnects or
+late link clicks.
+
+Fetch past meeting instances within the session window, aggregate rows by
+participant across instances, record the match strategy, and keep the
+legacy fallback only for meetings where Zoom reports no instances.
+```
+
+## See Also
+
+Read `references/release-config.md` when you need the exact repo-specific release behavior behind this skill.

--- a/.codex/skills/conventional-commits/references/release-config.md
+++ b/.codex/skills/conventional-commits/references/release-config.md
@@ -1,0 +1,39 @@
+# EduHub Release Config Notes
+
+This reference captures the repo-specific release details that matter when
+choosing or reviewing commit messages.
+
+## Actual Configuration
+
+The active semantic-release configuration is defined in:
+
+- `frontend-nx/.releaserc.json`
+- `.github/workflows/release.yml`
+
+Important current behavior:
+
+- semantic-release is configured only for the `production` branch
+- the GitHub Actions release workflow runs only on `push` to `production`
+- release notes are generated from conventional-commit types
+- release automation updates:
+  - `frontend-nx/package.json`
+  - `package.json`
+  - `functions/*/package.json`
+  - `CHANGELOG.md`
+  - `VERSION`
+  - `frontend-nx/apps/edu-hub/public/version.json`
+
+## Practical Implications
+
+- Conventional commit subjects still matter on feature branches because they
+  shape the eventual release notes and version bump once changes land in
+  `production`.
+- `feat`, `fix`, and `perf` have release significance.
+- Default GitHub merge messages are less informative than explicit
+  conventional merge messages.
+
+## Documentation Drift To Remember
+
+Some repo docs still describe older branch-channel behavior such as dev or
+staging releases. Do not treat those docs as the final source of truth when
+preparing release-sensitive commit messages. Prefer the actual config files.

--- a/.codex/skills/create-migration/SKILL.md
+++ b/.codex/skills/create-migration/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: create-migration
+description: Create and review EduHub Hasura schema migrations. Use when adding tables, columns, constraints, relationships, or other database schema changes, and when coordinating the required metadata, query, type-generation, and function follow-up steps.
+---
+# Create Migration
+
+Use this skill for any EduHub schema change.
+
+## Required Workflow
+
+Do not consider a schema-change task complete until all relevant steps are done:
+
+1. Create the SQL migration directory in `backend/migrations/default/`
+2. Add both `up.sql` and `down.sql`
+3. Update Hasura metadata if tables, relationships, or permissions changed
+4. Update GraphQL queries or fragments affected by the schema change
+5. Regenerate GraphQL types
+6. Scan `functions/` for affected table or column usage and update function logic if needed
+
+## Migration Folder Naming
+
+Use:
+
+```text
+backend/migrations/default/{timestamp}_{action}_{description}/
+```
+
+Examples:
+
+```text
+backend/migrations/default/1753957404053_add_column_status_to_mail_log/
+backend/migrations/default/1753957404053_create_table_AttendanceAudit/
+```
+
+## SQL Expectations
+
+- `up.sql` should do the real change
+- `down.sql` should reverse it cleanly
+- new tables should include a table comment where practical
+- keep the SQL narrow and explicit; do not mix unrelated schema changes in one migration
+
+## Metadata And Query Follow-Up
+
+After schema changes:
+
+- update `backend/metadata/` when permissions, tables, or relationships changed
+- update queries in `frontend-nx/apps/edu-hub/queries/` if field shape changed
+- use the `regenerate-types` skill for codegen
+
+## Function Impact Scan
+
+This repo has serverless consumers under `functions/`.
+
+For every changed table or column:
+
+- search `functions/` for the old and new names
+- update GraphQL queries or business logic where needed
+- pay special attention to `functions/callNodeFunction/`, `functions/sendMail/`, and related modules
+
+Suggested search:
+
+```text
+rg "<table_or_column_name>" functions/
+```
+
+## Naming Conventions
+
+- tables: PascalCase
+- columns: camelCase
+- timestamp fields: usually `created_at`, `updated_at`
+- foreign keys: `{tableName}Id`
+
+## Output Style For This Skill
+
+When asked to make a schema change, carry the work through this checklist and
+state clearly which of the six required follow-up steps were completed.

--- a/.codex/skills/frontend-patterns/SKILL.md
+++ b/.codex/skills/frontend-patterns/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: frontend-patterns
+description: Apply EduHub frontend conventions for components, layout, translations, TableGrid usage, and responsive behavior. Use when creating or refactoring frontend components or pages in the Next.js app.
+---
+# Frontend Patterns
+
+Use this skill for frontend component and page work in `frontend-nx/apps/edu-hub`.
+
+## Core Rules
+
+- organize code by feature, not by generic technology buckets
+- check existing shared components before creating a new one
+- prefer composition and small focused hooks over large monolithic components
+- keep user-facing text in translations, not inline strings
+- make layouts and interactions work on mobile as well as desktop
+
+## Reuse First
+
+Before creating new UI, check:
+
+- `components/common/`
+- `components/common/dialogs/`
+- `components/inputs/`
+- `components/common/TableGrid/`
+
+Common existing building blocks include:
+
+- `ErrorMessageDialog`
+- `QuestionConfirmationDialog`
+- `NotificationSnackbar`
+- `CreatableTagSelector`
+- `DropDownSelector`
+- `InputField`
+- `TableGrid`
+
+## Component Structure
+
+- keep feature code near the feature it serves
+- extract complex logic into a custom hook when the component becomes hard to read
+- avoid deep component nesting and broad prop drilling
+- use TypeScript interfaces for props
+
+## Translations
+
+German must use the informal "Du" form.
+
+Keep translations in `frontend-nx/apps/edu-hub/locales/` and add new keys to both:
+
+- `de.json`
+- `en.json`
+
+Read `references/translations.md` for naming and enum-key rules.
+
+## TableGrid
+
+Use the shared `TableGrid` rather than reinventing table behavior.
+
+Read `references/tablegrid.md` when:
+
+- adding a new table
+- configuring columns
+- wiring search or pagination
+- deciding between table and mobile-card presentation
+
+## Responsive Behavior
+
+- start from the smallest useful layout first
+- ensure tap targets and action visibility remain usable on mobile
+- when dense tables become unreadable on mobile, consider a card-like representation instead of forcing every desktop column into view
+
+## Output Style For This Skill
+
+When making frontend changes, mention the existing components or patterns you reused before creating anything new.

--- a/.codex/skills/frontend-patterns/references/tablegrid.md
+++ b/.codex/skills/frontend-patterns/references/tablegrid.md
@@ -1,0 +1,20 @@
+# EduHub TableGrid Notes
+
+Use `frontend-nx/apps/edu-hub/components/common/TableGrid/` as the first stop
+for table work.
+
+## Key Rules
+
+- memoize columns
+- use `size` rather than legacy width metadata
+- reset paging when filters or page size change
+- keep hook and component page-size behavior aligned
+- do not manually rebuild functionality that `useTableGrid` already handles
+
+## When Mobile Matters
+
+If a table is too dense for smaller screens:
+
+- reduce the column set
+- move secondary information into the main column cell
+- consider a card renderer instead of a forced wide table

--- a/.codex/skills/frontend-patterns/references/translations.md
+++ b/.codex/skills/frontend-patterns/references/translations.md
@@ -1,0 +1,25 @@
+# EduHub Translation Notes
+
+## Mandatory German Tone
+
+Use informal German "Du", never formal "Sie".
+
+## File Location
+
+- `frontend-nx/apps/edu-hub/locales/de.json`
+- `frontend-nx/apps/edu-hub/locales/en.json`
+
+## Key Naming
+
+- namespace: camelCase
+- component group: PascalCase
+- translation key: snake_case
+- DB enum-backed translation keys may remain ALL_CAPS when they map directly to database enum values
+
+## Practical Rule
+
+When adding a new user-facing label, error, or aria label:
+
+1. add the key in both locale files
+2. keep the wording consistent with nearby keys
+3. preserve the "Du" form in German

--- a/.codex/skills/graphql-backend/SKILL.md
+++ b/.codex/skills/graphql-backend/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: graphql-backend
+description: Apply EduHub GraphQL, Hasura, and schema-change conventions. Use when editing queries, mutations, fragments, metadata, role-based GraphQL hooks, or backend changes that affect frontend GraphQL usage.
+---
+# GraphQL Backend
+
+Use this skill for GraphQL and Hasura-facing work in EduHub.
+
+## Critical Hook Rule
+
+Do not use `useAuthedQuery`.
+
+Use role-aware hooks instead:
+
+- `useRoleQuery`
+- `useRoleMutation`
+- `useAdminQuery`
+- `useAdminMutation`
+- `useInstructorQuery`
+
+Reason: hardcoding the `user` role can produce incorrect Hasura permission behavior.
+
+## Query And Mutation Structure
+
+Keep GraphQL code organized under the repo's query structure:
+
+- fragments
+- queries
+- mutations
+
+Use fragments for reusable field groups and fetch only the fields actually needed.
+
+## Schema-Change Coordination
+
+If the task touches backend schema or permissions, do not stop at the query file.
+
+Coordinate across:
+
+- `backend/migrations/`
+- `backend/metadata/`
+- `frontend-nx/apps/edu-hub/queries/`
+- generated GraphQL types
+- `functions/` consumers when relevant
+
+Read `references/hasura-schema-change-checklist.md` for the full checklist.
+
+## Good Patterns
+
+- use `skip` for conditional queries
+- add explicit error handling on mutations
+- regenerate types after changing schema or documents
+- verify permissions for the actual role that will execute the query
+
+## Output Style For This Skill
+
+When making GraphQL-related changes, state which layers were affected:
+
+1. query or mutation documents
+2. metadata or permissions
+3. generated types
+4. downstream function consumers

--- a/.codex/skills/graphql-backend/references/hasura-schema-change-checklist.md
+++ b/.codex/skills/graphql-backend/references/hasura-schema-change-checklist.md
@@ -1,0 +1,19 @@
+# Hasura Schema Change Checklist
+
+Use this checklist for any schema-affecting task.
+
+## Required Layers
+
+1. SQL migration in `backend/migrations/default/...`
+2. metadata updates in `backend/metadata/` when tables, relationships, or permissions change
+3. query and fragment updates in `frontend-nx/apps/edu-hub/queries/`
+4. GraphQL type regeneration
+5. function impact scan in `functions/`
+
+## Permission Reminder
+
+When a field is role-restricted in Hasura:
+
+- verify which frontend role actually requests it
+- prefer role-aware query hooks
+- avoid hidden permission mismatches caused by hardcoded user-role helpers

--- a/.codex/skills/hotfix-cherrypick/SKILL.md
+++ b/.codex/skills/hotfix-cherrypick/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: hotfix-cherrypick
+description: Backport EduHub production hotfixes into develop and optionally staging. Use when a fix landed directly on production and must be cherry-picked into the normal promotion branches.
+---
+# Hotfix Cherry-Pick
+
+Use this skill when a production hotfix needs to be backported.
+
+## Default Flow
+
+1. identify commits present in `production` but missing from `develop`
+2. cherry-pick them onto `develop`
+3. verify the commit is now contained in `develop`
+
+Useful command:
+
+```bash
+git log --oneline develop..production
+```
+
+## Standard Cherry-Pick Flow
+
+```bash
+git checkout develop
+git pull origin develop
+git cherry-pick <commit-hash>
+git push origin develop
+```
+
+Verify:
+
+```bash
+git branch --contains <commit-hash>
+```
+
+## When To Also Pick To Staging
+
+Also backport to `staging` when:
+
+- the user explicitly asks for it
+- the fix is urgent and needed before the next normal promotion from `develop`
+- release timing means waiting for the next promotion would be risky
+
+## Conflict Handling
+
+If cherry-pick conflicts:
+
+- resolve the files intentionally
+- continue with `git cherry-pick --continue`
+- abort with `git cherry-pick --abort` if the pick was wrong or needs to be retried differently
+
+## Output Style For This Skill
+
+When helping with a hotfix backport, tell the user:
+
+1. which commit(s) were missing
+2. whether you are targeting only `develop` or both `develop` and `staging`
+3. whether conflicts occurred

--- a/.codex/skills/lint-project/SKILL.md
+++ b/.codex/skills/lint-project/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: lint-project
+description: Run and interpret EduHub frontend linting. Use when checking code style, running ESLint, fixing lint errors, or matching the repository's frontend lint behavior from CI.
+---
+# Lint Project
+
+Use this skill for frontend linting work.
+
+## Main Command
+
+Run from `frontend-nx`:
+
+```bash
+yarn lint
+```
+
+Auto-fix where appropriate:
+
+```bash
+yarn lint --fix
+```
+
+## Expectations
+
+- this matches the frontend lint step used in CI
+- use Node.js 20.x and Yarn 3.4.1 when reproducing local results
+- if local and CI results differ, reinstall dependencies with the repo's locked versions
+
+## Good Workflow
+
+1. run lint
+2. apply `--fix` if the failures are mechanical
+3. address remaining semantic issues manually
+4. rerun lint to verify a clean result
+
+## Common Manual Fixes
+
+- remove unused imports
+- correct hook dependency issues
+- tighten TypeScript types
+- align with existing frontend patterns instead of suppressing lint rules by default

--- a/.codex/skills/regenerate-types/SKILL.md
+++ b/.codex/skills/regenerate-types/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: regenerate-types
+description: Regenerate EduHub GraphQL TypeScript types. Use after GraphQL schema changes, query or mutation edits, metadata changes, or when updating generated query types from Hasura.
+---
+# Regenerate Types
+
+Use this skill when GraphQL documents or the underlying schema changed.
+
+## Prerequisite
+
+Hasura must be running and reachable at:
+
+```text
+http://localhost:8080/v1/graphql
+```
+
+## Command
+
+Run from `frontend-nx`:
+
+```bash
+GRAPHQL_URI=http://localhost:8080/v1/graphql yarn apollo
+```
+
+## When To Run
+
+Run codegen after:
+
+- new queries or mutations
+- changed fragments
+- schema migrations or metadata changes
+- pulled changes that modified generated GraphQL surfaces
+
+## Troubleshooting
+
+- If Hasura is not running, start the stack first.
+- If generated output looks stale, clear the generated directory and rerun codegen.
+- If the task involved schema changes, pair this skill with `create-migration`.
+
+## Output Style For This Skill
+
+When you use this skill, mention:
+
+1. whether Hasura was available
+2. whether codegen was run successfully
+3. whether any generated files changed

--- a/.codex/skills/release-workflow/SKILL.md
+++ b/.codex/skills/release-workflow/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: release-workflow
+description: Guide EduHub release preparation and branch-promotion work. Use when preparing release PRs, promoting changes across develop, staging, and production, drafting merge commit messages for release branches, or explaining how semantic-release behaves in this repository.
+---
+# Release Workflow
+
+Use this skill for EduHub branch-promotion and release work.
+
+## Source Of Truth
+
+Prefer the actual release configuration over prose docs:
+
+- `frontend-nx/.releaserc.json`
+- `.github/workflows/release.yml`
+
+Current reality:
+
+- semantic-release runs only for `production`
+- `develop` and `staging` still matter operationally, but they do not publish releases by themselves
+
+Read `references/semantic-release.md` when you need exact repo behavior.
+
+## Branch Flow
+
+Use this branch flow unless the user says otherwise:
+
+1. Feature branches merge into `develop`
+2. `develop` is promoted to `staging` for release-candidate testing
+3. `staging` is promoted to `production` for the actual release
+
+## When To Use Which Commit Message
+
+For ordinary feature work, individual commits should describe the real change and usually use `feat`, `fix`, `perf`, and so on.
+
+For branch-promotion merges:
+
+- prefer an explicit conventional merge message
+- avoid GitHub's default `Merge pull request #...` message when preparing a merge manually or when the user asks you to draft one
+
+Recommended branch-promotion subjects:
+
+```text
+chore: merge develop into staging for release candidate
+chore: promote staging to production release
+```
+
+If the user is squashing and needs the squash commit itself to carry release intent, use one of:
+
+```text
+fix(release): prepare staging release candidate from develop
+feat(release): prepare staging release candidate from develop
+feat(release)!: prepare staging release candidate from develop
+```
+
+Use the lowest truthful release-impact type.
+
+## Practical Guidance
+
+- Treat `production` as the only branch that publishes a semantic-release version.
+- Keep individual feature/fix commits descriptive so the final release notes remain useful.
+- Use `chore` for pure branch promotion when the underlying commits already describe the user-facing changes.
+- Use `feat`/`fix`/`feat!` on a squash merge only when that single merge commit must carry the version-bump meaning.
+
+## Output Style For This Skill
+
+When the user asks how to promote a release, answer with:
+
+1. the branch path to use
+2. the recommended PR or merge commit title
+3. any release-impact note that matters
+4. any repo-specific warning if docs and config differ
+
+## See Also
+
+- `../conventional-commits/SKILL.md`
+- `references/semantic-release.md`

--- a/.codex/skills/release-workflow/references/semantic-release.md
+++ b/.codex/skills/release-workflow/references/semantic-release.md
@@ -1,0 +1,28 @@
+# EduHub Semantic Release Notes
+
+## Actual Behavior
+
+Source files:
+
+- `frontend-nx/.releaserc.json`
+- `.github/workflows/release.yml`
+
+Current active behavior:
+
+- semantic-release is configured only for `production`
+- GitHub Actions runs the release workflow only on `push` to `production`
+- release notes are generated from conventional commits
+- release automation updates versioned files across the monorepo
+
+## Important Drift
+
+Some repo docs still describe older `develop` and `staging` release channels.
+Do not treat those docs as the final source of truth when advising on release
+behavior. Use the actual config files above.
+
+## Operational Implications
+
+- `develop` and `staging` are still useful promotion branches
+- only `production` creates version tags and GitHub releases
+- merge-message wording still matters because it affects changelog quality and
+  can matter when squash merges collapse many commits into one

--- a/.codex/skills/run-tests/SKILL.md
+++ b/.codex/skills/run-tests/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: run-tests
+description: Run and interpret EduHub tests. Use when executing the Jest suite, running a subset of frontend tests, checking coverage, or verifying changes before merge.
+---
+# Run Tests
+
+Use this skill for frontend test execution and test-targeting advice.
+
+## Main Commands
+
+Run from `frontend-nx`:
+
+```bash
+yarn test
+yarn test --watch
+yarn test --coverage
+yarn test --testPathPattern="MyComponent.test"
+```
+
+## Test Conventions
+
+- co-located test files are normal
+- Jest + React Testing Library are the default frontend stack
+- prefer behavior-oriented tests over implementation-detail tests
+
+## Common Patterns
+
+- run a single file or pattern when iterating on a focused change
+- use verbose output or only-failures mode when debugging
+- rerun the smallest meaningful scope first, then rerun the broader suite
+
+## Known Repo Issue
+
+This repo has a pre-existing Jest/Babel version conflict documented in `AGENTS.md`.
+If tests fail with a Babel version requirement rather than with a feature-specific
+assertion, treat that as an environment/repo baseline issue rather than proof that
+your change is wrong.
+
+## Output Style For This Skill
+
+When reporting test results, distinguish clearly between:
+
+- real regression or assertion failures
+- environment or baseline test-harness problems

--- a/.codex/skills/security-auth/SKILL.md
+++ b/.codex/skills/security-auth/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: security-auth
+description: Apply EduHub authentication, authorization, and security conventions. Use when working on Keycloak, NextAuth, JWT/session handling, role checks, Hasura permissions, or security-sensitive frontend and backend behavior.
+---
+# Security Auth
+
+Use this skill for authentication, authorization, and security-sensitive changes.
+
+## Core Architecture
+
+EduHub authentication spans:
+
+- Keycloak for identity and realm roles
+- NextAuth session handling in the frontend
+- Hasura role-based permissions
+- frontend role-aware GraphQL hooks
+
+Changes in one layer often require checking the others.
+
+## Core Rules
+
+- preserve least-privilege behavior
+- do not hardcode a lower or broader role than the user actually has
+- verify both authenticated and unauthorized behavior
+- treat admin, instructor, and participant flows as distinct
+
+## Frontend Expectations
+
+- use existing auth/session helpers instead of inventing parallel state
+- keep role checks explicit and readable
+- when gating UI actions, ensure unauthorized users cannot trigger the underlying write path indirectly
+
+## GraphQL Expectations
+
+- use role-aware hooks for GraphQL operations
+- verify Hasura permissions match the actual caller role
+- when adding fields to existing fragments, check whether all consuming roles are allowed to read them
+
+## Sensitive Change Checklist
+
+For auth or permission changes, check:
+
+1. login/session flow
+2. frontend role checks
+3. GraphQL role headers and hooks
+4. Hasura metadata permissions
+5. unauthorized and authorized test paths
+
+## Output Style For This Skill
+
+When you make a security-relevant change, state clearly:
+
+1. which role or permission boundary changed
+2. which layers were updated
+3. how unauthorized behavior was verified

--- a/.codex/skills/start-dev/SKILL.md
+++ b/.codex/skills/start-dev/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: start-dev
+description: Start and inspect the EduHub local development environment. Use when bringing up the Docker stack, checking service URLs and ports, tailing logs, or resetting the local dev environment.
+---
+# Start Dev
+
+Use this skill for local environment bring-up and service inspection.
+
+## Main Command
+
+From the repo root:
+
+```bash
+docker compose up -d
+```
+
+## Key Services
+
+- frontend: `http://localhost:5000`
+- Hasura: `http://localhost:8080`
+- Keycloak: `http://localhost:28080`
+
+Login:
+
+```text
+admin@example.com / dev
+```
+
+## Useful Variants
+
+```bash
+docker compose up frontend-nx hasura
+docker compose logs -f frontend-nx
+docker compose down
+docker compose down -v
+docker compose up --build
+```
+
+## Expected Startup Notes
+
+- Keycloak and Hasura may take 30-60 seconds on first boot
+- the frontend container may spend extra time installing dependencies before the app is ready
+
+## When To Use Host Commands Instead
+
+Lint, tests, and builds run on the host from `frontend-nx/`, not inside the Docker containers:
+
+- `yarn lint`
+- `yarn test`
+- `yarn build`
+
+## Output Style For This Skill
+
+When helping the user start the app, mention:
+
+1. the command used
+2. the primary service URLs
+3. any startup delay or known wait time that matters

--- a/.codex/skills/version-update-summaries/SKILL.md
+++ b/.codex/skills/version-update-summaries/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: version-update-summaries
+description: Write user-facing EduHub release summaries in plain language. Use when turning release notes or commit history into Slack posts, release announcements, newsletters, or other non-technical update summaries.
+---
+# Version Update Summaries
+
+Use this skill when the audience is non-technical.
+
+## Goals
+
+- focus on user-visible value
+- explain benefits, not implementation details
+- keep the summary easy to scan
+
+## Include
+
+- new features
+- meaningful workflow improvements
+- important UI/UX changes
+- major technical upgrades when users should know about them
+
+## Exclude By Default
+
+- commit hashes
+- low-level refactors
+- internal tooling changes
+- bug fixes that have no meaningful user-facing effect
+
+## Slack-Friendly Style
+
+- use short sections
+- use bold section headers
+- prefer concise bullets
+- group related changes by feature area
+
+## How To Gather Material
+
+Start from:
+
+1. the release page or generated release notes
+2. commits between versions
+3. feature commits first
+4. major technical upgrades that deserve plain-language explanation
+
+## Writing Rule
+
+Translate technical work into user impact:
+
+- not "migrated to next-intl"
+- instead "modernized the translation system to improve maintainability and reduce translation issues over time"
+
+## Output Style For This Skill
+
+When asked for a release summary:
+
+1. open with one short overview paragraph
+2. group changes by user-facing area
+3. keep each bullet benefit-oriented
+4. end with any important expectation-setting note if a major technical change may surface minor issues


### PR DESCRIPTION
## Summary
- Add and update several `.codex` skill docs for EduHub workflows.
- Cover commit conventions, migrations, frontend patterns, GraphQL backend
  changes, hotfix backports, linting, type regeneration, release workflow,
  tests, auth, dev startup, and version update summaries.
- Include supporting reference docs for release config, semantic-release,
  Hasura schema changes, TableGrid usage, and translations.

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive skill guides for conventional commits, schema migrations, frontend patterns, GraphQL backend development, testing, security authentication, release workflows, and local development environment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->