### PR TITLE
fix(tablegrid): allow table headers to grow for wrapped labels

### DIFF
--- a/frontend-nx/apps/edu-hub/components/common/TableGrid/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TableGrid/index.tsx
@@ -471,7 +471,7 @@ const TableGrid = <T extends BaseRow,>({
                 return (
                 <div
                   key={header.id}
-                  className={`${header.column.columnDef.meta?.className || ''} ${header.column.id === 'selection' ? '' : 'min-w-0'} relative flex items-center h-12 ${header.column.getCanSort() ? 'cursor-pointer' : ''}`}
+                  className={`${header.column.columnDef.meta?.className || ''} ${header.column.id === 'selection' ? '' : 'min-w-0'} relative flex items-center min-h-12 ${header.column.getCanSort() ? 'cursor-pointer' : ''}`}
                   style={getDataColumnStyle(header.column.id, header.getSize())}
                   onClick={header.column.getCanSort() ? header.column.getToggleSortingHandler() : undefined}
                 >


### PR DESCRIPTION
The shared header container used a fixed h-12 height, which clipped longer translations in the courses management table.

Replace the fixed header height with min-h-12 so wrapped labels can grow vertically while keeping the existing minimum header size.

Closes #1671

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Table header cells now support flexible minimum height instead of fixed height, allowing content to expand naturally when needed for improved layout accommodation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->