### PR TITLE
fix(frontend): align EduHub dropdown height in Safari

### DIFF
--- a/frontend-nx/apps/edu-hub/components/inputs/DropDownSelector/components/EduhubDropDown.tsx
+++ b/frontend-nx/apps/edu-hub/components/inputs/DropDownSelector/components/EduhubDropDown.tsx
@@ -39,7 +39,7 @@ export const EduhubDropDown: React.FC<EduhubDropDownProps> = ({
   getLabelForValue,
   disabled = false,
 }) => {
-  const baseClass = 'w-full pl-3 pr-10 py-3 text-label-primary rounded bg-fill-primary';
+  const baseClass = 'w-full h-12 pl-3 pr-10 py-3 text-label-primary rounded bg-fill-primary';
   const finalClassName = `${baseClass} ${className}`;
 
   const handleChange = (event: React.ChangeEvent<HTMLSelectElement>) => {


### PR DESCRIPTION
The profile page renders country and occupation as native EduHub select fields, which Safari displayed shorter than adjacent free-text fields.

Closes #1679

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated dropdown input height for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->