### PR TITLE
fix(functions): restore python_functions dev startup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,7 +82,7 @@ services:
     ports:
       - "42025:42025"
       - "42026:42026"
-    command: sh -c "pip install -r /functions/callPythonFunction/requirements.txt && pip install -r /functions/apiProxy/requirements.txt && /functions/start-python.sh"
+    command: sh -c "pip install -r /functions/apiProxy/requirements.txt && pip install -r /functions/callPythonFunction/requirements.txt && /functions/start-python.sh"
     environment:
       ENVIRONMENT: development
       KEYCLOAK_URL: http://keycloak:8080


### PR DESCRIPTION
The dev python_functions container installs both Python requirement files into one shared environment. Installing callPythonFunction first let apiProxy downgrade cryptography below the version required by pyHanko, causing xhtml2pdf imports to crash on startup.

Install apiProxy requirements first in Docker Compose so the final shared dev environment satisfies callPythonFunction's PDF dependencies. Production Cloud Functions keep their separate requirement files unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal dependency installation sequence in deployment configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->