### PR TITLE
fix(projects): block confirm-team without an accepted author

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/ConfirmTeamDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/ConfirmTeamDialog.tsx
@@ -54,8 +54,10 @@ const ConfirmTeamDialog: FC<ConfirmTeamDialogProps> = ({
       .map((a) => `${a.User?.firstName ?? ''} ${a.User?.lastName ?? ''}`.trim());
   }, [project]);
 
+  const hasAcceptedAuthor = acceptedAuthorNames.length > 0;
+
   const handleConfirm = async () => {
-    if (!project || !type || !templateId) {
+    if (!project || !type || !templateId || !hasAcceptedAuthor) {
       return;
     }
     try {
@@ -87,7 +89,7 @@ const ConfirmTeamDialog: FC<ConfirmTeamDialogProps> = ({
           <Button
             filled
             onClick={handleConfirm}
-            disabled={loading || !type || !templateId}
+            disabled={loading || !type || !templateId || !hasAcceptedAuthor}
           >
             {t('projects.confirm_team_dialog.confirm_button')}
           </Button>
@@ -98,12 +100,12 @@ const ConfirmTeamDialog: FC<ConfirmTeamDialogProps> = ({
         <div className="space-y-4">
           <div>
             <p className="text-sm font-medium mb-1">{t('projects.confirm_team_dialog.authors_label')}</p>
-            {acceptedAuthorNames.length === 0 ? (
-              <p className="text-sm text-label-secondary">
-                {t('projects.confirm_team_dialog.no_authors')}
-              </p>
-            ) : (
+            {hasAcceptedAuthor ? (
               <p className="text-sm">{acceptedAuthorNames.join(', ')}</p>
+            ) : (
+              <p className="text-sm text-error">
+                {t('projects.confirm_team_dialog.no_authors_blocking')}
+              </p>
             )}
           </div>
           <label className="block">

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1302,7 +1302,7 @@
       "confirm_team_dialog": {
         "title": "Team bestätigen und Projekt starten",
         "authors_label": "Bestätigte Autor:innen",
-        "no_authors": "Noch keine bestätigten Autor:innen.",
+        "no_authors_blocking": "Füge mindestens eine:n bestätigte:n Autor:in hinzu, bevor Du das Team bestätigst.",
         "type_label": "Projekttyp",
         "type_placeholder": "Projekttyp auswählen",
         "template_label": "Dokumentationsvorlage",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1320,7 +1320,7 @@
       "confirm_team_dialog": {
         "title": "Confirm team and start project",
         "authors_label": "Accepted authors",
-        "no_authors": "No accepted authors yet.",
+        "no_authors_blocking": "Add at least one accepted author before confirming the team.",
         "type_label": "Project type",
         "type_placeholder": "Select a project type",
         "template_label": "Documentation template",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In the new project workflow, the **Confirm team and start project** dialog only gates the action on `type` and `documentationTemplateId`. Nothing prevents an instructor from flipping a `PROPOSED` project to `ONGOING` while the project still has no `ACCEPTED` `ProjectAuthor`. The result is a "team-less" ongoing project, which is meaningless to every later step of the workflow (submission, review, completion, publish).

The mutation `UPDATE_PROJECT_CONFIRM_TEAM` itself sets `status: ONGOING` with no server-side check, so the only existing guard is the dialog UI — and it didn't enforce the obvious precondition.

## Fix

Surgical client-side change in `ConfirmTeamDialog`:

- Disable the **Start project** button when there is no author with `participationStatus = ACCEPTED`.
- Guard `handleConfirm` with the same check (defense in depth in case the disabled state is ever bypassed).
- Replace the soft "No accepted authors yet." hint with a clear, blocking instruction: _"Add at least one accepted author before confirming the team."_ Translation key renamed (`no_authors` → `no_authors_blocking`) in both `de.json` and `en.json`. German keeps the informal `Du` form per repo convention.

No backend changes. The dialog is the only consumer of `UPDATE_PROJECT_CONFIRM_TEAM`, and the rest of the project surfaces (`ProjectsManagementGrid`, `MyProjectPanel`, etc.) are untouched.

## Walkthrough

[Confirm Team dialog blocks confirm and shows a red instruction when no accepted authors exist](https://cursor.com/agents/bc-71718a12-66b9-4e65-8277-a45f5f21423c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconfirm_team_dialog_blocked_no_authors.webp)

The **Projekt starten** button is greyed out and unresponsive; the red message _"Füge mindestens eine:n bestätigte:n Autor:in hinzu, bevor Du das Team bestätigst."_ is shown in place of the previous neutral hint.

[ProjectsManagementGrid showing the proposed project under course 302](https://cursor.com/agents/bc-71718a12-66b9-4e65-8277-a45f5f21423c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fprojects_management_grid.webp)

Reproduced manually on `localhost:5000/manage/course/302` after seeding a `PROPOSED` Project with no authors via Hasura.

## Testing

- ✅ `yarn lint` — passes (no new warnings; one pre-existing warning unrelated to this change)
- ✅ Manual UI verification: dialog opened on a `PROPOSED` project with zero `ACCEPTED` authors; `Start project` is disabled; red helper text is rendered; click attempts on the disabled button perform no action.

## Out of scope / follow-ups

- A server-side guard on `UPDATE_PROJECT_CONFIRM_TEAM` (e.g. a Postgres trigger or a Hasura action) would close the same hole if anyone calls the mutation directly. Happy to add that as a separate change if you want belt-and-suspenders.
- Unrelated finding while reviewing: `ProjectsManagementGrid` uses `useAuthedQuery` for `PROJECT_TYPES` and `PROJECT_DOCUMENTATION_TEMPLATES`. The repo rule (`graphql-integration-patterns.mdc`) says to always prefer `useRoleQuery`. Not touching it here to keep the diff scoped to the bug you flagged.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-71718a12-66b9-4e65-8277-a45f5f21423c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-71718a12-66b9-4e65-8277-a45f5f21423c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

