### PR TITLE
feat(manage-course): bulk mark participations as aborted

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
@@ -1,7 +1,7 @@
 import { ApolloError, QueryResult } from '@apollo/client';
 import { useTranslations } from 'next-intl';
 import { FC, useCallback, useMemo, useState } from 'react';
-import { useIsAdmin } from '../../../../hooks/authentication';
+import { useIsAdmin, useIsInstructor } from '../../../../hooks/authentication';
 import { useRoleMutation } from '../../../../hooks/authedMutation';
 import Dot, { DotColor } from '../../../common/Dot';
 import { CertificateDownload } from '../../../common/CertificateDownload';
@@ -27,7 +27,16 @@ import {
   InsertSingleAttendanceVariables,
 } from '../../../../queries/__generated__/InsertSingleAttendance';
 import { ManagedCourse_Course_by_pk } from '../../../../queries/__generated__/ManagedCourse';
-import { AttendanceStatus_enum, ProjectRating_enum } from '../../../../__generated__/globalTypes';
+import {
+  AttendanceStatus_enum,
+  CourseEnrollmentStatus_enum,
+  ProjectRating_enum,
+} from '../../../../__generated__/globalTypes';
+import { UPDATE_ENROLLMENT_STATUS_WHEN_CONFIRMED } from '../../../../queries/insertEnrollment';
+import {
+  UpdateEnrollmentStatusWhenConfirmed,
+  UpdateEnrollmentStatusWhenConfirmedVariables,
+} from '../../../../queries/__generated__/UpdateEnrollmentStatusWhenConfirmed';
 import { Tooltip } from '@mui/material';
 import { pickEffectiveAttendance } from '../../../../helpers/attendance';
 import { IoIosCheckmarkCircle } from 'react-icons/io';
@@ -45,6 +54,7 @@ import {
   getCourseProjectSubmissionDefaultSource,
   submissionDeadlineToIsoString,
 } from '../../CourseContent/Projects/projectEffectiveSubmissionDeadline';
+import { QuestionConfirmationDialog } from '../../../common/dialogs/QuestionConfirmationDialog';
 
 interface CourseParticipationsTabIProps {
   course: ManagedCourse_Course_by_pk;
@@ -131,15 +141,23 @@ function getAttendanceStatus(
 
 export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ course, qResult }) => {
   const t = useTranslations('manageCourse');
+  const tCommon = useTranslations('common');
   const tCoursePage = useTranslations('coursePage');
   const isAdmin = useIsAdmin();
+  const isInstructor = useIsInstructor();
 
   const [pageSize, setPageSize] = useState(20);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [snackbarMessage, setSnackbarMessage] = useState('');
   const [bulkActionError, setBulkActionError] = useState<string | null>(null);
+  const [abortDialogOpen, setAbortDialogOpen] = useState(false);
+  const [pendingAbortRows, setPendingAbortRows] = useState<ExtendedEnrollment[]>([]);
 
   const [createCertificates] = useRoleMutation(CREATE_CERTIFICATES);
+  const [updateEnrollmentStatusWhenConfirmed] = useRoleMutation<
+    UpdateEnrollmentStatusWhenConfirmed,
+    UpdateEnrollmentStatusWhenConfirmedVariables
+  >(UPDATE_ENROLLMENT_STATUS_WHEN_CONFIRMED);
   const [removeAchievementCertificates] = useRoleMutation(REMOVE_ACHIEVEMENT_CERTIFICATES);
   const [removeAttendanceCertificates] = useRoleMutation(REMOVE_ATTENDANCE_CERTIFICATES);
 
@@ -221,8 +239,54 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
     [setPageIndex]
   );
 
+  const handleConfirmAbortParticipations = useCallback(async () => {
+    const enrollmentIds = pendingAbortRows.map((r) => r.id);
+    setAbortDialogOpen(false);
+    try {
+      const result = await updateEnrollmentStatusWhenConfirmed({
+        variables: {
+          enrollmentIds,
+          status: CourseEnrollmentStatus_enum.ABORTED,
+          courseId: course.id,
+        },
+      });
+      const affectedRows = result.data?.update_CourseEnrollment?.affected_rows ?? 0;
+      const messageKey =
+        affectedRows === 1
+          ? 'participations_bulk_actions.mark_aborted_success_singular'
+          : 'participations_bulk_actions.mark_aborted_success_plural';
+      setSnackbarMessage(t(messageKey, { count: affectedRows }));
+      setSnackbarOpen(true);
+      setPendingAbortRows([]);
+      refetch();
+      qResult.refetch();
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : String(err);
+      setBulkActionError(t('participations_bulk_actions.mark_aborted_error', { error: errorMessage }));
+      setPendingAbortRows([]);
+      refetch();
+      qResult.refetch();
+    }
+  }, [
+    pendingAbortRows,
+    updateEnrollmentStatusWhenConfirmed,
+    course.id,
+    t,
+    refetch,
+    qResult,
+  ]);
+
   const handleBulkAction = useCallback(
     async (action: string, selectedRows: ExtendedEnrollment[]) => {
+      if (action === 'mark_participation_aborted') {
+        if (selectedRows.length === 0) {
+          return;
+        }
+        setPendingAbortRows(selectedRows);
+        setAbortDialogOpen(true);
+        return;
+      }
+
       try {
         if (action === 'generate_attendance_certificates') {
           const qualifyingRows = selectedRows.filter(
@@ -386,8 +450,20 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
       value: 'email_selected',
       label: t('bulk_actions.email_selected'),
     });
+    if (isInstructor) {
+      actions.push({
+        value: 'mark_participation_aborted',
+        label: t('participations_bulk_actions.mark_aborted_selected'),
+      });
+    }
     return actions;
-  }, [isAdmin, course.attendanceCertificatePossible, course.achievementCertificatePossible, t]);
+  }, [
+    isAdmin,
+    isInstructor,
+    course.attendanceCertificatePossible,
+    course.achievementCertificatePossible,
+    t,
+  ]);
 
   const AttendanceDotsCell = useMemo(() => {
     return function AttendanceDotsCellInner({
@@ -626,6 +702,30 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
     [t]
   );
 
+  const abortConfirmationDialog = (
+    <QuestionConfirmationDialog
+      open={abortDialogOpen}
+      question={
+        pendingAbortRows.length === 1
+          ? t('participations_bulk_actions.mark_aborted_confirm_singular')
+          : t('participations_bulk_actions.mark_aborted_confirm_plural', {
+              count: pendingAbortRows.length,
+            })
+      }
+      confirmationText={tCommon('confirm')}
+      cancelText={tCommon('cancel')}
+      onClose={() => {
+        setAbortDialogOpen(false);
+        setPendingAbortRows([]);
+      }}
+      onCancel={() => {
+        setAbortDialogOpen(false);
+        setPendingAbortRows([]);
+      }}
+      onConfirm={handleConfirmAbortParticipations}
+    />
+  );
+
   if (!course.achievementCertificatePossible) {
     return (
       <div className="flex flex-col gap-8">
@@ -670,6 +770,7 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
             onClose={() => setBulkActionError(null)}
           />
         )}
+        {abortConfirmationDialog}
       </div>
     );
   }
@@ -736,6 +837,7 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
           onClose={() => setBulkActionError(null)}
         />
       )}
+      {abortConfirmationDialog}
     </div>
   );
 };

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
@@ -242,6 +242,7 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
   const handleConfirmAbortParticipations = useCallback(async () => {
     const enrollmentIds = pendingAbortRows.map((r) => r.id);
     setAbortDialogOpen(false);
+    setBulkActionError(null);
     try {
       const result = await updateEnrollmentStatusWhenConfirmed({
         variables: {

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1392,6 +1392,18 @@
     "no_attendance_certificates_deleted": "Es wurden keine Teilnahmebescheinigungen gelöscht",
     "attendance_certificate_deleted_singular": "{count} Teilnahmebescheinigung wurde gelöscht",
     "attendance_certificates_deleted_plural": "{count} Teilnahmebescheinigungen wurden gelöscht",
+    "participations_bulk_actions": {
+      "mark_aborted_selected": "Teilnahme als abgebrochen markieren",
+      "mark_aborted_dialog_title": "Teilnahme als abgebrochen markieren",
+      "mark_aborted_confirm_singular": "Möchtest du die ausgewählte Person als abgebrochen markieren? Sie verschwindet aus der Teilnehmenden-Liste, bleibt aber unter Bewerbungen sichtbar. Du kannst den Status dort später wieder ändern.",
+      "mark_aborted_confirm_plural": "Möchtest du {count} ausgewählte Personen als abgebrochen markieren? Sie verschwinden aus der Teilnehmenden-Liste, bleiben aber unter Bewerbungen sichtbar. Du kannst den Status dort später wieder ändern.",
+      "mark_aborted_success_singular": "{count} Teilnahme wurde als abgebrochen markiert.",
+      "mark_aborted_success_plural": "{count} Teilnahmen wurden als abgebrochen markiert.",
+      "mark_aborted_error": "Teilnahmen konnten nicht als abgebrochen markiert werden: {error}",
+      "disabled_reasons": {
+        "instructors_only": "Diese Sammelaktion können nur Instructor:innen ausführen."
+      }
+    },
     "certificates_group": "Zertifikate",
     "application_status_tooltip": "Klicke auf die Kreise, um die Bewertung zu ändern",
     "application_deadline_tooltip": "Wenn du das Datum für die Bestätigungsfrist ändern möchtest, kannst du die Einladung erneut senden.",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1410,6 +1410,18 @@
     "no_attendance_certificates_deleted": "No attendance certificates were deleted",
     "attendance_certificate_deleted_singular": "{count} attendance certificate was deleted",
     "attendance_certificates_deleted_plural": "{count} attendance certificates were deleted",
+    "participations_bulk_actions": {
+      "mark_aborted_selected": "Mark participation as aborted",
+      "mark_aborted_dialog_title": "Mark participation as aborted",
+      "mark_aborted_confirm_singular": "Mark the selected person as aborted? They will be removed from the participants list but remain visible under applications. You can change the status there later.",
+      "mark_aborted_confirm_plural": "Mark {count} selected people as aborted? They will be removed from the participants list but remain visible under applications. You can change the status there later.",
+      "mark_aborted_success_singular": "{count} participation was marked as aborted.",
+      "mark_aborted_success_plural": "{count} participations were marked as aborted.",
+      "mark_aborted_error": "Could not mark participations as aborted: {error}",
+      "disabled_reasons": {
+        "instructors_only": "Only instructors can run this bulk action."
+      }
+    },
     "certificates_group": "Certificates",
     "application_status_tooltip": "Click on the circles to change the rating",
     "application_deadline_tooltip": "If you want to change the date for the Confirmation deadline you can resend the invitation.",

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateEnrollmentStatusWhenConfirmed.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateEnrollmentStatusWhenConfirmed.ts
@@ -1,0 +1,40 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { CourseEnrollmentStatus_enum } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: UpdateEnrollmentStatusWhenConfirmed
+// ====================================================
+
+export interface UpdateEnrollmentStatusWhenConfirmed_update_CourseEnrollment_returning {
+  __typename: "CourseEnrollment";
+  id: number;
+}
+
+export interface UpdateEnrollmentStatusWhenConfirmed_update_CourseEnrollment {
+  __typename: "CourseEnrollment_mutation_response";
+  /**
+   * number of rows affected by the mutation
+   */
+  affected_rows: number;
+  /**
+   * data from the rows affected by the mutation
+   */
+  returning: UpdateEnrollmentStatusWhenConfirmed_update_CourseEnrollment_returning[];
+}
+
+export interface UpdateEnrollmentStatusWhenConfirmed {
+  /**
+   * update data of the table: "CourseEnrollment"
+   */
+  update_CourseEnrollment: UpdateEnrollmentStatusWhenConfirmed_update_CourseEnrollment | null;
+}
+
+export interface UpdateEnrollmentStatusWhenConfirmedVariables {
+  enrollmentIds: number[];
+  status: CourseEnrollmentStatus_enum;
+  courseId: number;
+}

--- a/frontend-nx/apps/edu-hub/queries/insertEnrollment.ts
+++ b/frontend-nx/apps/edu-hub/queries/insertEnrollment.ts
@@ -181,6 +181,31 @@ export const UPDATE_ENROLLMENT_STATUS_WHEN_APPLIED = gql`
   }
 `;
 
+/** Bulk status change only for rows still CONFIRMED (participations list → mark as aborted). */
+export const UPDATE_ENROLLMENT_STATUS_WHEN_CONFIRMED = gql`
+  mutation UpdateEnrollmentStatusWhenConfirmed(
+    $enrollmentIds: [Int!]!
+    $status: CourseEnrollmentStatus_enum!
+    $courseId: Int!
+  ) {
+    update_CourseEnrollment(
+      where: {
+        _and: [
+          { id: { _in: $enrollmentIds } }
+          { status: { _eq: CONFIRMED } }
+          { courseId: { _eq: $courseId } }
+        ]
+      }
+      _set: { status: $status }
+    ) {
+      affected_rows
+      returning {
+        id
+      }
+    }
+  }
+`;
+
 /** Bulk invite update for APPLIED, WAITLIST, or already INVITED rows (supports invite resend/deadline changes). */
 export const UPDATE_ENROLLMENT_STATUS_FOR_INVITE = gql`
   mutation UpdateEnrollmentStatusForInvite(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [#1694](https://github.com/eduhub-org/eduhub/issues/1694): organizers can mark selected confirmed participations as **abgebrochen** (ABORTED) from the **Teilnahmen & Leistungen** tab.

## Changes

- New bulk action **"Teilnahme als abgebrochen markieren"** on the participations `TableGrid` (instructors only)
- Confirmation dialog explains that rows leave the participants list but stay under applications, and that the status can be changed again there
- GraphQL mutation `UpdateEnrollmentStatusWhenConfirmed` only updates enrollments that are `CONFIRMED` for the current course (safe bulk update)
- German and English translations under `manageCourse.participations_bulk_actions`

## Data model

Uses existing `CourseEnrollmentStatus.ABORTED` — no migration required.

## Testing

- `yarn lint` (frontend-nx): pass (pre-existing warning in TableGrid hooks only)
- Hasura E2E (Docker): mutation `CONFIRMED → ABORTED` for enrollment 402 on course 201
  - Participant query (`status: CONFIRMED`) no longer returns the row
  - Applications query still returns the enrollment with `ABORTED`
  - Test data reverted to `CONFIRMED` after verification

## Customer announcement (DE)

Du kannst ausgewählte Teilnahmen in einem Schritt als abgebrochen markieren. Sie erscheinen nicht mehr in der aktiven Teilnehmenden-Liste, bleiben aber unter Bewerbungen sichtbar.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-727add18-7aa5-4868-acab-6c6594da1fc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-727add18-7aa5-4868-acab-6c6594da1fc1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Instructors can now bulk mark course participations as "aborted" through a new bulk action. Select multiple participations and confirm via dialog. The system displays success or error feedback with the count of affected participations. This action is restricted to instructors only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->