### PR TITLE
perf(manage-course): reduce session attendance UI latency

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/AttendanceDotsCell.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/AttendanceDotsCell.tsx
@@ -1,0 +1,121 @@
+import { memo, useMemo } from 'react';
+import { Tooltip } from '@mui/material';
+import Dot, { DotColor } from '../../../common/Dot';
+import {
+  collapseAttendancesBySession,
+  getAttendanceStatusFromMap,
+  getDotColorForAttendance,
+} from '../../../../helpers/courseParticipationAttendance';
+import {
+  CourseParticipations_Course_by_pk_CourseEnrollments,
+  CourseParticipations_Course_by_pk_Sessions,
+} from '../../../../queries/__generated__/CourseParticipations';
+
+export interface AttendanceDotsCellProps {
+  enrollment: CourseParticipations_Course_by_pk_CourseEnrollments;
+  sessions: readonly CourseParticipations_Course_by_pk_Sessions[];
+  sessionTooltips: readonly string[];
+  maxMissedSessions: number;
+  statusTooltipPassed: string;
+  statusTooltipFailed: string;
+  statusTooltipUncertain: string;
+  onDotClick: (session: CourseParticipations_Course_by_pk_Sessions, userId: string) => void;
+}
+
+const SessionDot = memo(function SessionDot({
+  color,
+  title,
+  onClick,
+}: {
+  color: DotColor;
+  title: string;
+  onClick: () => void;
+}) {
+  return (
+    <Dot
+      color={color}
+      className="cursor-pointer hover:border-2 hover:border-indigo-200 hover:rounded-full flex-shrink-0"
+      title={title}
+      onClick={onClick}
+    />
+  );
+});
+
+function AttendanceDotsCellComponent({
+  enrollment,
+  sessions,
+  sessionTooltips,
+  maxMissedSessions,
+  statusTooltipPassed,
+  statusTooltipFailed,
+  statusTooltipUncertain,
+  onDotClick,
+}: AttendanceDotsCellProps) {
+  const attendanceBySession = useMemo(
+    () => collapseAttendancesBySession(enrollment.User.Attendances),
+    [enrollment.User.Attendances]
+  );
+
+  const { attended, total, statusDotColor, statusTooltip } = useMemo(() => {
+    let missed = 0;
+    let attendedCount = 0;
+    for (const session of sessions) {
+      const color = getDotColorForAttendance(attendanceBySession[session.id]);
+      if (color === 'red') missed += 1;
+      if (color === 'lightgreen') attendedCount += 1;
+    }
+    const status = getAttendanceStatusFromMap(attendanceBySession, sessions, maxMissedSessions);
+    const statusDotColor: DotColor =
+      status === 'passed' ? 'lightgreen' : status === 'failed' ? 'red' : 'grey';
+    const statusTooltip =
+      status === 'passed'
+        ? statusTooltipPassed
+        : status === 'failed'
+          ? statusTooltipFailed
+          : statusTooltipUncertain;
+    return {
+      attended: attendedCount,
+      total: attendedCount + missed,
+      statusDotColor,
+      statusTooltip,
+    };
+  }, [
+    attendanceBySession,
+    sessions,
+    maxMissedSessions,
+    statusTooltipPassed,
+    statusTooltipFailed,
+    statusTooltipUncertain,
+  ]);
+
+  const userId = enrollment.userId;
+
+  return (
+    <div className="flex flex-row items-center gap-4 min-w-0">
+      <div
+        className="flex flex-row items-center gap-1 overflow-x-auto max-w-[220px] flex-nowrap"
+        role="list"
+        aria-label="session attendance"
+      >
+        {sessions.map((session, index) => (
+          <SessionDot
+            key={session.id}
+            color={getDotColorForAttendance(attendanceBySession[session.id])}
+            title={sessionTooltips[index] ?? ''}
+            onClick={() => onDotClick(session, userId)}
+          />
+        ))}
+      </div>
+      <div className="flex flex-row items-center gap-1 flex-shrink-0">
+        <span className="text-label-primary text-sm whitespace-nowrap">{`${attended}/${total}`}</span>
+        <Tooltip title={statusTooltip}>
+          <span className="inline-flex">
+            <Dot color={statusDotColor} />
+          </span>
+        </Tooltip>
+      </div>
+    </div>
+  );
+}
+
+export const AttendanceDotsCell = memo(AttendanceDotsCellComponent);

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
@@ -4,6 +4,13 @@ import { FC, useCallback, useMemo, useState } from 'react';
 import { useIsAdmin } from '../../../../hooks/authentication';
 import { useRoleMutation } from '../../../../hooks/authedMutation';
 import Dot, { DotColor } from '../../../common/Dot';
+import { AttendanceDotsCell } from './AttendanceDotsCell';
+import { useOptimisticAttendance } from './useOptimisticAttendance';
+import {
+  collapseAttendancesBySession,
+  getAttendanceStatusFromMap,
+  AttendanceOverallStatus,
+} from '../../../../helpers/courseParticipationAttendance';
 import { CertificateDownload } from '../../../common/CertificateDownload';
 import { Card } from '../../../common/Card';
 import { useLazyRoleQuery, useRoleQuery } from '../../../../hooks/authedQuery';
@@ -19,7 +26,6 @@ import {
   CourseParticipations_Course_by_pk_AchievementOptionCourses,
   CourseParticipations_Course_by_pk_AchievementOptionCourses_AchievementOption_AchievementRecords,
   CourseParticipations_Course_by_pk_CourseEnrollments,
-  CourseParticipations_Course_by_pk_CourseEnrollments_User_Attendances,
   CourseParticipations_Course_by_pk_Sessions,
   CourseParticipationsVariables,
 } from '../../../../queries/__generated__/CourseParticipations';
@@ -33,14 +39,13 @@ import {
 } from '../../../../queries/__generated__/InsertSingleAttendance';
 import { GetSignedUrl, GetSignedUrlVariables } from '../../../../queries/__generated__/GetSignedUrl';
 import { ManagedCourse_Course_by_pk } from '../../../../queries/__generated__/ManagedCourse';
-import { AchievementRecordRating_enum, AttendanceStatus_enum } from '../../../../__generated__/globalTypes';
+import { AchievementRecordRating_enum } from '../../../../__generated__/globalTypes';
 import { Button } from '../../../common/Button';
 import { CircularProgress, Tooltip } from '@mui/material';
 import { formattedDateWithTime, makeFullName } from '../../../../helpers/util';
-import { pickEffectiveAttendance } from '../../../../helpers/attendance';
 import { IoIosCheckmarkCircle } from 'react-icons/io';
 import { GoDotFill } from 'react-icons/go';
-import { ColumnDef, Row } from '@tanstack/react-table';
+import { ColumnDef } from '@tanstack/react-table';
 import TableGrid from '../../../common/TableGrid';
 import { useTableGrid } from '../../../common/TableGrid/hooks';
 import { createMultiWordSearchCondition } from '../../../common/TableGrid/utils';
@@ -67,11 +72,6 @@ const EMPTY_ENROLLMENTS: CourseParticipations_Course_by_pk_CourseEnrollments[] =
 const EMPTY_SESSIONS: CourseParticipations_Course_by_pk_Sessions[] = [];
 const EMPTY_ACHIEVEMENT_OPTION_COURSES: CourseParticipations_Course_by_pk_AchievementOptionCourses[] = [];
 
-interface IDotData {
-  color: DotColor;
-  session: CourseParticipations_Course_by_pk_Sessions;
-}
-
 function computeMostRecentRecord(
   enrollment: CourseParticipations_Course_by_pk_CourseEnrollments,
   courseId: number,
@@ -95,54 +95,6 @@ function flattenAchievementRecords(
   }[]
 ): CourseParticipations_Course_by_pk_AchievementOptionCourses_AchievementOption_AchievementRecords[] {
   return achievementOptionCourses.flatMap((opt) => opt.AchievementOption.AchievementRecords);
-}
-
-type AttendanceOverallStatus = 'passed' | 'failed' | 'uncertain';
-
-function collapseAttendancesBySession(
-  attendances: readonly CourseParticipations_Course_by_pk_CourseEnrollments_User_Attendances[]
-): Record<number, CourseParticipations_Course_by_pk_CourseEnrollments_User_Attendances> {
-  const bySession = attendances.reduce<
-    Record<number, CourseParticipations_Course_by_pk_CourseEnrollments_User_Attendances[]>
-  >((prev, curr) => {
-    const bucket = prev[curr.Session.id] ?? [];
-    bucket.push(curr);
-    prev[curr.Session.id] = bucket;
-    return prev;
-  }, {});
-
-  const result: Record<number, CourseParticipations_Course_by_pk_CourseEnrollments_User_Attendances> = {};
-  for (const [sessionId, rows] of Object.entries(bySession)) {
-    const effective = pickEffectiveAttendance(rows, (a) => a.id);
-    if (effective !== undefined) {
-      result[Number(sessionId)] = effective;
-    }
-  }
-  return result;
-}
-
-function getAttendanceStatusFromMap(
-  attendanceBySession: Record<number, CourseParticipations_Course_by_pk_CourseEnrollments_User_Attendances>,
-  sessions: CourseParticipations_Course_by_pk_Sessions[],
-  maxMissedSessions: number
-): AttendanceOverallStatus {
-  let missed = 0;
-  let unchecked = 0;
-  for (const session of sessions) {
-    const att = attendanceBySession[session.id];
-    if (!att) {
-      unchecked += 1;
-    } else if (att.status === AttendanceStatus_enum.MISSED) {
-      missed += 1;
-    } else if (att.status === AttendanceStatus_enum.NO_INFO) {
-      unchecked += 1;
-    }
-    // ATTENDED: no change to missed or unchecked
-  }
-
-  if (missed > maxMissedSessions) return 'failed';
-  if (missed + unchecked <= maxMissedSessions) return 'passed';
-  return 'uncertain';
 }
 
 function getAttendanceStatus(
@@ -228,14 +180,49 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
     [achievementOptionCourses]
   );
   const maxMissedSessions = courseData?.maxMissedSessions ?? course.maxMissedSessions;
+  const isInitialLoading = loading && !courseData;
+
+  const [insertAttendance] = useRoleMutation<InsertSingleAttendance, InsertSingleAttendanceVariables>(
+    INSERT_SINGLE_ATTENDANCE
+  );
+
+  const handleAttendanceError = useCallback(
+    (message: string) => {
+      setBulkActionError(message || t('attendance_update_failed'));
+    },
+    [t]
+  );
+
+  const { enrollmentsWithOverlay, handleDotClick } = useOptimisticAttendance({
+    enrollments,
+    sessions,
+    insertAttendance,
+    refetchParticipations: refetch,
+    qResult,
+    onError: handleAttendanceError,
+  });
 
   const extendedEnrollments: ExtendedEnrollment[] = useMemo(
     () =>
-      enrollments.map((enrollment: CourseParticipations_Course_by_pk_CourseEnrollments) => ({
+      enrollmentsWithOverlay.map((enrollment) => ({
         ...enrollment,
         mostRecentRecord: computeMostRecentRecord(enrollment, course.id, allRecords),
       })),
-    [enrollments, course.id, allRecords]
+    [enrollmentsWithOverlay, course.id, allRecords]
+  );
+
+  const sessionTooltips = useMemo(
+    () => sessions.map((session) => new Date(session.startDateTime).toLocaleString(locale)),
+    [sessions, locale]
+  );
+
+  const attendanceStatusTooltips = useMemo(
+    () => ({
+      passed: t('attendance_status_passed'),
+      failed: t('attendance_status_failed'),
+      uncertain: t('attendance_status_uncertain'),
+    }),
+    [t]
   );
 
   const totalCount = courseData?.CourseEnrollments_aggregate?.aggregate?.count ?? 0;
@@ -416,100 +403,6 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
     return actions;
   }, [isAdmin, course.attendanceCertificatePossible, course.achievementCertificatePossible, t]);
 
-  const AttendanceDotsCell = useMemo(() => {
-    return function AttendanceDotsCellInner({
-      row,
-      onDotClick,
-    }: {
-      row: Row<ExtendedEnrollment>;
-      onDotClick: (session: CourseParticipations_Course_by_pk_Sessions, userId: string) => void;
-    }) {
-      const enrollment = row.original;
-      const attendanceBySession = collapseAttendancesBySession(enrollment.User.Attendances);
-
-      const dotColor = (sn: CourseParticipations_Course_by_pk_Sessions): DotColor => {
-        const att = attendanceBySession[sn.id];
-        if (!att) return 'grey';
-        if (att.status === AttendanceStatus_enum.MISSED) return 'red';
-        if (att.status === AttendanceStatus_enum.ATTENDED) return 'lightgreen';
-        return 'grey';
-      };
-
-      const dotsData: IDotData[] = sessions.map((s: CourseParticipations_Course_by_pk_Sessions) => ({ session: s, color: dotColor(s) }));
-      const missed = dotsData.filter((d) => d.color === 'red').length;
-      const attended = dotsData.filter((d) => d.color === 'lightgreen').length;
-      const total = attended + missed;
-      const status = getAttendanceStatusFromMap(attendanceBySession, sessions, maxMissedSessions);
-      const statusDotColor: DotColor =
-        status === 'passed' ? 'lightgreen' : status === 'failed' ? 'red' : 'grey';
-      const statusTooltip =
-        status === 'passed'
-          ? t('attendance_status_passed')
-          : status === 'failed'
-            ? t('attendance_status_failed')
-            : t('attendance_status_uncertain');
-
-      return (
-        <div className="flex flex-row items-center gap-4">
-          <div className="flex flex-row items-center gap-1 flex-wrap">
-            {dotsData.map((d) => (
-              <Dot
-                key={d.session.id}
-                color={d.color}
-                className="cursor-pointer hover:border-2 hover:border-indigo-200 hover:rounded-full"
-                title={new Date(d.session.startDateTime).toLocaleString()}
-                onClick={() => onDotClick(d.session, enrollment.userId)}
-              />
-            ))}
-          </div>
-          <div className="flex flex-row items-center gap-1 flex-shrink-0">
-            <span className="text-label-primary text-sm whitespace-nowrap">{`${attended}/${total}`}</span>
-            <Tooltip title={statusTooltip}>
-              <span className="inline-flex">
-                <Dot color={statusDotColor} />
-              </span>
-            </Tooltip>
-          </div>
-        </div>
-      );
-    };
-  }, [sessions, maxMissedSessions, t]);
-
-  const [insertAttendance] = useRoleMutation<InsertSingleAttendance, InsertSingleAttendanceVariables>(
-    INSERT_SINGLE_ATTENDANCE
-  );
-
-  const handleDotClick = useCallback(
-    async (session: CourseParticipations_Course_by_pk_Sessions, userId: string) => {
-      const enrollment = extendedEnrollments.find((e) => e.userId === userId);
-      if (!enrollment) return;
-      const attBySession = collapseAttendancesBySession(enrollment.User.Attendances);
-      const att = attBySession[session.id];
-      let status: AttendanceStatus_enum;
-      if (
-        !att ||
-        att.status === AttendanceStatus_enum.MISSED ||
-        att.status === AttendanceStatus_enum.NO_INFO
-      ) {
-        status = AttendanceStatus_enum.ATTENDED;
-      } else {
-        status = AttendanceStatus_enum.MISSED;
-      }
-      await insertAttendance({
-        variables: {
-          input: {
-            status,
-            sessionId: session.id,
-            source: 'INSTRUCTOR',
-            userId,
-          },
-        },
-      });
-      refetch();
-      qResult.refetch();
-    },
-    [insertAttendance, extendedEnrollments, refetch, qResult]
-  );
 
   const columns = useMemo<ColumnDef<ExtendedEnrollment>[]>(
     () => [
@@ -538,7 +431,16 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
         header: t('attendances'),
         size: 300,
         cell: ({ row }) => (
-          <AttendanceDotsCell row={row} onDotClick={handleDotClick} />
+          <AttendanceDotsCell
+            enrollment={row.original}
+            sessions={sessions}
+            sessionTooltips={sessionTooltips}
+            maxMissedSessions={maxMissedSessions}
+            statusTooltipPassed={attendanceStatusTooltips.passed}
+            statusTooltipFailed={attendanceStatusTooltips.failed}
+            statusTooltipUncertain={attendanceStatusTooltips.uncertain}
+            onDotClick={handleDotClick}
+          />
         ),
       },
       {
@@ -646,7 +548,14 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
         },
       },
     ],
-    [t, AttendanceDotsCell, handleDotClick]
+    [
+      t,
+      sessions,
+      sessionTooltips,
+      maxMissedSessions,
+      attendanceStatusTooltips,
+      handleDotClick,
+    ]
   );
 
   const ExpandableParticipationRow = useCallback(
@@ -688,7 +597,7 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
             setSearchFilter={setSearchFilter}
             sorting={sorting}
             setSorting={setSorting}
-            loading={loading}
+            loading={isInitialLoading}
             error={error}
             bulkActions={bulkActions}
             onBulkAction={handleBulkAction}
@@ -754,7 +663,7 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
           setSearchFilter={setSearchFilter}
           sorting={sorting}
           setSorting={setSorting}
-          loading={loading}
+          loading={isInitialLoading}
           error={error}
           bulkActions={bulkActions}
           onBulkAction={handleBulkAction}

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/index.tsx
@@ -212,7 +212,10 @@ export const CourseParticipationsTab: FC<CourseParticipationsTabIProps> = ({ cou
   );
 
   const sessionTooltips = useMemo(
-    () => sessions.map((session) => new Date(session.startDateTime).toLocaleString(locale)),
+    () =>
+      sessions.map((session: CourseParticipations_Course_by_pk_Sessions) =>
+        new Date(session.startDateTime).toLocaleString(locale)
+      ),
     [sessions, locale]
   );
 

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/useOptimisticAttendance.ts
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/useOptimisticAttendance.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { QueryResult } from '@apollo/client';
+import { AttendanceStatus_enum } from '../../../../__generated__/globalTypes';
+import {
+  attendanceOverlayKey,
+  applyAttendanceOverlay,
+  getNextAttendanceStatus,
+  collapseAttendancesBySession,
+  AttendanceLike,
+} from '../../../../helpers/courseParticipationAttendance';
+import { ATTENDANCE_SOURCE_INSTRUCTOR } from '../../../../helpers/attendance';
+import {
+  CourseParticipations_Course_by_pk_Sessions,
+} from '../../../../queries/__generated__/CourseParticipations';
+import {
+  InsertSingleAttendance,
+  InsertSingleAttendanceVariables,
+} from '../../../../queries/__generated__/InsertSingleAttendance';
+
+const REFETCH_DEBOUNCE_MS = 1500;
+
+type EnrollmentWithAttendances = {
+  userId: string;
+  User: { Attendances: AttendanceLike[] };
+};
+
+interface UseOptimisticAttendanceOptions<T extends EnrollmentWithAttendances> {
+  enrollments: readonly T[];
+  sessions: readonly CourseParticipations_Course_by_pk_Sessions[];
+  insertAttendance: (options: {
+    variables: InsertSingleAttendanceVariables;
+  }) => Promise<{ data?: InsertSingleAttendance }>;
+  refetchParticipations: () => Promise<unknown>;
+  qResult: Pick<QueryResult<unknown, unknown>, 'refetch'>;
+  onError: (message: string) => void;
+}
+
+export function useOptimisticAttendance<T extends EnrollmentWithAttendances>({
+  enrollments,
+  sessions,
+  insertAttendance,
+  refetchParticipations,
+  qResult,
+  onError,
+}: UseOptimisticAttendanceOptions<T>) {
+  const [overlay, setOverlay] = useState<Record<string, AttendanceStatus_enum>>({});
+  const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingMutationsRef = useRef(0);
+
+  const clearRefetchTimer = useCallback(() => {
+    if (refetchTimerRef.current !== null) {
+      clearTimeout(refetchTimerRef.current);
+      refetchTimerRef.current = null;
+    }
+  }, []);
+
+  const scheduleBackgroundSync = useCallback(() => {
+    clearRefetchTimer();
+    refetchTimerRef.current = setTimeout(() => {
+      refetchTimerRef.current = null;
+      void Promise.all([
+        refetchParticipations(),
+        qResult.refetch(),
+      ]).finally(() => {
+        if (pendingMutationsRef.current === 0) {
+          setOverlay({});
+        }
+      });
+    }, REFETCH_DEBOUNCE_MS);
+  }, [clearRefetchTimer, refetchParticipations, qResult]);
+
+  useEffect(() => () => clearRefetchTimer(), [clearRefetchTimer]);
+
+  const enrollmentsWithOverlay = applyAttendanceOverlay(enrollments, overlay, sessions);
+
+  const handleDotClick = useCallback(
+    (session: CourseParticipations_Course_by_pk_Sessions, userId: string) => {
+      const enrollment = enrollments.find((e) => e.userId === userId);
+      if (!enrollment) return;
+
+      const attBySession = collapseAttendancesBySession(enrollment.User.Attendances);
+      const overlayKey = attendanceOverlayKey(userId, session.id);
+      const current =
+        overlay[overlayKey] !== undefined
+          ? { status: overlay[overlayKey], source: ATTENDANCE_SOURCE_INSTRUCTOR, Session: session, id: -1 }
+          : attBySession[session.id];
+      const nextStatus = getNextAttendanceStatus(current);
+
+      setOverlay((prev) => ({ ...prev, [overlayKey]: nextStatus }));
+      pendingMutationsRef.current += 1;
+
+      void insertAttendance({
+        variables: {
+          input: {
+            status: nextStatus,
+            sessionId: session.id,
+            source: ATTENDANCE_SOURCE_INSTRUCTOR,
+            userId,
+          },
+        },
+      })
+        .then(() => {
+          pendingMutationsRef.current -= 1;
+          scheduleBackgroundSync();
+        })
+        .catch((err: unknown) => {
+          pendingMutationsRef.current -= 1;
+          setOverlay((prev) => {
+            const next = { ...prev };
+            delete next[overlayKey];
+            return next;
+          });
+          const msg = err instanceof Error ? err.message : String(err);
+          onError(msg);
+          void refetchParticipations();
+        });
+    },
+    [enrollments, overlay, insertAttendance, scheduleBackgroundSync, onError, refetchParticipations]
+  );
+
+  return {
+    enrollmentsWithOverlay,
+    handleDotClick,
+    hasPendingOverlay: Object.keys(overlay).length > 0,
+  };
+}

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/useOptimisticAttendance.ts
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/useOptimisticAttendance.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { QueryResult } from '@apollo/client';
+import { MutationFunction } from '@apollo/client';
 import { AttendanceStatus_enum } from '../../../../__generated__/globalTypes';
 import {
   attendanceOverlayKey,
@@ -10,6 +10,7 @@ import {
 } from '../../../../helpers/courseParticipationAttendance';
 import { ATTENDANCE_SOURCE_INSTRUCTOR } from '../../../../helpers/attendance';
 import {
+  CourseParticipations_Course_by_pk_CourseEnrollments,
   CourseParticipations_Course_by_pk_Sessions,
 } from '../../../../queries/__generated__/CourseParticipations';
 import {
@@ -19,30 +20,23 @@ import {
 
 const REFETCH_DEBOUNCE_MS = 1500;
 
-type EnrollmentWithAttendances = {
-  userId: string;
-  User: { Attendances: AttendanceLike[] };
-};
-
-interface UseOptimisticAttendanceOptions<T extends EnrollmentWithAttendances> {
-  enrollments: readonly T[];
+interface UseOptimisticAttendanceOptions {
+  enrollments: readonly CourseParticipations_Course_by_pk_CourseEnrollments[];
   sessions: readonly CourseParticipations_Course_by_pk_Sessions[];
-  insertAttendance: (options: {
-    variables: InsertSingleAttendanceVariables;
-  }) => Promise<{ data?: InsertSingleAttendance }>;
+  insertAttendance: MutationFunction<InsertSingleAttendance, InsertSingleAttendanceVariables>;
   refetchParticipations: () => Promise<unknown>;
-  qResult: Pick<QueryResult<unknown, unknown>, 'refetch'>;
+  qResult: { refetch: () => Promise<unknown> };
   onError: (message: string) => void;
 }
 
-export function useOptimisticAttendance<T extends EnrollmentWithAttendances>({
+export function useOptimisticAttendance({
   enrollments,
   sessions,
   insertAttendance,
   refetchParticipations,
   qResult,
   onError,
-}: UseOptimisticAttendanceOptions<T>) {
+}: UseOptimisticAttendanceOptions) {
   const [overlay, setOverlay] = useState<Record<string, AttendanceStatus_enum>>({});
   const refetchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const pendingMutationsRef = useRef(0);
@@ -80,9 +74,14 @@ export function useOptimisticAttendance<T extends EnrollmentWithAttendances>({
 
       const attBySession = collapseAttendancesBySession(enrollment.User.Attendances);
       const overlayKey = attendanceOverlayKey(userId, session.id);
-      const current =
+      const current: AttendanceLike | undefined =
         overlay[overlayKey] !== undefined
-          ? { status: overlay[overlayKey], source: ATTENDANCE_SOURCE_INSTRUCTOR, Session: session, id: -1 }
+          ? {
+              id: Number.MAX_SAFE_INTEGER,
+              status: overlay[overlayKey],
+              source: ATTENDANCE_SOURCE_INSTRUCTOR,
+              Session: { __typename: 'Session', id: session.id },
+            }
           : attBySession[session.id];
       const nextStatus = getNextAttendanceStatus(current);
 

--- a/frontend-nx/apps/edu-hub/helpers/courseParticipationAttendance.test.ts
+++ b/frontend-nx/apps/edu-hub/helpers/courseParticipationAttendance.test.ts
@@ -8,13 +8,20 @@ import {
   getNextAttendanceStatus,
 } from './courseParticipationAttendance';
 
-type Row = { id: number; status: string; source: string | null; Session: { id: number } };
+type Row = {
+  __typename: 'Attendance';
+  id: number;
+  status: AttendanceStatus_enum;
+  source: string;
+  Session: { __typename: 'Session'; id: number };
+};
 
-const row = (id: number, sessionId: number, status: string, source: string | null): Row => ({
+const row = (id: number, sessionId: number, status: AttendanceStatus_enum, source: string): Row => ({
+  __typename: 'Attendance',
   id,
   status,
   source,
-  Session: { id: sessionId },
+  Session: { __typename: 'Session', id: sessionId },
 });
 
 describe('courseParticipationAttendance', () => {
@@ -26,25 +33,29 @@ describe('courseParticipationAttendance', () => {
 
   it('getNextAttendanceStatus toggles between attended and missed', () => {
     expect(getNextAttendanceStatus(undefined)).toBe(AttendanceStatus_enum.ATTENDED);
-    expect(getNextAttendanceStatus(row(1, 1, 'MISSED', 'INSTRUCTOR'))).toBe(
+    expect(getNextAttendanceStatus(row(1, 1, AttendanceStatus_enum.MISSED, 'INSTRUCTOR'))).toBe(
       AttendanceStatus_enum.ATTENDED
     );
-    expect(getNextAttendanceStatus(row(1, 1, 'ATTENDED', 'INSTRUCTOR'))).toBe(
+    expect(getNextAttendanceStatus(row(1, 1, AttendanceStatus_enum.ATTENDED, 'INSTRUCTOR'))).toBe(
       AttendanceStatus_enum.MISSED
     );
   });
 
   it('getDotColorForAttendance maps status to dot colors', () => {
     expect(getDotColorForAttendance(undefined)).toBe('grey');
-    expect(getDotColorForAttendance(row(1, 1, 'ATTENDED', 'INSTRUCTOR'))).toBe('lightgreen');
-    expect(getDotColorForAttendance(row(1, 1, 'MISSED', 'INSTRUCTOR'))).toBe('red');
+    expect(getDotColorForAttendance(row(1, 1, AttendanceStatus_enum.ATTENDED, 'INSTRUCTOR'))).toBe(
+      'lightgreen'
+    );
+    expect(getDotColorForAttendance(row(1, 1, AttendanceStatus_enum.MISSED, 'INSTRUCTOR'))).toBe(
+      'red'
+    );
   });
 
   it('getAttendanceStatusFromMap respects maxMissedSessions', () => {
     const bySession = {
-      1: row(1, 1, 'ATTENDED', 'INSTRUCTOR'),
-      2: row(2, 2, 'MISSED', 'INSTRUCTOR'),
-      3: row(3, 3, 'MISSED', 'INSTRUCTOR'),
+      1: row(1, 1, AttendanceStatus_enum.ATTENDED, 'INSTRUCTOR'),
+      2: row(2, 2, AttendanceStatus_enum.MISSED, 'INSTRUCTOR'),
+      3: row(3, 3, AttendanceStatus_enum.MISSED, 'INSTRUCTOR'),
     };
     expect(getAttendanceStatusFromMap(bySession, sessions, 1)).toBe('failed');
     expect(getAttendanceStatusFromMap(bySession, sessions, 2)).toBe('passed');
@@ -55,7 +66,7 @@ describe('courseParticipationAttendance', () => {
       {
         userId: 'u1',
         User: {
-          Attendances: [row(5, 1, 'ATTENDED', 'ZOOM')],
+          Attendances: [row(5, 1, AttendanceStatus_enum.ATTENDED, 'ZOOM')],
         },
       },
     ];
@@ -66,12 +77,27 @@ describe('courseParticipationAttendance', () => {
     expect(effective[1]?.source).toBe('INSTRUCTOR');
   });
 
+  it('applyAttendanceOverlay overrides an existing INSTRUCTOR row', () => {
+    const enrollments = [
+      {
+        userId: 'u1',
+        User: {
+          Attendances: [row(42, 1, AttendanceStatus_enum.ATTENDED, 'INSTRUCTOR')],
+        },
+      },
+    ];
+    const overlay = { [attendanceOverlayKey('u1', 1)]: AttendanceStatus_enum.MISSED };
+    const result = applyAttendanceOverlay(enrollments, overlay, sessions);
+    const effective = collapseAttendancesBySession(result[0].User.Attendances);
+    expect(effective[1]?.status).toBe(AttendanceStatus_enum.MISSED);
+  });
+
   it('collapseAttendancesBySession prefers instructor over zoom', () => {
     const attendances = [
-      row(1, 1, 'ATTENDED', 'ZOOM'),
-      row(2, 1, 'MISSED', 'INSTRUCTOR'),
+      row(1, 1, AttendanceStatus_enum.ATTENDED, 'ZOOM'),
+      row(2, 1, AttendanceStatus_enum.MISSED, 'INSTRUCTOR'),
     ];
     const effective = collapseAttendancesBySession(attendances);
-    expect(effective[1]?.status).toBe('MISSED');
+    expect(effective[1]?.status).toBe(AttendanceStatus_enum.MISSED);
   });
 });

--- a/frontend-nx/apps/edu-hub/helpers/courseParticipationAttendance.test.ts
+++ b/frontend-nx/apps/edu-hub/helpers/courseParticipationAttendance.test.ts
@@ -1,0 +1,77 @@
+import { AttendanceStatus_enum } from '../__generated__/globalTypes';
+import {
+  applyAttendanceOverlay,
+  attendanceOverlayKey,
+  collapseAttendancesBySession,
+  getAttendanceStatusFromMap,
+  getDotColorForAttendance,
+  getNextAttendanceStatus,
+} from './courseParticipationAttendance';
+
+type Row = { id: number; status: string; source: string | null; Session: { id: number } };
+
+const row = (id: number, sessionId: number, status: string, source: string | null): Row => ({
+  id,
+  status,
+  source,
+  Session: { id: sessionId },
+});
+
+describe('courseParticipationAttendance', () => {
+  const sessions = [{ id: 1 }, { id: 2 }, { id: 3 }];
+
+  it('attendanceOverlayKey is stable', () => {
+    expect(attendanceOverlayKey('user-1', 42)).toBe('user-1:42');
+  });
+
+  it('getNextAttendanceStatus toggles between attended and missed', () => {
+    expect(getNextAttendanceStatus(undefined)).toBe(AttendanceStatus_enum.ATTENDED);
+    expect(getNextAttendanceStatus(row(1, 1, 'MISSED', 'INSTRUCTOR'))).toBe(
+      AttendanceStatus_enum.ATTENDED
+    );
+    expect(getNextAttendanceStatus(row(1, 1, 'ATTENDED', 'INSTRUCTOR'))).toBe(
+      AttendanceStatus_enum.MISSED
+    );
+  });
+
+  it('getDotColorForAttendance maps status to dot colors', () => {
+    expect(getDotColorForAttendance(undefined)).toBe('grey');
+    expect(getDotColorForAttendance(row(1, 1, 'ATTENDED', 'INSTRUCTOR'))).toBe('lightgreen');
+    expect(getDotColorForAttendance(row(1, 1, 'MISSED', 'INSTRUCTOR'))).toBe('red');
+  });
+
+  it('getAttendanceStatusFromMap respects maxMissedSessions', () => {
+    const bySession = {
+      1: row(1, 1, 'ATTENDED', 'INSTRUCTOR'),
+      2: row(2, 2, 'MISSED', 'INSTRUCTOR'),
+      3: row(3, 3, 'MISSED', 'INSTRUCTOR'),
+    };
+    expect(getAttendanceStatusFromMap(bySession, sessions, 1)).toBe('failed');
+    expect(getAttendanceStatusFromMap(bySession, sessions, 2)).toBe('passed');
+  });
+
+  it('applyAttendanceOverlay adds synthetic instructor rows', () => {
+    const enrollments = [
+      {
+        userId: 'u1',
+        User: {
+          Attendances: [row(5, 1, 'ATTENDED', 'ZOOM')],
+        },
+      },
+    ];
+    const overlay = { [attendanceOverlayKey('u1', 1)]: AttendanceStatus_enum.MISSED };
+    const result = applyAttendanceOverlay(enrollments, overlay, sessions);
+    const effective = collapseAttendancesBySession(result[0].User.Attendances);
+    expect(effective[1]?.status).toBe(AttendanceStatus_enum.MISSED);
+    expect(effective[1]?.source).toBe('INSTRUCTOR');
+  });
+
+  it('collapseAttendancesBySession prefers instructor over zoom', () => {
+    const attendances = [
+      row(1, 1, 'ATTENDED', 'ZOOM'),
+      row(2, 1, 'MISSED', 'INSTRUCTOR'),
+    ];
+    const effective = collapseAttendancesBySession(attendances);
+    expect(effective[1]?.status).toBe('MISSED');
+  });
+});

--- a/frontend-nx/apps/edu-hub/helpers/courseParticipationAttendance.ts
+++ b/frontend-nx/apps/edu-hub/helpers/courseParticipationAttendance.ts
@@ -1,0 +1,124 @@
+import { ATTENDANCE_SOURCE_INSTRUCTOR, pickEffectiveAttendance } from './attendance';
+import { AttendanceStatus_enum } from '../__generated__/globalTypes';
+import { DotColor } from '../components/common/Dot';
+import {
+  CourseParticipations_Course_by_pk_CourseEnrollments_User_Attendances,
+  CourseParticipations_Course_by_pk_Sessions,
+} from '../queries/__generated__/CourseParticipations';
+
+export type AttendanceLike = Pick<
+  CourseParticipations_Course_by_pk_CourseEnrollments_User_Attendances,
+  'id' | 'status' | 'source' | 'Session'
+>;
+
+export type AttendanceOverallStatus = 'passed' | 'failed' | 'uncertain';
+
+export function attendanceOverlayKey(userId: string, sessionId: number): string {
+  return `${userId}:${sessionId}`;
+}
+
+export function collapseAttendancesBySession(
+  attendances: readonly AttendanceLike[]
+): Record<number, AttendanceLike> {
+  const bySession = attendances.reduce<Record<number, AttendanceLike[]>>((prev, curr) => {
+    const bucket = prev[curr.Session.id] ?? [];
+    bucket.push(curr);
+    prev[curr.Session.id] = bucket;
+    return prev;
+  }, {});
+
+  const result: Record<number, AttendanceLike> = {};
+  for (const [sessionId, rows] of Object.entries(bySession)) {
+    const effective = pickEffectiveAttendance(rows, (a) => a.id);
+    if (effective !== undefined) {
+      result[Number(sessionId)] = effective;
+    }
+  }
+  return result;
+}
+
+export function getAttendanceStatusFromMap(
+  attendanceBySession: Record<number, AttendanceLike>,
+  sessions: readonly Pick<CourseParticipations_Course_by_pk_Sessions, 'id'>[],
+  maxMissedSessions: number
+): AttendanceOverallStatus {
+  let missed = 0;
+  let unchecked = 0;
+  for (const session of sessions) {
+    const att = attendanceBySession[session.id];
+    if (!att) {
+      unchecked += 1;
+    } else if (att.status === AttendanceStatus_enum.MISSED) {
+      missed += 1;
+    } else if (att.status === AttendanceStatus_enum.NO_INFO) {
+      unchecked += 1;
+    }
+  }
+
+  if (missed > maxMissedSessions) return 'failed';
+  if (missed + unchecked <= maxMissedSessions) return 'passed';
+  return 'uncertain';
+}
+
+export function getDotColorForAttendance(att: AttendanceLike | undefined): DotColor {
+  if (!att) return 'grey';
+  if (att.status === AttendanceStatus_enum.MISSED) return 'red';
+  if (att.status === AttendanceStatus_enum.ATTENDED) return 'lightgreen';
+  return 'grey';
+}
+
+export function getNextAttendanceStatus(att: AttendanceLike | undefined): AttendanceStatus_enum {
+  if (
+    !att ||
+    att.status === AttendanceStatus_enum.MISSED ||
+    att.status === AttendanceStatus_enum.NO_INFO
+  ) {
+    return AttendanceStatus_enum.ATTENDED;
+  }
+  return AttendanceStatus_enum.MISSED;
+}
+
+/**
+ * Merges instructor overlay statuses into enrollments as synthetic INSTRUCTOR rows
+ * so pickEffectiveAttendance continues to prefer them over automated sources.
+ */
+export function applyAttendanceOverlay<T extends { userId: string; User: { Attendances: AttendanceLike[] } }>(
+  enrollments: readonly T[],
+  overlay: Readonly<Record<string, AttendanceStatus_enum>>,
+  sessions: readonly Pick<CourseParticipations_Course_by_pk_Sessions, 'id'>[]
+): T[] {
+  if (Object.keys(overlay).length === 0) {
+    return [...enrollments];
+  }
+
+  return enrollments.map((enrollment) => {
+    const additions: AttendanceLike[] = [];
+    let tempId = -1;
+
+    for (const session of sessions) {
+      const key = attendanceOverlayKey(enrollment.userId, session.id);
+      const status = overlay[key];
+      if (status === undefined) continue;
+
+      additions.push({
+        id: tempId,
+        status,
+        source: ATTENDANCE_SOURCE_INSTRUCTOR,
+        Session: { id: session.id },
+      });
+      tempId -= 1;
+    }
+
+    if (additions.length === 0) {
+      return enrollment;
+    }
+
+    return {
+      ...enrollment,
+      User: {
+        ...enrollment.User,
+        Attendances: [...enrollment.User.Attendances, ...additions],
+      },
+    };
+  });
+}

--- a/frontend-nx/apps/edu-hub/helpers/courseParticipationAttendance.ts
+++ b/frontend-nx/apps/edu-hub/helpers/courseParticipationAttendance.ts
@@ -93,7 +93,9 @@ export function applyAttendanceOverlay<T extends { userId: string; User: { Atten
 
   return enrollments.map((enrollment) => {
     const additions: AttendanceLike[] = [];
-    let tempId = -1;
+    // Use ids above any real DB id so synthetic rows beat existing INSTRUCTOR
+    // rows in pickEffectiveAttendance's largest-id tie-break.
+    let tempId = Number.MAX_SAFE_INTEGER;
 
     for (const session of sessions) {
       const key = attendanceOverlayKey(enrollment.userId, session.id);
@@ -104,7 +106,7 @@ export function applyAttendanceOverlay<T extends { userId: string; User: { Atten
         id: tempId,
         status,
         source: ATTENDANCE_SOURCE_INSTRUCTOR,
-        Session: { id: session.id },
+        Session: { __typename: 'Session', id: session.id },
       });
       tempId -= 1;
     }

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1478,6 +1478,7 @@
     "attendance_status_passed": "Anwesenheitsanforderung erfüllt",
     "attendance_status_failed": "Anwesenheitsanforderung nicht erfüllt",
     "attendance_status_uncertain": "Anwesenheitsstatus noch offen",
+    "attendance_update_failed": "Anwesenheit konnte nicht gespeichert werden. Bitte versuche es erneut.",
     "certificates_skipped_singular": "1 Person übersprungen (Anforderungen nicht erfüllt)",
     "certificates_skipped_plural": "{count} Personen übersprungen (Anforderungen nicht erfüllt)",
     "achievement_not_submitted": "Keine Dokumentation hochgeladen",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1496,6 +1496,7 @@
     "attendance_status_passed": "Attendance requirement met",
     "attendance_status_failed": "Attendance requirement not met",
     "attendance_status_uncertain": "Attendance status pending",
+    "attendance_update_failed": "Could not save attendance. Please try again.",
     "certificates_skipped_singular": "1 participant skipped (requirements not met)",
     "certificates_skipped_plural": "{count} participants skipped (requirements not met)",
     "achievement_not_submitted": "No documentation uploaded",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Improves responsiveness of the course participations attendance table when instructors mark session attendance for large participant lists.

Fixes eduhub-org/eduhub#1693.

## Problem

Each attendance dot click triggered a full GraphQL refetch. While loading, `TableGrid` hid all rows, so every click felt slow—especially with many participants and sessions.

## Solution

- **Optimistic UI**: apply instructor attendance changes locally immediately via an overlay map.
- **Debounced sync**: batch background refetches (1.5s) instead of refetching on every click.
- **Stable table during sync**: only show the loading state on initial load (`loading && !data`), not during background refetch.
- **Rendering optimizations**: memoized `AttendanceDotsCell`, precomputed session tooltips, horizontal scroll for long session rows.
- **Shared helpers**: extracted `courseParticipationAttendance` utilities with unit tests.

## Testing

- Unit tests: `courseParticipationAttendance.test.ts`, `attendance.test.ts` (13 passed)
- Lint: `yarn lint` (clean)
- Manual E2E on `http://localhost:5000`: rapid dot clicks on "Current Course B" participations tab — instant color/count updates, table stayed visible, no errors

## Customer-facing impact

Taking attendance feels immediate: the list stays responsive for large groups, and present/absent toggles update without waiting for the server round-trip.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-982ca9e2-e38f-4d3f-8524-2cb03b965e0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-982ca9e2-e38f-4d3f-8524-2cb03b965e0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

