### PR TITLE
feat(session): per-session public event pages and EventTile

### DIFF
--- a/backend/metadata/databases/default/tables/public_Event.yaml
+++ b/backend/metadata/databases/default/tables/public_Event.yaml
@@ -1,3 +1,0 @@
-table:
-  name: Event
-  schema: public

--- a/backend/metadata/databases/default/tables/public_Session.yaml
+++ b/backend/metadata/databases/default/tables/public_Session.yaml
@@ -52,6 +52,7 @@ select_permissions:
         - description
         - endDateTime
         - id
+        - isPublicEvent
         - startDateTime
         - title
         - updated_at
@@ -65,6 +66,7 @@ select_permissions:
         - description
         - endDateTime
         - id
+        - isPublicEvent
         - startDateTime
         - title
         - updated_at
@@ -88,6 +90,12 @@ update_permissions:
             User:
               id:
                 _eq: X-Hasura-User-Id
+      check: null
+  - role: admin
+    permission:
+      columns:
+        - isPublicEvent
+      filter: {}
       check: null
 delete_permissions:
   - role: instructor_access

--- a/backend/metadata/inherited_roles.yaml
+++ b/backend/metadata/inherited_roles.yaml
@@ -3,6 +3,12 @@
     - user_access
     - instructor_access
     - anonymous
+- role_name: admin
+  role_set:
+    - instructor_access
+    - user_access
+    - user_access_others
+    - anonymous
 - role_name: user
   role_set:
     - user_access

--- a/backend/migrations/default/1778000000030_add_session_is_public_event/down.sql
+++ b/backend/migrations/default/1778000000030_add_session_is_public_event/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."Session" DROP COLUMN "isPublicEvent";

--- a/backend/migrations/default/1778000000030_add_session_is_public_event/up.sql
+++ b/backend/migrations/default/1778000000030_add_session_is_public_event/up.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "public"."Session"
+ADD COLUMN "isPublicEvent" boolean NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN "public"."Session"."isPublicEvent" IS 'When true, the session is exposed as a standalone public event page and can appear in public event listings.';

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/EventTile.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/EventTile.tsx
@@ -1,0 +1,44 @@
+import Link from 'next/link';
+import { FC } from 'react';
+import { useTranslations } from 'next-intl';
+import { PublicEvents_Session } from '../../../queries/__generated__/PublicEvents';
+import { PublicEventById_Session } from '../../../queries/__generated__/PublicEventById';
+import { useDisplayDate, useFormatTimeString } from '../../../helpers/dateTimeHelpers';
+import { TileBase } from './TileBase';
+
+export type PublicEventSession = PublicEvents_Session | PublicEventById_Session;
+
+interface EventTileProps {
+  session: PublicEventSession;
+}
+
+export const EventTile: FC<EventTileProps> = ({ session }) => {
+  const t = useTranslations('event');
+  const displayDate = useDisplayDate();
+  const formatTimeString = useFormatTimeString();
+  const course = session.Course;
+
+  return (
+    <Link href={`/event/${session.id}`}>
+      <TileBase coverImage={course?.coverImage ?? null} title={session.title}>
+        <div className="text-sm tracking-wider text-label-secondary mb-2">
+          {displayDate(session.startDateTime)}
+          {' · '}
+          {formatTimeString(session.startDateTime)}
+          {' – '}
+          {formatTimeString(session.endDateTime)}
+        </div>
+        <span className="text-lg mb-auto line-clamp-2 text-label-primary">{course?.title}</span>
+        <div className="text-xs tracking-wider text-label-secondary mt-3">
+          {course?.CourseLocations?.map((location, index) => (
+            <span key={location.id}>
+              {location.locationOption}
+              {index < (course.CourseLocations?.length ?? 0) - 1 ? ' + ' : ''}
+            </span>
+          ))}
+        </div>
+        <span className="sr-only">{t('EventTile.view_event')}</span>
+      </TileBase>
+    </Link>
+  );
+};

--- a/frontend-nx/apps/edu-hub/components/common/TileSlider/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/TileSlider/index.tsx
@@ -11,6 +11,9 @@ import { CoursesEnrolledByUser_Course } from '../../../queries/__generated__/Cou
 import { Tile } from './Tile';
 import { TileWidget } from './TileWidget';
 
+export { EventTile } from './EventTile';
+export type { PublicEventSession } from './EventTile';
+
 export type CourseType = CourseList_Course | CourseTiles_Course | CoursesEnrolledByUser_Course;
 
 interface TileSliderProps {

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Sessions.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Sessions.tsx
@@ -1,4 +1,5 @@
 import { FC, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io';
 
@@ -70,8 +71,9 @@ export const Sessions: FC<SessionsProps> = ({ sessions, courseLocations, isLogge
             {sessions.length === 1 ? t('sessions.date_singular') : t('sessions.date_plural')}
           </span>
           <ul className="max-w-2xl">
-            {visibleSessions.map(({ startDateTime, endDateTime, title, SessionSpeakers, SessionAddresses }, index) => (
-              <li key={index} className="flex mb-4">
+            {visibleSessions.map(
+              ({ id, startDateTime, endDateTime, title, SessionSpeakers, SessionAddresses, isPublicEvent }, index) => (
+              <li key={id ?? index} className="flex mb-4">
                 <div className="flex flex-wrap items-start flex-shrink-0 mb-2">
                   <div className="flex flex-col mr-6">
                     <span className="block text-sm sm:text-lg font-semibold">{displayDate(startDateTime)}</span>
@@ -83,7 +85,17 @@ export const Sessions: FC<SessionsProps> = ({ sessions, courseLocations, isLogge
                   </div>
                 </div>
                 <div className="flex flex-col flex-1">
-                  <span className="block text-sm sm:text-lg break-words">{title}</span>
+                  <div className="flex flex-wrap items-center gap-2 mb-1">
+                    <span className="block text-sm sm:text-lg break-words">{title}</span>
+                    {isPublicEvent ? (
+                      <Link
+                        href={`/event/${id}`}
+                        className="inline-flex items-center rounded-full border border-brand px-2 py-0.5 text-xs font-medium text-brand hover:bg-brand/10"
+                      >
+                        {t('sessions.public_event_badge')}
+                      </Link>
+                    ) : null}
+                  </div>
                   <div className="break-words">
                     {/* Sort SessionAddresses by CourseLocations order */}
                     {(() => {
@@ -181,7 +193,8 @@ export const Sessions: FC<SessionsProps> = ({ sessions, courseLocations, isLogge
                   </div>
                 </div>
               </li>
-            ))}
+            )
+            )}
           </ul>
           {sessions.length > initiallyShownSessions &&
             (showAllSessions ? (

--- a/frontend-nx/apps/edu-hub/components/pages/EventContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/EventContent/index.tsx
@@ -1,0 +1,205 @@
+import { FC, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { CircularProgress } from '@mui/material';
+import ReactMarkdown from 'react-markdown';
+
+import { useRoleQuery } from '../../../hooks/authedQuery';
+import { AuthRoles } from '../../../types/enums';
+import { PUBLIC_EVENT_BY_ID } from '../../../queries/publicEvents';
+import {
+  PublicEventById,
+  PublicEventByIdVariables,
+} from '../../../queries/__generated__/PublicEventById';
+import { useDisplayDate, useFormatTimeString } from '../../../helpers/dateTimeHelpers';
+import { getBackgroundImage } from '../../../helpers/imageHandling';
+import { isLinkFormat } from '../../../helpers/util';
+import UserCard from '../../common/UserCard';
+import { PageBlock } from '../../common/PageBlock';
+import { LOCATION_ADDRESSES_BY_IDS } from '../../../queries/locationAddress';
+
+const EventContent: FC<{ sessionId: number }> = ({ sessionId }) => {
+  const t = useTranslations('event');
+  const tCourse = useTranslations('course');
+  const displayDate = useDisplayDate();
+  const formatTimeString = useFormatTimeString();
+  const [backgroundImage, setBackgroundImage] = useState('');
+
+  const { data, loading } = useRoleQuery<PublicEventById, PublicEventByIdVariables>(PUBLIC_EVENT_BY_ID, {
+    variables: { sessionId },
+    context: { role: AuthRoles.anonymous },
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const session = data?.Session?.[0];
+  const course = session?.Course;
+
+  useEffect(() => {
+    const loadImage = async () => {
+      const image = await getBackgroundImage(course?.coverImage ?? null);
+      setBackgroundImage(image);
+    };
+    void loadImage();
+  }, [course?.coverImage]);
+
+  const addressIds = useMemo(() => {
+    const ids = new Set<number>();
+    session?.SessionAddresses.forEach((sessionAddress) => {
+      const locationAddressId = sessionAddress.locationAddressId;
+      const defaultSessionAddressId = sessionAddress.CourseLocation?.defaultSessionAddressId;
+      if (locationAddressId) ids.add(locationAddressId);
+      if (defaultSessionAddressId) ids.add(defaultSessionAddressId);
+    });
+    return Array.from(ids);
+  }, [session?.SessionAddresses]);
+
+  const { data: addressData } = useRoleQuery(LOCATION_ADDRESSES_BY_IDS, {
+    variables: { ids: addressIds },
+    skip: addressIds.length === 0,
+    context: { role: AuthRoles.anonymous },
+  });
+
+  const addressMap = useMemo(() => {
+    const map = new Map<number, { address: string }>();
+    addressData?.LocationAddress?.forEach((addr: { id: number; address: string }) => {
+      map.set(addr.id, addr);
+    });
+    return map;
+  }, [addressData]);
+
+  if (loading && !session) {
+    return (
+      <div className="flex justify-center max-w-screen-xl mx-auto w-full pt-32">
+        <CircularProgress />
+      </div>
+    );
+  }
+
+  if (!session || !course) {
+    return (
+      <div className="flex justify-center max-w-screen-xl mx-auto w-full pt-32">
+        <div className="text-white">{t('EventContent.not_found')}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col space-y-12 lg:space-y-24">
+      <div
+        className="h-96 p-3 text-3xl text-white flex justify-start items-end bg-cover bg-center bg-no-repeat"
+        style={{
+          backgroundImage: `linear-gradient(51.32deg, rgba(0, 0, 0, 0.7) 17.57%, rgba(0, 0, 0, 0) 85.36%), url("${backgroundImage}")`,
+        }}
+      >
+        <div className="max-w-screen-xl mx-auto w-full">
+          <p className="text-sm mb-2 opacity-90">{course.title}</p>
+          <h1>{session.title}</h1>
+        </div>
+      </div>
+
+      <PageBlock>
+        <div className="max-w-screen-xl mx-auto w-full text-white space-y-10">
+          <section>
+            <h2 className="text-2xl font-semibold mb-3">{t('EventContent.date_time_heading')}</h2>
+            <p className="text-lg">
+              {displayDate(session.startDateTime)}
+              {', '}
+              {formatTimeString(session.startDateTime)}
+              {' – '}
+              {formatTimeString(session.endDateTime)}
+            </p>
+          </section>
+
+          {session.description ? (
+            <section>
+              <h2 className="text-2xl font-semibold mb-3">{t('EventContent.description_heading')}</h2>
+              <div className="prose prose-invert max-w-none">
+                <ReactMarkdown>{session.description}</ReactMarkdown>
+              </div>
+            </section>
+          ) : null}
+
+          {session.SessionSpeakers.length > 0 ? (
+            <section>
+              <h2 className="text-2xl font-semibold mb-3">{t('EventContent.speakers_heading')}</h2>
+              <div className="space-y-2">
+                {session.SessionSpeakers.map((speaker) => (
+                  <UserCard
+                    key={speaker.id}
+                    className="flex items-center"
+                    user={speaker.User}
+                    role={tCourse('general.speaker')}
+                    size="medium"
+                  />
+                ))}
+              </div>
+            </section>
+          ) : null}
+
+          {session.SessionAddresses.length > 0 ? (
+            <section>
+              <h2 className="text-2xl font-semibold mb-3">{t('EventContent.location_heading')}</h2>
+              <ul className="space-y-2 text-label-secondary">
+                {session.SessionAddresses.map((sessionAddress) => {
+                  const { address, CourseLocation } = sessionAddress;
+                  const locationAddressId = sessionAddress.locationAddressId;
+                  const defaultSessionAddressId = CourseLocation?.defaultSessionAddressId;
+                  const effectiveAddressId = locationAddressId || defaultSessionAddressId;
+                  let displayAddress = '';
+                  if (effectiveAddressId && addressMap.has(effectiveAddressId)) {
+                    displayAddress = addressMap.get(effectiveAddressId)?.address ?? '';
+                  } else {
+                    displayAddress =
+                      address && address.trim() !== ''
+                        ? address
+                        : CourseLocation?.defaultSessionAddress || '';
+                  }
+
+                  return (
+                    <li key={sessionAddress.id}>
+                      {CourseLocation?.locationOption === 'ONLINE' ? (
+                        isLinkFormat(displayAddress) ? (
+                          <a
+                            href={displayAddress}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="underline text-brand"
+                          >
+                            ONLINE
+                          </a>
+                        ) : (
+                          'ONLINE'
+                        )
+                      ) : displayAddress ? (
+                        <a
+                          href={`https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(displayAddress)}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="underline text-brand"
+                        >
+                          {displayAddress}
+                        </a>
+                      ) : (
+                        CourseLocation?.locationOption
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+          ) : null}
+
+          <section>
+            <h2 className="text-2xl font-semibold mb-3">{t('EventContent.course_heading')}</h2>
+            <p className="mb-4 text-label-secondary">{course.tagline}</p>
+            <Link href={`/course/${course.id}`} className="text-brand underline font-medium">
+              {t('EventContent.view_course_link')}
+            </Link>
+          </section>
+        </div>
+      </PageBlock>
+    </div>
+  );
+};
+
+export default EventContent;

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/SessionsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/SessionsTab/index.tsx
@@ -15,7 +15,9 @@ import {
   UPDATE_SESSION_END_TIME,
   UPDATE_SESSION_START_TIME,
   UPDATE_SESSION_TITLE,
+  UPDATE_SESSION_IS_PUBLIC_EVENT,
 } from '../../../../queries/course';
+import CheckboxSelector from '../../../inputs/CheckboxSelector';
 import {
   ManagedCourse,
   ManagedCourseVariables,
@@ -349,6 +351,7 @@ const ExpandableSessionRowContent: FC<ExpandableSessionRowContentProps> = ({ ses
   const t = useTranslations('manageCourse');
   const tCoursePage = useTranslations('coursePage');
   const tCommon = useTranslations('common');
+  const isAdmin = useIsAdmin();
 
   const [createUserDialogOpen, setCreateUserDialogOpen] = useState(false);
   const [searchValueForNewUser, setSearchValueForNewUser] = useState('');
@@ -446,6 +449,19 @@ const ExpandableSessionRowContent: FC<ExpandableSessionRowContentProps> = ({ ses
                     <SessionAddresses key={address.id} address={address} refetchQueries={['ManagedCourse']} />
                   ))}
               </div>
+            </Card>
+
+            <Card title={t('SessionsTab.public_event.label')} helpText={t('SessionsTab.public_event.help_text')}>
+              <CheckboxSelector
+                variant="eduhub"
+                label={t('SessionsTab.public_event.label')}
+                helpText={t('SessionsTab.public_event.help_text')}
+                checked={Boolean(session.isPublicEvent)}
+                updateValueMutation={isAdmin ? UPDATE_SESSION_IS_PUBLIC_EVENT : undefined}
+                identifierVariables={{ sessionId: session.id }}
+                refetchQueries={['ManagedCourse']}
+                disabled={!isAdmin}
+              />
             </Card>
 
             <Card

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/SessionsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/SessionsTab/index.tsx
@@ -304,8 +304,28 @@ export const SessionsTab: FC<IProps> = ({ course, qResult }) => {
           </span>
         ),
       },
+      {
+        id: 'publicEvent',
+        header: t('SessionsTab.public_event.label'),
+        accessorKey: 'isPublicEvent',
+        size: 160,
+        enableSorting: false,
+        cell: ({ row }) => (
+          <div className="light flex items-center min-w-[140px]">
+            <CheckboxSelector
+              variant="eduhub"
+              label=""
+              checked={Boolean(row.original.isPublicEvent)}
+              updateValueMutation={isAdmin ? UPDATE_SESSION_IS_PUBLIC_EVENT : undefined}
+              identifierVariables={{ sessionId: row.original.id }}
+              refetchQueries={['ManagedCourse']}
+              disabled={!isAdmin}
+            />
+          </div>
+        ),
+      },
     ],
-    [tCoursePage, lectureStart, lectureEnd, handleSetDate]
+    [t, tCoursePage, lectureStart, lectureEnd, handleSetDate, isAdmin]
   );
 
   return (
@@ -351,7 +371,6 @@ const ExpandableSessionRowContent: FC<ExpandableSessionRowContentProps> = ({ ses
   const t = useTranslations('manageCourse');
   const tCoursePage = useTranslations('coursePage');
   const tCommon = useTranslations('common');
-  const isAdmin = useIsAdmin();
 
   const [createUserDialogOpen, setCreateUserDialogOpen] = useState(false);
   const [searchValueForNewUser, setSearchValueForNewUser] = useState('');
@@ -449,19 +468,6 @@ const ExpandableSessionRowContent: FC<ExpandableSessionRowContentProps> = ({ ses
                     <SessionAddresses key={address.id} address={address} refetchQueries={['ManagedCourse']} />
                   ))}
               </div>
-            </Card>
-
-            <Card title={t('SessionsTab.public_event.label')} helpText={t('SessionsTab.public_event.help_text')}>
-              <CheckboxSelector
-                variant="eduhub"
-                label={t('SessionsTab.public_event.label')}
-                helpText={t('SessionsTab.public_event.help_text')}
-                checked={Boolean(session.isPublicEvent)}
-                updateValueMutation={isAdmin ? UPDATE_SESSION_IS_PUBLIC_EVENT : undefined}
-                identifierVariables={{ sessionId: session.id }}
-                refetchQueries={['ManagedCourse']}
-                disabled={!isAdmin}
-              />
             </Card>
 
             <Card

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -348,7 +348,8 @@
       "show_all_dates": "Alle Termine anzeigen",
       "hide_dates": "Termine einklappen",
       "date_singular": "Termin",
-      "date_plural": "Termine"
+      "date_plural": "Termine",
+      "public_event_badge": "Öffentliches Event"
     },
     "attendances": {
       "attendances": "Anwesenheiten",
@@ -495,6 +496,26 @@
       "success_title": "Bewerbung erfolgreich eingereicht!",
       "success_body": "Du wirst spätestens ein bis zwei Tage nach Bewerbungsschluss über deine Zulassung informiert.",
       "success_close_button_title": "Schließen"
+    }
+  },
+  "event": {
+    "seo": {
+      "title": "EduHub Event | opencampus.sh",
+      "metaDescription": "Öffentliche Event-Details auf EduHub von opencampus.sh",
+      "ogDescription": "Entdecke dieses öffentliche Event auf EduHub",
+      "twitterDescription": "Entdecke dieses öffentliche Event auf EduHub"
+    },
+    "EventTile": {
+      "view_event": "Event ansehen"
+    },
+    "EventContent": {
+      "not_found": "Dieses öffentliche Event wurde nicht gefunden.",
+      "date_time_heading": "Datum & Uhrzeit",
+      "description_heading": "Beschreibung",
+      "speakers_heading": "Speaker:innen",
+      "location_heading": "Ort",
+      "course_heading": "Kurs",
+      "view_course_link": "Zum zugehörigen Kurs"
     }
   },
   "coursePage": {
@@ -1297,6 +1318,10 @@
         "select_location_option_first": "Bitte wähle zuerst eine Standortoption aus",
         "location_mismatch_error": "Die ausgewählte Adresse passt nicht zur Standortoption dieser Session. Bitte wähle eine Adresse aus, die zum richtigen Standort gehört.",
         "failed_to_load_session_addresses": "Session-Adressen konnten nicht geladen werden."
+      },
+      "public_event": {
+        "label": "Öffentliches Event",
+        "help_text": "Wenn aktiviert, erhält dieser Termin eine eigene öffentliche Seite unter /event/[id] und kann in Event-Listen erscheinen. Nur Admins können diese Einstellung ändern."
       },
       "session_description": {
         "label": "Beschreibung",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -348,7 +348,8 @@
       "show_all_dates": "Show all dates",
       "hide_dates": "Collapse dates",
       "date_singular": "Date",
-      "date_plural": "Dates"
+      "date_plural": "Dates",
+      "public_event_badge": "Public event"
     },
     "attendances": {
       "attendances": "Attendances",
@@ -495,6 +496,26 @@
       "success_title": "You have successfully applied",
       "success_body": "You will be informed about your admission no later than one to two days after the application deadline.",
       "success_close_button_title": "Close"
+    }
+  },
+  "event": {
+    "seo": {
+      "title": "EduHub Event | opencampus.sh",
+      "metaDescription": "Public event details on EduHub by opencampus.sh",
+      "ogDescription": "Discover this public event on EduHub",
+      "twitterDescription": "Discover this public event on EduHub"
+    },
+    "EventTile": {
+      "view_event": "View event"
+    },
+    "EventContent": {
+      "not_found": "This public event could not be found.",
+      "date_time_heading": "Date & time",
+      "description_heading": "Description",
+      "speakers_heading": "Speakers",
+      "location_heading": "Location",
+      "course_heading": "Course",
+      "view_course_link": "View parent course"
     }
   },
   "coursePage": {
@@ -1315,6 +1336,10 @@
         "select_location_option_first": "Please select a location option first",
         "location_mismatch_error": "The selected address does not match the location option for this session. Please select an address that belongs to the correct location.",
         "failed_to_load_session_addresses": "Failed to load session addresses."
+      },
+      "public_event": {
+        "label": "Public event",
+        "help_text": "When enabled, this session gets its own public page at /event/[id] and can be shown in event listings. Only admins can change this setting."
       },
       "session_description": {
         "label": "Description",

--- a/frontend-nx/apps/edu-hub/pages/event/[sessionId].tsx
+++ b/frontend-nx/apps/edu-hub/pages/event/[sessionId].tsx
@@ -1,0 +1,53 @@
+import Head from 'next/head';
+import { useRouter } from 'next/router';
+import { FC } from 'react';
+import { useTranslations, useLocale } from 'next-intl';
+
+import { Page } from '../../components/layout/Page';
+import EventContent from '../../components/pages/EventContent';
+
+const EventPage: FC = () => {
+  const router = useRouter();
+  const { sessionId } = router.query;
+  const t = useTranslations('event');
+  const locale = useLocale();
+
+  const id = parseInt(sessionId as string, 10);
+
+  if (!sessionId || Number.isNaN(id)) {
+    return (
+      <Page>
+        <div className="flex justify-center max-w-screen-xl mx-auto w-full pt-32 text-white">
+          {t('EventContent.not_found')}
+        </div>
+      </Page>
+    );
+  }
+
+  return (
+    <>
+      <Head>
+        <title>{t('seo.title')}</title>
+        <meta name="description" content={t('seo.metaDescription')} />
+        <meta name="robots" content="index, follow" />
+        <link rel="icon" href="/favicon.png" />
+        <meta property="og:type" content="website" />
+        <meta property="og:title" content={t('seo.title')} />
+        <meta property="og:description" content={t('seo.ogDescription')} />
+        <meta property="og:url" content={`https://edu.opencampus.sh/event/${id}`} />
+        <meta property="og:site_name" content="EduHub" />
+        <meta property="og:image" content="https://edu.opencampus.sh/images/edu_WISE23_HeaderWebsitePreview.png" />
+        <meta property="og:locale" content={locale === 'de' ? 'de_DE' : 'en_US'} />
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={t('seo.title')} />
+        <meta name="twitter:description" content={t('seo.twitterDescription')} />
+        <meta name="twitter:image" content="https://edu.opencampus.sh/images/edu_WISE23_HeaderWebsitePreview.png" />
+      </Head>
+      <Page className="text-white">
+        <EventContent sessionId={id} />
+      </Page>
+    </>
+  );
+};
+
+export default EventPage;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminSessionFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminSessionFragment.ts
@@ -110,6 +110,7 @@ export interface AdminSessionFragment {
    * A description of the session
    */
   description: string;
+  isPublicEvent: boolean;
   /**
    * The day and time of the start of the session
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/Course.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/Course.ts
@@ -88,6 +88,7 @@ export interface Course_Course_by_pk_Sessions {
    * A description of the session
    */
   description: string;
+  isPublicEvent: boolean;
   /**
    * The day and time of the start of the session
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/ManagedCourse.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/ManagedCourse.ts
@@ -110,6 +110,7 @@ export interface ManagedCourse_Course_by_pk_Sessions {
    * A description of the session
    */
   description: string;
+  isPublicEvent: boolean;
   /**
    * The day and time of the start of the session
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/PublicEventById.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/PublicEventById.ts
@@ -1,0 +1,191 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { LocationOption_enum } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL query operation: PublicEventById
+// ====================================================
+
+export interface PublicEventById_Session_Course_Program {
+  __typename: "Program";
+  id: number;
+  /**
+   * The title of the program
+   */
+  title: string;
+  /**
+   * The 6 letter short title for the program.
+   */
+  shortTitle: string | null;
+}
+
+export interface PublicEventById_Session_Course_CourseLocations {
+  __typename: "CourseLocation";
+  id: number;
+  /**
+   * Either 'ONLINE' or one of the possible given offline locations
+   */
+  locationOption: LocationOption_enum | null;
+  /**
+   * Will be used as default for any new session address.
+   */
+  defaultSessionAddress: string | null;
+}
+
+export interface PublicEventById_Session_Course {
+  __typename: "Course";
+  id: number;
+  /**
+   * The title of the course (only editable by an admin user)
+   */
+  title: string;
+  /**
+   * The cover image for the course
+   */
+  coverImage: string | null;
+  /**
+   * Shown below the title on the course page
+   */
+  tagline: string;
+  /**
+   * An object relationship
+   */
+  Program: PublicEventById_Session_Course_Program;
+  /**
+   * An array relationship
+   */
+  CourseLocations: PublicEventById_Session_Course_CourseLocations[];
+}
+
+export interface PublicEventById_Session_SessionAddresses_CourseLocation {
+  __typename: "CourseLocation";
+  id: number;
+  /**
+   * Either 'ONLINE' or one of the possible given offline locations
+   */
+  locationOption: LocationOption_enum | null;
+  /**
+   * Will be used as default for any new session address.
+   */
+  defaultSessionAddress: string | null;
+  /**
+   * References a LocationAddress that serves as the default for sessions in this course location. Replaces the legacy text-based defaultSessionAddress field.
+   */
+  defaultSessionAddressId: number | null;
+}
+
+export interface PublicEventById_Session_SessionAddresses_LocationAddress {
+  __typename: "LocationAddress";
+  id: number;
+  /**
+   * Concise label shown in lists and typeahead (e.g., "Room 2.12", "Main Building").
+   */
+  shortLabel: string;
+  /**
+   * Full human-readable address (street, building, room number, etc.).
+   */
+  address: string;
+}
+
+export interface PublicEventById_Session_SessionAddresses {
+  __typename: "SessionAddress";
+  id: number;
+  /**
+   * Where the session will take place; might be an offline or online location which is provided according to the provided type
+   */
+  address: string;
+  /**
+   * Foreign key to LocationAddress. Replaces the free-text address field with a structured address reference. Nullable during migration period.
+   */
+  locationAddressId: number | null;
+  /**
+   * An object relationship
+   */
+  CourseLocation: PublicEventById_Session_SessionAddresses_CourseLocation | null;
+  /**
+   * An object relationship
+   */
+  LocationAddress: PublicEventById_Session_SessionAddresses_LocationAddress | null;
+}
+
+export interface PublicEventById_Session_SessionSpeakers_User {
+  __typename: "User";
+  id: any;
+  /**
+   * The user's first name
+   */
+  firstName: string;
+  /**
+   * The user's last name
+   */
+  lastName: string;
+  /**
+   * The user's profile picture
+   */
+  picture: string | null;
+  /**
+   * A link to an external profile, for example in LinkedIn or Xing
+   */
+  externalProfile: string | null;
+}
+
+export interface PublicEventById_Session_SessionSpeakers {
+  __typename: "SessionSpeaker";
+  id: number;
+  /**
+   * An object relationship
+   */
+  User: PublicEventById_Session_SessionSpeakers_User;
+}
+
+export interface PublicEventById_Session {
+  __typename: "Session";
+  id: number;
+  /**
+   * The title of the session
+   */
+  title: string;
+  /**
+   * A description of the session
+   */
+  description: string;
+  /**
+   * The day and time of the start of the session
+   */
+  startDateTime: any;
+  /**
+   * The day and time of the end of the session
+   */
+  endDateTime: any;
+  /**
+   * The ID of the course the session belongs to
+   */
+  courseId: number;
+  isPublicEvent: boolean;
+  /**
+   * An object relationship
+   */
+  Course: PublicEventById_Session_Course;
+  /**
+   * An array relationship
+   */
+  SessionAddresses: PublicEventById_Session_SessionAddresses[];
+  /**
+   * An array relationship
+   */
+  SessionSpeakers: PublicEventById_Session_SessionSpeakers[];
+}
+
+export interface PublicEventById {
+  /**
+   * fetch data from the table: "Session"
+   */
+  Session: PublicEventById_Session[];
+}
+
+export interface PublicEventByIdVariables {
+  sessionId: number;
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/PublicEventSessionFields.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/PublicEventSessionFields.ts
@@ -1,0 +1,180 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { LocationOption_enum } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL fragment: PublicEventSessionFields
+// ====================================================
+
+export interface PublicEventSessionFields_Course_Program {
+  __typename: "Program";
+  id: number;
+  /**
+   * The title of the program
+   */
+  title: string;
+  /**
+   * The 6 letter short title for the program.
+   */
+  shortTitle: string | null;
+}
+
+export interface PublicEventSessionFields_Course_CourseLocations {
+  __typename: "CourseLocation";
+  id: number;
+  /**
+   * Either 'ONLINE' or one of the possible given offline locations
+   */
+  locationOption: LocationOption_enum | null;
+  /**
+   * Will be used as default for any new session address.
+   */
+  defaultSessionAddress: string | null;
+}
+
+export interface PublicEventSessionFields_Course {
+  __typename: "Course";
+  id: number;
+  /**
+   * The title of the course (only editable by an admin user)
+   */
+  title: string;
+  /**
+   * The cover image for the course
+   */
+  coverImage: string | null;
+  /**
+   * Shown below the title on the course page
+   */
+  tagline: string;
+  /**
+   * An object relationship
+   */
+  Program: PublicEventSessionFields_Course_Program;
+  /**
+   * An array relationship
+   */
+  CourseLocations: PublicEventSessionFields_Course_CourseLocations[];
+}
+
+export interface PublicEventSessionFields_SessionAddresses_CourseLocation {
+  __typename: "CourseLocation";
+  id: number;
+  /**
+   * Either 'ONLINE' or one of the possible given offline locations
+   */
+  locationOption: LocationOption_enum | null;
+  /**
+   * Will be used as default for any new session address.
+   */
+  defaultSessionAddress: string | null;
+  /**
+   * References a LocationAddress that serves as the default for sessions in this course location. Replaces the legacy text-based defaultSessionAddress field.
+   */
+  defaultSessionAddressId: number | null;
+}
+
+export interface PublicEventSessionFields_SessionAddresses_LocationAddress {
+  __typename: "LocationAddress";
+  id: number;
+  /**
+   * Concise label shown in lists and typeahead (e.g., "Room 2.12", "Main Building").
+   */
+  shortLabel: string;
+  /**
+   * Full human-readable address (street, building, room number, etc.).
+   */
+  address: string;
+}
+
+export interface PublicEventSessionFields_SessionAddresses {
+  __typename: "SessionAddress";
+  id: number;
+  /**
+   * Where the session will take place; might be an offline or online location which is provided according to the provided type
+   */
+  address: string;
+  /**
+   * Foreign key to LocationAddress. Replaces the free-text address field with a structured address reference. Nullable during migration period.
+   */
+  locationAddressId: number | null;
+  /**
+   * An object relationship
+   */
+  CourseLocation: PublicEventSessionFields_SessionAddresses_CourseLocation | null;
+  /**
+   * An object relationship
+   */
+  LocationAddress: PublicEventSessionFields_SessionAddresses_LocationAddress | null;
+}
+
+export interface PublicEventSessionFields_SessionSpeakers_User {
+  __typename: "User";
+  id: any;
+  /**
+   * The user's first name
+   */
+  firstName: string;
+  /**
+   * The user's last name
+   */
+  lastName: string;
+  /**
+   * The user's profile picture
+   */
+  picture: string | null;
+  /**
+   * A link to an external profile, for example in LinkedIn or Xing
+   */
+  externalProfile: string | null;
+}
+
+export interface PublicEventSessionFields_SessionSpeakers {
+  __typename: "SessionSpeaker";
+  id: number;
+  /**
+   * An object relationship
+   */
+  User: PublicEventSessionFields_SessionSpeakers_User;
+}
+
+export interface PublicEventSessionFields {
+  __typename: "Session";
+  id: number;
+  /**
+   * The title of the session
+   */
+  title: string;
+  /**
+   * A description of the session
+   */
+  description: string;
+  /**
+   * The day and time of the start of the session
+   */
+  startDateTime: any;
+  /**
+   * The day and time of the end of the session
+   */
+  endDateTime: any;
+  /**
+   * The ID of the course the session belongs to
+   */
+  courseId: number;
+  isPublicEvent: boolean;
+  /**
+   * An object relationship
+   */
+  Course: PublicEventSessionFields_Course;
+  /**
+   * An array relationship
+   */
+  SessionAddresses: PublicEventSessionFields_SessionAddresses[];
+  /**
+   * An array relationship
+   */
+  SessionSpeakers: PublicEventSessionFields_SessionSpeakers[];
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/PublicEvents.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/PublicEvents.ts
@@ -1,0 +1,187 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { LocationOption_enum } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL query operation: PublicEvents
+// ====================================================
+
+export interface PublicEvents_Session_Course_Program {
+  __typename: "Program";
+  id: number;
+  /**
+   * The title of the program
+   */
+  title: string;
+  /**
+   * The 6 letter short title for the program.
+   */
+  shortTitle: string | null;
+}
+
+export interface PublicEvents_Session_Course_CourseLocations {
+  __typename: "CourseLocation";
+  id: number;
+  /**
+   * Either 'ONLINE' or one of the possible given offline locations
+   */
+  locationOption: LocationOption_enum | null;
+  /**
+   * Will be used as default for any new session address.
+   */
+  defaultSessionAddress: string | null;
+}
+
+export interface PublicEvents_Session_Course {
+  __typename: "Course";
+  id: number;
+  /**
+   * The title of the course (only editable by an admin user)
+   */
+  title: string;
+  /**
+   * The cover image for the course
+   */
+  coverImage: string | null;
+  /**
+   * Shown below the title on the course page
+   */
+  tagline: string;
+  /**
+   * An object relationship
+   */
+  Program: PublicEvents_Session_Course_Program;
+  /**
+   * An array relationship
+   */
+  CourseLocations: PublicEvents_Session_Course_CourseLocations[];
+}
+
+export interface PublicEvents_Session_SessionAddresses_CourseLocation {
+  __typename: "CourseLocation";
+  id: number;
+  /**
+   * Either 'ONLINE' or one of the possible given offline locations
+   */
+  locationOption: LocationOption_enum | null;
+  /**
+   * Will be used as default for any new session address.
+   */
+  defaultSessionAddress: string | null;
+  /**
+   * References a LocationAddress that serves as the default for sessions in this course location. Replaces the legacy text-based defaultSessionAddress field.
+   */
+  defaultSessionAddressId: number | null;
+}
+
+export interface PublicEvents_Session_SessionAddresses_LocationAddress {
+  __typename: "LocationAddress";
+  id: number;
+  /**
+   * Concise label shown in lists and typeahead (e.g., "Room 2.12", "Main Building").
+   */
+  shortLabel: string;
+  /**
+   * Full human-readable address (street, building, room number, etc.).
+   */
+  address: string;
+}
+
+export interface PublicEvents_Session_SessionAddresses {
+  __typename: "SessionAddress";
+  id: number;
+  /**
+   * Where the session will take place; might be an offline or online location which is provided according to the provided type
+   */
+  address: string;
+  /**
+   * Foreign key to LocationAddress. Replaces the free-text address field with a structured address reference. Nullable during migration period.
+   */
+  locationAddressId: number | null;
+  /**
+   * An object relationship
+   */
+  CourseLocation: PublicEvents_Session_SessionAddresses_CourseLocation | null;
+  /**
+   * An object relationship
+   */
+  LocationAddress: PublicEvents_Session_SessionAddresses_LocationAddress | null;
+}
+
+export interface PublicEvents_Session_SessionSpeakers_User {
+  __typename: "User";
+  id: any;
+  /**
+   * The user's first name
+   */
+  firstName: string;
+  /**
+   * The user's last name
+   */
+  lastName: string;
+  /**
+   * The user's profile picture
+   */
+  picture: string | null;
+  /**
+   * A link to an external profile, for example in LinkedIn or Xing
+   */
+  externalProfile: string | null;
+}
+
+export interface PublicEvents_Session_SessionSpeakers {
+  __typename: "SessionSpeaker";
+  id: number;
+  /**
+   * An object relationship
+   */
+  User: PublicEvents_Session_SessionSpeakers_User;
+}
+
+export interface PublicEvents_Session {
+  __typename: "Session";
+  id: number;
+  /**
+   * The title of the session
+   */
+  title: string;
+  /**
+   * A description of the session
+   */
+  description: string;
+  /**
+   * The day and time of the start of the session
+   */
+  startDateTime: any;
+  /**
+   * The day and time of the end of the session
+   */
+  endDateTime: any;
+  /**
+   * The ID of the course the session belongs to
+   */
+  courseId: number;
+  isPublicEvent: boolean;
+  /**
+   * An object relationship
+   */
+  Course: PublicEvents_Session_Course;
+  /**
+   * An array relationship
+   */
+  SessionAddresses: PublicEvents_Session_SessionAddresses[];
+  /**
+   * An array relationship
+   */
+  SessionSpeakers: PublicEvents_Session_SessionSpeakers[];
+}
+
+export interface PublicEvents {
+  /**
+   * fetch data from the table: "Session"
+   */
+  Session: PublicEvents_Session[];
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/SessionFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/SessionFragment.ts
@@ -88,6 +88,7 @@ export interface SessionFragment {
    * A description of the session
    */
   description: string;
+  isPublicEvent: boolean;
   /**
    * The day and time of the start of the session
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateSessionIsPublicEvent.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateSessionIsPublicEvent.ts
@@ -1,0 +1,26 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: UpdateSessionIsPublicEvent
+// ====================================================
+
+export interface UpdateSessionIsPublicEvent_update_Session_by_pk {
+  __typename: "Session";
+  id: number;
+  isPublicEvent: boolean;
+}
+
+export interface UpdateSessionIsPublicEvent {
+  /**
+   * update single row of the table: "Session"
+   */
+  update_Session_by_pk: UpdateSessionIsPublicEvent_update_Session_by_pk | null;
+}
+
+export interface UpdateSessionIsPublicEventVariables {
+  sessionId: number;
+  value: boolean;
+}

--- a/frontend-nx/apps/edu-hub/queries/course.ts
+++ b/frontend-nx/apps/edu-hub/queries/course.ts
@@ -188,6 +188,8 @@ export const UPDATE_SESSION_DESCRIPTION = gql`
   }
 `;
 
+export { UPDATE_SESSION_IS_PUBLIC_EVENT } from './publicEvents';
+
 export const INSERT_NEW_SESSION_SPEAKER = gql`
   mutation InsertNewSessionSpeaker($sessionId: Int!, $userId: uuid!) {
     insert_SessionSpeaker(

--- a/frontend-nx/apps/edu-hub/queries/publicEvents.ts
+++ b/frontend-nx/apps/edu-hub/queries/publicEvents.ts
@@ -1,0 +1,95 @@
+import { gql } from '@apollo/client';
+
+export const PUBLIC_EVENT_SESSION_FIELDS = gql`
+  fragment PublicEventSessionFields on Session {
+    id
+    title
+    description
+    startDateTime
+    endDateTime
+    courseId
+    isPublicEvent
+    Course {
+      id
+      title
+      coverImage
+      tagline
+      Program {
+        id
+        title
+        shortTitle
+      }
+      CourseLocations {
+        id
+        locationOption
+        defaultSessionAddress
+      }
+    }
+    SessionAddresses {
+      id
+      address
+      locationAddressId
+      CourseLocation {
+        id
+        locationOption
+        defaultSessionAddress
+        defaultSessionAddressId
+      }
+      LocationAddress {
+        id
+        shortLabel
+        address
+      }
+    }
+    SessionSpeakers {
+      id
+      User {
+        id
+        firstName
+        lastName
+        picture
+        externalProfile
+      }
+    }
+  }
+`;
+
+export const PUBLIC_EVENTS = gql`
+  ${PUBLIC_EVENT_SESSION_FIELDS}
+  query PublicEvents {
+    Session(
+      where: {
+        isPublicEvent: { _eq: true }
+        Course: { published: { _eq: true }, Program: { published: { _eq: true } } }
+      }
+      order_by: { startDateTime: asc }
+    ) {
+      ...PublicEventSessionFields
+    }
+  }
+`;
+
+export const PUBLIC_EVENT_BY_ID = gql`
+  ${PUBLIC_EVENT_SESSION_FIELDS}
+  query PublicEventById($sessionId: Int!) {
+    Session(
+      where: {
+        id: { _eq: $sessionId }
+        isPublicEvent: { _eq: true }
+        Course: { published: { _eq: true }, Program: { published: { _eq: true } } }
+      }
+      limit: 1
+    ) {
+      ...PublicEventSessionFields
+    }
+  }
+`;
+
+export const UPDATE_SESSION_IS_PUBLIC_EVENT = gql`
+  mutation UpdateSessionIsPublicEvent($sessionId: Int!, $value: Boolean!) {
+    update_Session_by_pk(pk_columns: { id: $sessionId }, _set: { isPublicEvent: $value }) {
+      id
+      isPublicEvent
+    }
+  }
+`;

--- a/frontend-nx/apps/edu-hub/queries/sessionFragement.ts
+++ b/frontend-nx/apps/edu-hub/queries/sessionFragement.ts
@@ -8,6 +8,7 @@ export const SESSION_FRAGMENT = gql`
     endDateTime
     courseId
     description
+    isPublicEvent
     startDateTime
     title
     SessionAddresses {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements issue #1695: admins can mark any session as a **public event**. That exposes a standalone `/event/[sessionId]` page (built from existing Course + Session data) and an `EventTile` component ready for the follow-up homepage slider issue (#1696).

## Changes

### Backend
- Migration `1778000000030_add_session_is_public_event`: `Session.isPublicEvent boolean NOT NULL DEFAULT false`
- Hasura permissions: `isPublicEvent` on `anonymous` + `instructor_access` select; `admin` role update only for this column
- Added inherited Hasura role `admin` (inherits instructor/user/anonymous access)
- Removed stale `public_Event.yaml` metadata (table was dropped in 2021)

### GraphQL
- `PublicEvents`, `PublicEventById`, `UpdateSessionIsPublicEvent` queries/mutations
- `isPublicEvent` on `SessionFragment` / managed course session types

### Frontend
- Sessions table column: public event checkbox (admin can toggle; instructors read-only)
- Course session list: badge linking to `/event/[sessionId]` when public
- `EventContent` + `/event/[sessionId]` public detail page with SEO meta tags
- `EventTile` in `TileSlider` (drop-in for future sliders)

### i18n
- German (Du) + English keys for toggle, badge, event page, and tile

## Function impact scan (`functions/`)

Searched `Session` / session-related consumers (reminders, certificates, attendance, email templates). **No updates required** — none depend on public-event semantics.

## Testing

- Anonymous GraphQL: public session query works with `x-hasura-role: anonymous`
- E2E (browser): `/event/24` loads without login; course page badge + link work
- Admin sessions table: public event column visible after UX fix (scroll right if needed)

## Out of scope (per issue)

- Homepage slider placement of `EventTile` (#1696)
- `EVENTS` program / `CalendarContent` filtering changes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff624fd9-ecb4-499c-8cdc-ce12853b07b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff624fd9-ecb4-499c-8cdc-ce12853b07b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

