### PR TITLE
feat(admin): finish organization admin management (issue #1202)

### DIFF
--- a/backend/metadata/actions.yaml
+++ b/backend/metadata/actions.yaml
@@ -122,6 +122,8 @@ actions:
           value_from_env: HASURA_BUCKET
         - name: name
           value: getAdminUsers
+    permissions:
+      - role: instructor_access
   - name: getFormbricksResponses
     definition:
       kind: ""
@@ -359,7 +361,9 @@ actions:
         - name: bucket
           value_from_env: HASURA_BUCKET
         - name: name
-          value: setUserAdmin
+          value: updateAdminUser
+    permissions:
+      - role: instructor_access
   - name: validateFormbricksSurvey
     definition:
       kind: synchronous

--- a/backend/metadata/databases/default/tables/public_OrganizationAdmin.yaml
+++ b/backend/metadata/databases/default/tables/public_OrganizationAdmin.yaml
@@ -8,3 +8,109 @@ object_relationships:
   - name: User
     using:
       foreign_key_constraint_on: userId
+select_permissions:
+  - role: instructor_access
+    permission:
+      columns:
+        - canManageCourses
+        - canManageEvents
+        - canManageSettings
+        - created_at
+        - id
+        - organizationId
+        - updated_at
+        - userId
+      filter: {}
+      allow_aggregations: true
+  - role: user_access
+    permission:
+      columns:
+        - canManageCourses
+        - canManageEvents
+        - canManageSettings
+        - created_at
+        - id
+        - organizationId
+        - updated_at
+        - userId
+      filter:
+        Organization:
+          OrganizationAdmins:
+            _and:
+              - userId:
+                  _eq: X-Hasura-User-Id
+              - canManageSettings:
+                  _eq: true
+      allow_aggregations: true
+insert_permissions:
+  - role: instructor_access
+    permission:
+      check: {}
+      columns:
+        - canManageCourses
+        - canManageEvents
+        - canManageSettings
+        - organizationId
+        - userId
+  - role: user_access
+    permission:
+      check:
+        Organization:
+          OrganizationAdmins:
+            _and:
+              - userId:
+                  _eq: X-Hasura-User-Id
+              - canManageSettings:
+                  _eq: true
+      columns:
+        - canManageCourses
+        - canManageEvents
+        - canManageSettings
+        - organizationId
+        - userId
+update_permissions:
+  - role: instructor_access
+    permission:
+      columns:
+        - canManageCourses
+        - canManageEvents
+        - canManageSettings
+        - organizationId
+      filter: {}
+      check: {}
+  - role: user_access
+    permission:
+      columns:
+        - canManageCourses
+        - canManageEvents
+        - canManageSettings
+      filter:
+        Organization:
+          OrganizationAdmins:
+            _and:
+              - userId:
+                  _eq: X-Hasura-User-Id
+              - canManageSettings:
+                  _eq: true
+      check:
+        Organization:
+          OrganizationAdmins:
+            _and:
+              - userId:
+                  _eq: X-Hasura-User-Id
+              - canManageSettings:
+                  _eq: true
+delete_permissions:
+  - role: instructor_access
+    permission:
+      filter: {}
+  - role: user_access
+    permission:
+      filter:
+        Organization:
+          OrganizationAdmins:
+            _and:
+              - userId:
+                  _eq: X-Hasura-User-Id
+              - canManageSettings:
+                  _eq: true

--- a/backend/metadata/inherited_roles.yaml
+++ b/backend/metadata/inherited_roles.yaml
@@ -1,3 +1,6 @@
+- role_name: admin
+  role_set:
+    - instructor
 - role_name: instructor
   role_set:
     - user_access

--- a/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
+++ b/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { FC, useCallback } from 'react';
 import { useIsAdmin, useIsInstructor } from '../../hooks/authentication';
+import { useCanManageOrganizationAdmins } from '../../hooks/useOrganizationAdminAccess';
 import { useTranslations } from 'next-intl';
 import useLogout from '../../hooks/logout';
 
@@ -53,6 +54,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
   const isAdmin = useIsAdmin();
   const isInstructor = useIsInstructor();
+  const canManageAdmins = useCanManageOrganizationAdmins();
   const isInstructorOrAdmin = isAdmin || isInstructor;
 
   const t = useTranslations('common');
@@ -115,6 +117,14 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/users')}>
           <Link className="w-full text-lg" href="/manage/users">
             {t('menu.user')}
+          </Link>
+        </MenuItem>
+      )}
+
+      {canManageAdmins && (
+        <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/admin-users')}>
+          <Link className="w-full text-lg" href="/manage/admin-users">
+            {t('menu.manage_admins')}
           </Link>
         </MenuItem>
       )}

--- a/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/AddOrganizationAdminDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/AddOrganizationAdminDialog.tsx
@@ -1,0 +1,213 @@
+import { FC, useCallback, useMemo, useState } from 'react';
+import { Dialog, DialogContent, DialogTitle, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent } from '@mui/material';
+import { useTranslations } from 'next-intl';
+import { MdClose } from 'react-icons/md';
+
+import { Button } from '../../common/Button';
+import { SelectUserDialog } from '../../common/dialogs/SelectUserDialog';
+import NotificationSnackbar from '../../common/dialogs/NotificationSnackbar';
+import { ErrorMessageDialog } from '../../common/dialogs/ErrorMessageDialog';
+import CheckboxSelector from '../../inputs/CheckboxSelector';
+import { useRoleMutation } from '../../../hooks/authedMutation';
+import { INSERT_ORGANIZATION_ADMIN } from '../../../queries/organizationAdmin';
+import { UserSelectionWithFilter_User } from '../../../queries/__generated__/UserSelectionWithFilter';
+
+interface OrganizationOption {
+  id: number;
+  name: string;
+}
+
+interface AddOrganizationAdminDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+  organizationOptions: OrganizationOption[];
+  defaultOrganizationId?: number;
+}
+
+export const AddOrganizationAdminDialog: FC<AddOrganizationAdminDialogProps> = ({
+  open,
+  onClose,
+  onSuccess,
+  organizationOptions,
+  defaultOrganizationId,
+}) => {
+  const t = useTranslations('manageAdminUsers');
+  const [selectedUser, setSelectedUser] = useState<UserSelectionWithFilter_User | null>(null);
+  const [selectUserOpen, setSelectUserOpen] = useState(false);
+  const [organizationId, setOrganizationId] = useState<number | ''>(defaultOrganizationId ?? '');
+  const [canManageCourses, setCanManageCourses] = useState(false);
+  const [canManageEvents, setCanManageEvents] = useState(false);
+  const [canManageSettings, setCanManageSettings] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [showSuccessNotification, setShowSuccessNotification] = useState(false);
+
+  const [insertOrganizationAdmin, { loading }] = useRoleMutation(INSERT_ORGANIZATION_ADMIN, {
+    refetchQueries: ['OrganizationAdminList', 'MyManageableOrganizationAdmins'],
+  });
+
+  const resetForm = useCallback(() => {
+    setSelectedUser(null);
+    setOrganizationId(defaultOrganizationId ?? '');
+    setCanManageCourses(false);
+    setCanManageEvents(false);
+    setCanManageSettings(false);
+    setValidationError(null);
+    setServerError(null);
+  }, [defaultOrganizationId]);
+
+  const handleClose = useCallback(() => {
+    resetForm();
+    onClose();
+  }, [onClose, resetForm]);
+
+  const handleOrganizationChange = useCallback((event: SelectChangeEvent<number | ''>) => {
+    setOrganizationId(event.target.value as number | '');
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (!selectedUser) {
+      setValidationError(t('add_admin.validation_user_required'));
+      return;
+    }
+    if (!organizationId) {
+      setValidationError(t('add_admin.validation_organization_required'));
+      return;
+    }
+
+    setValidationError(null);
+    setServerError(null);
+
+    try {
+      await insertOrganizationAdmin({
+        variables: {
+          userId: selectedUser.id,
+          organizationId,
+          canManageCourses,
+          canManageEvents,
+          canManageSettings,
+        },
+      });
+      setShowSuccessNotification(true);
+      onSuccess();
+      handleClose();
+    } catch (error) {
+      setServerError(error instanceof Error ? error.message : t('add_admin.error'));
+    }
+  }, [
+    selectedUser,
+    organizationId,
+    canManageCourses,
+    canManageEvents,
+    canManageSettings,
+    insertOrganizationAdmin,
+    onSuccess,
+    handleClose,
+    t,
+  ]);
+
+  const selectedUserLabel = useMemo(() => {
+    if (!selectedUser) {
+      return '';
+    }
+    return `${selectedUser.firstName} ${selectedUser.lastName} (${selectedUser.email})`;
+  }, [selectedUser]);
+
+  return (
+    <>
+      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+        <DialogTitle className="light">
+          <div className="grid grid-cols-2">
+            <div className="text-label-primary">{t('add_admin.title')}</div>
+            <div className="cursor-pointer flex justify-end text-label-primary">
+              <MdClose onClick={handleClose} />
+            </div>
+          </div>
+        </DialogTitle>
+        <DialogContent className="light space-y-4">
+          <div>
+            <p className="text-label-secondary text-sm mb-2">{t('add_admin.user_label')}</p>
+            <Button onClick={() => setSelectUserOpen(true)} filled inverted>
+              {selectedUser ? t('add_admin.change_user') : t('add_admin.select_user')}
+            </Button>
+            {selectedUserLabel && <p className="mt-2 text-label-primary text-sm">{selectedUserLabel}</p>}
+          </div>
+
+          {organizationOptions.length > 1 ? (
+            <FormControl fullWidth>
+              <InputLabel id="organization-admin-org-label">{t('organization')}</InputLabel>
+              <Select
+                labelId="organization-admin-org-label"
+                label={t('organization')}
+                value={organizationId}
+                onChange={handleOrganizationChange}
+              >
+                {organizationOptions.map((org) => (
+                  <MenuItem key={org.id} value={org.id}>
+                    {org.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          ) : (
+            organizationOptions.length === 1 && (
+              <p className="text-label-primary">
+                {t('organization')}: {organizationOptions[0].name}
+              </p>
+            )
+          )}
+
+          <div className="space-y-2">
+            <CheckboxSelector
+              variant="eduhub"
+              label={t('can_manage_events')}
+              checked={canManageEvents}
+              onValueUpdated={setCanManageEvents}
+            />
+            <CheckboxSelector
+              variant="eduhub"
+              label={t('can_manage_courses')}
+              checked={canManageCourses}
+              onValueUpdated={setCanManageCourses}
+            />
+            <CheckboxSelector
+              variant="eduhub"
+              label={t('can_manage_users_and_settings')}
+              checked={canManageSettings}
+              onValueUpdated={setCanManageSettings}
+            />
+          </div>
+
+          {validationError && <p className="text-red-500 text-sm">{validationError}</p>}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button onClick={handleClose}>{t('add_admin.cancel')}</Button>
+            <Button onClick={handleSubmit} filled disabled={loading}>
+              {loading ? t('add_admin.saving') : t('add_admin.save')}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <SelectUserDialog
+        open={selectUserOpen}
+        title={t('add_admin.select_user')}
+        onClose={(confirmed, user) => {
+          setSelectUserOpen(false);
+          if (confirmed && user) {
+            setSelectedUser(user);
+          }
+        }}
+      />
+
+      <NotificationSnackbar
+        open={showSuccessNotification}
+        onClose={() => setShowSuccessNotification(false)}
+        message={t('add_admin.success')}
+      />
+
+      <ErrorMessageDialog errorMessage={serverError ?? ''} open={!!serverError} onClose={() => setServerError(null)} />
+    </>
+  );
+};

--- a/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactNode, useMemo, useCallback, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { ColumnDef } from '@tanstack/react-table';
+import { useSession } from 'next-auth/react';
 
 import TableGrid from '../../common/TableGrid';
 import Loading from '../../common/Loading';
@@ -8,7 +9,7 @@ import { useTableGrid } from '../../common/TableGrid/hooks';
 import { createMultiWordSearchCondition } from '../../common/TableGrid/utils';
 import CheckboxSelector from '../../inputs/CheckboxSelector';
 
-import { useAdminQuery } from '../../../hooks/authedQuery';
+import { useRoleQuery, useAdminQuery } from '../../../hooks/authedQuery';
 import { useAdminMutation } from '../../../hooks/authedMutation';
 import {
   ORGANIZATION_ADMIN_LIST,
@@ -16,33 +17,41 @@ import {
   UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_EVENTS,
   UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_COURSES,
   UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_SETTINGS,
+  MY_MANAGEABLE_ORGANIZATION_ADMINS,
 } from '../../../queries/organizationAdmin';
 import { UPDATE_USER_ADMIN_STATUS, ADMIN_USERS } from '../../../queries/actions';
 import { PageBlock } from '../../common/PageBlock';
 import CommonPageHeader from '../../common/CommonPageHeader';
 import { useIsAdmin } from '../../../hooks/authentication';
+import { useManageableOrganizationIds } from '../../../hooks/useOrganizationAdminAccess';
 import { OrganizationAdminList_OrganizationAdmin } from '../../../queries/__generated__/OrganizationAdminList';
+import { AddOrganizationAdminDialog } from './AddOrganizationAdminDialog';
+import { ORGANIZATION_LIST } from '../../../queries/organization';
 
 const ExpandableUserRow: FC<{
   row: OrganizationAdminList_OrganizationAdmin;
   isSuperAdmin: boolean;
+  isEduHubAdmin: boolean;
   onAdminStatusChange: () => void;
-}> = ({ row, isSuperAdmin, onAdminStatusChange }) => {
+}> = ({ row, isSuperAdmin, isEduHubAdmin, onAdminStatusChange }) => {
   const t = useTranslations('manageAdminUsers');
-  const isAdmin = useIsAdmin();
 
   const [setAdminStatus] = useAdminMutation(UPDATE_USER_ADMIN_STATUS);
 
   const handleAdminToggle = async (checked: boolean) => {
+    if (!row.User?.id) {
+      return;
+    }
+
     try {
       const response = await setAdminStatus({
         variables: {
-          userId: row.id,
+          userId: row.User.id,
           isAdmin: checked,
         },
       });
 
-      if (response.data?.success) {
+      if (response.data?.updateUserAdminStatus?.success) {
         onAdminStatusChange();
       }
     } catch (error) {
@@ -59,8 +68,8 @@ const ExpandableUserRow: FC<{
             label={t('can_manage_events')}
             checked={row.canManageEvents}
             updateValueMutation={UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_EVENTS}
-            identifierVariables={{ itemId: row.id }}
-            refetchQueries={['GetAdminUsers']}
+            identifierVariables={{ id: row.id }}
+            refetchQueries={['OrganizationAdminList', 'AdminUsers']}
           />
         </div>
         <div className="pl-3 col-span-3">
@@ -69,8 +78,8 @@ const ExpandableUserRow: FC<{
             label={t('can_manage_courses')}
             checked={row.canManageCourses}
             updateValueMutation={UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_COURSES}
-            identifierVariables={{ itemId: row.id }}
-            refetchQueries={['GetAdminUsers']}
+            identifierVariables={{ id: row.id }}
+            refetchQueries={['OrganizationAdminList', 'AdminUsers']}
           />
         </div>
         <div className="pl-3 col-span-4">
@@ -79,19 +88,19 @@ const ExpandableUserRow: FC<{
             label={t('can_manage_users_and_settings')}
             checked={row.canManageSettings}
             updateValueMutation={UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_SETTINGS}
-            identifierVariables={{ itemId: row.id }}
-            refetchQueries={['GetAdminUsers']}
+            identifierVariables={{ id: row.id }}
+            refetchQueries={['OrganizationAdminList', 'AdminUsers']}
           />
         </div>
       </div>
-      {isAdmin && (
-        <div className="pl-3 col-span-3">
+      {isEduHubAdmin && (
+        <div className="pl-3 col-span-3 mt-2">
           <CheckboxSelector
             variant="eduhub"
             label={t('is_super_admin')}
             checked={isSuperAdmin}
             onValueUpdated={handleAdminToggle}
-            refetchQueries={['GetAdminUsers']}
+            refetchQueries={['OrganizationAdminList', 'AdminUsers']}
           />
         </div>
       )}
@@ -101,13 +110,19 @@ const ExpandableUserRow: FC<{
 
 const ManageAdminUsersContent: FC = () => {
   const t = useTranslations('manageAdminUsers');
+  const isEduHubAdmin = useIsAdmin();
+  const manageableOrganizationIds = useManageableOrganizationIds();
   const [adminUserIds, setAdminUserIds] = useState<string[]>([]);
   const [adminError, setAdminError] = useState<Error | null>(null);
+  const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const { data: sessionData } = useSession();
+  const userId = sessionData?.profile?.['https://hasura.io/jwt/claims']?.['x-hasura-user-id'] as string | undefined;
 
   useAdminQuery(ADMIN_USERS, {
+    skip: !isEduHubAdmin,
     onCompleted: (data) => {
       if (data?.getAdminUsers?.success) {
-        setAdminUserIds(data.getAdminUsers.adminUserIds);
+        setAdminUserIds(data.getAdminUsers.adminUserIds ?? []);
       }
     },
     onError: (error) => {
@@ -116,19 +131,54 @@ const ManageAdminUsersContent: FC = () => {
     },
   });
 
+  const { data: myOrganizationsData } = useRoleQuery(MY_MANAGEABLE_ORGANIZATION_ADMINS, {
+    variables: { userId },
+    skip: isEduHubAdmin || !userId,
+  });
+
+  const { data: allOrganizationsData } = useAdminQuery(ORGANIZATION_LIST, {
+    variables: { limit: 500, offset: 0 },
+    skip: !isEduHubAdmin,
+  });
+
+  const organizationOptions = useMemo(() => {
+    if (isEduHubAdmin) {
+      return (
+        allOrganizationsData?.Organization?.map((org) => ({
+          id: org.id,
+          name: org.name,
+        })) ?? []
+      );
+    }
+
+    return (
+      myOrganizationsData?.OrganizationAdmin?.map((admin) => ({
+        id: admin.Organization?.id ?? admin.organizationId,
+        name: admin.Organization?.name ?? String(admin.organizationId),
+      })).filter((org): org is { id: number; name: string } => org.id != null) ?? []
+    );
+  }, [isEduHubAdmin, allOrganizationsData, myOrganizationsData]);
+
   const { data, loading, error, pageIndex, setPageIndex, searchFilter, setSearchFilter, refetch } = useTableGrid({
-    queryHook: useAdminQuery,
+    queryHook: useRoleQuery,
     query: ORGANIZATION_ADMIN_LIST,
     pageSize: 15,
-    refetchFilter: (searchFilter) => {
-      const searchCondition = createMultiWordSearchCondition(searchFilter, [
+    refetchFilter: (searchFilterValue) => {
+      const searchCondition = createMultiWordSearchCondition(searchFilterValue, [
         'User.lastName',
         'User.firstName',
         'User.email',
         'Organization.name',
       ]);
+      const filters = [];
+      if (!isEduHubAdmin && manageableOrganizationIds.length > 0) {
+        filters.push({ organizationId: { _in: manageableOrganizationIds } });
+      }
+      if (Object.keys(searchCondition).length > 0) {
+        filters.push(searchCondition);
+      }
       return {
-        filter: searchCondition,
+        filter: filters.length > 0 ? { _and: filters } : {},
       };
     },
   });
@@ -182,7 +232,7 @@ const ManageAdminUsersContent: FC = () => {
     <PageBlock>
       <div className="max-w-screen-xl mx-auto mt-20">
         {loading && <Loading />}
-        {adminError && <div className="text-red-500 p-4">{t('error_loading_admin_users')}</div>}
+        {adminError && <p className="text-red-500 p-4">{t('error_loading_admin_users')}</p>}
         {!loading && !error && (
           <div>
             <CommonPageHeader headline={t('headline')} />
@@ -195,15 +245,18 @@ const ManageAdminUsersContent: FC = () => {
               searchFilter={searchFilter}
               onSearchFilterChange={setSearchFilter}
               deleteMutation={DELETE_ORGANIZATION_ADMIN}
-              deleteIdType="uuidString"
+              deleteIdType="number"
               error={error}
               loading={loading}
-              refetchQueries={['UsersByLastName', 'GetAdminUsers']}
+              refetchQueries={['OrganizationAdminList', 'AdminUsers', 'MyManageableOrganizationAdmins']}
               generateDeletionConfirmationQuestion={generateDeletionConfirmation}
+              addButtonText={t('add_admin.button')}
+              onAddButtonClick={() => setAddDialogOpen(true)}
               expandableRowComponent={({ row }) => (
                 <ExpandableUserRow
                   row={row}
-                  isSuperAdmin={adminUserIds.includes(row.User?.id)}
+                  isSuperAdmin={row.User?.id ? adminUserIds.includes(row.User.id) : false}
+                  isEduHubAdmin={isEduHubAdmin}
                   onAdminStatusChange={() => refetch()}
                 />
               )}
@@ -211,6 +264,14 @@ const ManageAdminUsersContent: FC = () => {
           </div>
         )}
       </div>
+
+      <AddOrganizationAdminDialog
+        open={addDialogOpen}
+        onClose={() => setAddDialogOpen(false)}
+        onSuccess={() => refetch()}
+        organizationOptions={organizationOptions}
+        defaultOrganizationId={organizationOptions.length === 1 ? organizationOptions[0].id : undefined}
+      />
     </PageBlock>
   );
 };

--- a/frontend-nx/apps/edu-hub/components/pages/ManageUsersContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageUsersContent/index.tsx
@@ -14,6 +14,7 @@ import { PageBlock } from '../../common/PageBlock';
 import CommonPageHeader from '../../common/CommonPageHeader';
 import NavigationButton from '../../common/NavigationButton';
 import { CreateUserDialog } from '../../common/dialogs/CreateUserDialog';
+import { useCanManageOrganizationAdmins } from '../../../hooks/useOrganizationAdminAccess';
 
 const ExpandableUserRow: FC<{ row: UsersByLastName_User }> = ({ row }) => {
   const t = useTranslations('manageUsers');
@@ -52,6 +53,7 @@ const ExpandableUserRow: FC<{ row: UsersByLastName_User }> = ({ row }) => {
 
 const ManageUsersContent: FC = () => {
   const t = useTranslations('manageUsers');
+  const canManageAdmins = useCanManageOrganizationAdmins();
   const [pageSize, setPageSize] = useState(20);
   const [createUserDialogOpen, setCreateUserDialogOpen] = useState(false);
 
@@ -127,9 +129,11 @@ const ManageUsersContent: FC = () => {
           <div>
             <div className="flex justify-between items-center mb-4">
               <CommonPageHeader headline={t('headline')} />
-              <NavigationButton href="/manage/admin-users" filled inverted>
-                {t('manage_admins')}
-              </NavigationButton>
+              {canManageAdmins && (
+                <NavigationButton href="/manage/admin-users" filled inverted>
+                  {t('manage_admins')}
+                </NavigationButton>
+              )}
             </div>
             <TableGrid
               columns={columns}

--- a/frontend-nx/apps/edu-hub/hooks/authentication.ts
+++ b/frontend-nx/apps/edu-hub/hooks/authentication.ts
@@ -53,3 +53,5 @@ export const useCurrentRole = (): AuthRoles => {
       return AuthRoles.anonymous;
   }
 };
+
+export { useCanManageOrganizationAdmins, useManageableOrganizationIds } from './useOrganizationAdminAccess';

--- a/frontend-nx/apps/edu-hub/hooks/useOrganizationAdminAccess.ts
+++ b/frontend-nx/apps/edu-hub/hooks/useOrganizationAdminAccess.ts
@@ -1,0 +1,30 @@
+import { useSession } from 'next-auth/react';
+import { useRoleQuery } from './authedQuery';
+import { useIsAdmin } from './authentication';
+import { MY_MANAGEABLE_ORGANIZATION_ADMINS } from '../queries/organizationAdmin';
+
+export const useManageableOrganizationIds = (): number[] => {
+  const isAdmin = useIsAdmin();
+  const { data: sessionData, status } = useSession();
+  const userId = sessionData?.profile?.['https://hasura.io/jwt/claims']?.['x-hasura-user-id'] as string | undefined;
+
+  const { data } = useRoleQuery(MY_MANAGEABLE_ORGANIZATION_ADMINS, {
+    variables: { userId },
+    skip: isAdmin || status !== 'authenticated' || !userId,
+  });
+
+  if (isAdmin) {
+    return [];
+  }
+
+  return (
+    data?.OrganizationAdmin?.map((admin) => admin.organizationId).filter((id): id is number => id != null) ?? []
+  );
+};
+
+export const useCanManageOrganizationAdmins = (): boolean => {
+  const isAdmin = useIsAdmin();
+  const manageableOrganizationIds = useManageableOrganizationIds();
+
+  return isAdmin || manageableOrganizationIds.length > 0;
+};

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -51,6 +51,7 @@
       "calendar": "Kalender",
       "statistics": "Statistiken",
       "course_instructor_manual": "Kursleitungshandbuch",
+      "manage_admins": "Admins verwalten",
       "logout": "Logout"
     },
     "change-password": "Passwort oder E-Mail ändern",
@@ -1515,16 +1516,32 @@
     }
   },
   "manageAdminUsers": {
-    "headline": "Admin-Benutzer",
+    "headline": "Admins verwalten",
     "first_name": "Vorname",
     "last_name": "Nachname",
     "email": "E-Mail",
     "organization": "Organisation",
-    "deletion_confirmation_question": "Bist du sicher, dass du die Administrationsrechte von {firstName} {lastName} für die Organisation {organization} löschen möchtest?",
-    "is_super_admin": "Ist Super-Admin",
+    "deletion_confirmation_question": "Bist du sicher, dass du die Administrationsrechte von {firstName} {lastName} für die Organisation {organization} entfernen möchtest?",
+    "is_super_admin": "EduHub-Super-Admin",
     "can_manage_events": "Kann Events verwalten",
     "can_manage_courses": "Kann Kurse verwalten",
-    "can_manage_users_and_settings": "Kann Benutzer und Einstellungen verwalten"
+    "can_manage_users_and_settings": "Kann Benutzer und Einstellungen verwalten",
+    "error_loading_admin_users": "Super-Admins konnten nicht geladen werden.",
+    "access_denied": "Du hast keine Berechtigung, Organisationsadmins zu verwalten.",
+    "add_admin": {
+      "button": "Organisationsadmin hinzufügen",
+      "title": "Organisationsadmin hinzufügen",
+      "user_label": "Benutzer",
+      "select_user": "Benutzer auswählen",
+      "change_user": "Benutzer ändern",
+      "cancel": "Abbrechen",
+      "save": "Admin hinzufügen",
+      "saving": "Wird hinzugefügt...",
+      "success": "Organisationsadmin wurde hinzugefügt.",
+      "error": "Organisationsadmin konnte nicht hinzugefügt werden.",
+      "validation_user_required": "Bitte wähle einen Benutzer aus.",
+      "validation_organization_required": "Bitte wähle eine Organisation aus."
+    }
   },
   "manageAppSettings": {
     "app_settings": "App Einstellungen",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -51,6 +51,7 @@
       "calendar": "Calendar",
       "statistics": "Statistics",
       "course_instructor_manual": "Course Instructor Manual",
+      "manage_admins": "Manage admins",
       "logout": "Logout"
     },
     "change-password": "Change email or password",
@@ -1530,12 +1531,32 @@
     }
   },
   "manageAdminUsers": {
-    "headline": "Admin Users",
+    "headline": "Manage admins",
     "first_name": "First Name",
     "last_name": "Last Name",
     "email": "Email",
     "organization": "Organization",
-    "deletion_confirmation_question": "Are you sure you want to delete the admin rights of {firstName} {lastName} for the organization {organization}?"
+    "is_super_admin": "EduHub super admin",
+    "can_manage_events": "Can manage events",
+    "can_manage_courses": "Can manage courses",
+    "can_manage_users_and_settings": "Can manage users and settings",
+    "error_loading_admin_users": "Could not load super admin users.",
+    "access_denied": "You do not have permission to manage organization admins.",
+    "deletion_confirmation_question": "Are you sure you want to remove the admin rights of {firstName} {lastName} for the organization {organization}?",
+    "add_admin": {
+      "button": "Add organization admin",
+      "title": "Add organization admin",
+      "user_label": "User",
+      "select_user": "Select user",
+      "change_user": "Change user",
+      "cancel": "Cancel",
+      "save": "Add admin",
+      "saving": "Adding...",
+      "success": "Organization admin added.",
+      "error": "Could not add organization admin.",
+      "validation_user_required": "Please select a user.",
+      "validation_organization_required": "Please select an organization."
+    }
   },
   "manageAppSettings": {
     "backgroundImageURL": "Background image URL",

--- a/frontend-nx/apps/edu-hub/pages/manage/admin-users/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/admin-users/index.tsx
@@ -5,13 +5,16 @@ path.resolve('./next.config.js');
 import Head from 'next/head';
 import { FC } from 'react';
 import { Page } from '../../../components/layout/Page';
-import { useIsAdmin, useIsLoggedIn } from '../../../hooks/authentication';
+import { useIsLoggedIn } from '../../../hooks/authentication';
+import { useCanManageOrganizationAdmins } from '../../../hooks/useOrganizationAdminAccess';
+import { useTranslations } from 'next-intl';
 
 import ManageAdminUsersContent from '../../../components/pages/ManageAdminUsersContent';
 
 const ManageAdminUsers: FC = () => {
-  const isAdmin = useIsAdmin();
   const isLoggedIn = useIsLoggedIn();
+  const canManageAdmins = useCanManageOrganizationAdmins();
+  const t = useTranslations('manageAdminUsers');
 
   return (
     <>
@@ -21,7 +24,13 @@ const ManageAdminUsers: FC = () => {
       </Head>
       <div className="max-w-screen-xl mx-auto">
         <Page>
-          <div className="min-h-[77vh]">{isLoggedIn && isAdmin && <ManageAdminUsersContent />}</div>
+          <div className="min-h-[77vh]">
+            {isLoggedIn && canManageAdmins ? (
+              <ManageAdminUsersContent />
+            ) : (
+              isLoggedIn && <p className="p-8 text-label-primary">{t('access_denied')}</p>
+            )}
+          </div>
         </Page>
       </div>
     </>

--- a/frontend-nx/apps/edu-hub/queries/__generated__/InsertOrganizationAdmin.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/InsertOrganizationAdmin.ts
@@ -1,0 +1,30 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL mutation operation: InsertOrganizationAdmin
+// ====================================================
+
+export interface InsertOrganizationAdmin_insert_OrganizationAdmin_one {
+  __typename: "OrganizationAdmin";
+  id: number;
+  userId: string;
+  organizationId: number;
+  canManageCourses: boolean;
+  canManageEvents: boolean;
+  canManageSettings: boolean;
+}
+
+export interface InsertOrganizationAdmin {
+  insert_OrganizationAdmin_one: InsertOrganizationAdmin_insert_OrganizationAdmin_one | null;
+}
+
+export interface InsertOrganizationAdminVariables {
+  userId: string;
+  organizationId: number;
+  canManageCourses: boolean;
+  canManageEvents: boolean;
+  canManageSettings: boolean;
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MyManageableOrganizationAdmins.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MyManageableOrganizationAdmins.ts
@@ -1,0 +1,28 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: MyManageableOrganizationAdmins
+// ====================================================
+
+export interface MyManageableOrganizationAdmins_OrganizationAdmin_Organization {
+  __typename: "Organization";
+  id: number;
+  name: string;
+}
+
+export interface MyManageableOrganizationAdmins_OrganizationAdmin {
+  __typename: "OrganizationAdmin";
+  organizationId: number;
+  Organization: MyManageableOrganizationAdmins_OrganizationAdmin_Organization;
+}
+
+export interface MyManageableOrganizationAdmins {
+  OrganizationAdmin: MyManageableOrganizationAdmins_OrganizationAdmin[];
+}
+
+export interface MyManageableOrganizationAdminsVariables {
+  userId: string;
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateOrganizationAdminCanManageCourses.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateOrganizationAdminCanManageCourses.ts
@@ -22,5 +22,5 @@ export interface UpdateOrganizationAdminCanManageCourses {
 
 export interface UpdateOrganizationAdminCanManageCoursesVariables {
   id: number;
-  canManageCourses: boolean;
+  value: boolean;
 }

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateOrganizationAdminCanManageEvents.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateOrganizationAdminCanManageEvents.ts
@@ -22,5 +22,5 @@ export interface UpdateOrganizationAdminCanManageEvents {
 
 export interface UpdateOrganizationAdminCanManageEventsVariables {
   id: number;
-  canManageEvents: boolean;
+  value: boolean;
 }

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateOrganizationAdminCanManageSettings.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateOrganizationAdminCanManageSettings.ts
@@ -22,5 +22,5 @@ export interface UpdateOrganizationAdminCanManageSettings {
 
 export interface UpdateOrganizationAdminCanManageSettingsVariables {
   id: number;
-  canManageSettings: boolean;
+  value: boolean;
 }

--- a/frontend-nx/apps/edu-hub/queries/organizationAdmin.ts
+++ b/frontend-nx/apps/edu-hub/queries/organizationAdmin.ts
@@ -36,6 +36,50 @@ export const ORGANIZATION_ADMIN_LIST = gql`
   }
 `;
 
+export const MY_MANAGEABLE_ORGANIZATION_ADMINS = gql`
+  query MyManageableOrganizationAdmins($userId: uuid!) {
+    OrganizationAdmin(
+      where: {
+        userId: { _eq: $userId }
+        canManageSettings: { _eq: true }
+      }
+    ) {
+      organizationId
+      Organization {
+        id
+        name
+      }
+    }
+  }
+`;
+
+export const INSERT_ORGANIZATION_ADMIN = gql`
+  mutation InsertOrganizationAdmin(
+    $userId: uuid!
+    $organizationId: Int!
+    $canManageCourses: Boolean! = false
+    $canManageEvents: Boolean! = false
+    $canManageSettings: Boolean! = false
+  ) {
+    insert_OrganizationAdmin_one(
+      object: {
+        userId: $userId
+        organizationId: $organizationId
+        canManageCourses: $canManageCourses
+        canManageEvents: $canManageEvents
+        canManageSettings: $canManageSettings
+      }
+    ) {
+      id
+      userId
+      organizationId
+      canManageCourses
+      canManageEvents
+      canManageSettings
+    }
+  }
+`;
+
 export const DELETE_ORGANIZATION_ADMIN = gql`
   mutation DeleteOrganizationAdmin($id: Int!) {
     delete_OrganizationAdmin_by_pk(id: $id) {
@@ -54,10 +98,10 @@ export const DELETE_ORGANIZATION_ADMIN = gql`
 `;
 
 export const UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_EVENTS = gql`
-  mutation UpdateOrganizationAdminCanManageEvents($id: Int!, $canManageEvents: Boolean!) {
+  mutation UpdateOrganizationAdminCanManageEvents($id: Int!, $value: Boolean!) {
     update_OrganizationAdmin_by_pk(
       pk_columns: { id: $id },
-      _set: { canManageEvents: $canManageEvents }
+      _set: { canManageEvents: $value }
     ) {
       id
       canManageEvents
@@ -66,10 +110,10 @@ export const UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_EVENTS = gql`
 `;
 
 export const UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_COURSES = gql`
-  mutation UpdateOrganizationAdminCanManageCourses($id: Int!, $canManageCourses: Boolean!) {
+  mutation UpdateOrganizationAdminCanManageCourses($id: Int!, $value: Boolean!) {
     update_OrganizationAdmin_by_pk(
       pk_columns: { id: $id },
-      _set: { canManageCourses: $canManageCourses }
+      _set: { canManageCourses: $value }
     ) {
       id
       canManageCourses
@@ -78,10 +122,10 @@ export const UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_COURSES = gql`
 `;
 
 export const UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_SETTINGS = gql`
-  mutation UpdateOrganizationAdminCanManageSettings($id: Int!, $canManageSettings: Boolean!) {
+  mutation UpdateOrganizationAdminCanManageSettings($id: Int!, $value: Boolean!) {
     update_OrganizationAdmin_by_pk(
       pk_columns: { id: $id },
-      _set: { canManageSettings: $canManageSettings }
+      _set: { canManageSettings: $value }
     ) {
       id
       canManageSettings


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes [issue #1202](https://github.com/eduhub-org/eduhub/issues/1202) by finishing the organization admin management page started earlier in the repo.

## Changes

### Backend (Hasura)
- Added full CRUD permissions on `OrganizationAdmin` for `instructor_access` (EduHub super admins) and scoped `user_access` (organization admins with `canManageSettings`).
- Added `admin` inherited role so the `admin` JWT role receives instructor permissions.
- Fixed `updateUserAdminStatus` action handler name (`setUserAdmin` → `updateAdminUser`) and added action permissions for super-admin toggling.

### Frontend
- `/manage/admin-users` is available to EduHub super admins and organization admins who have `canManageSettings` on at least one organization.
- Fixed super-admin toggle bug (used organization admin row id instead of user id).
- Fixed checkbox mutations to use `$id` / `$value` (compatible with `CheckboxSelector`).
- Fixed table delete id type (`number` instead of `uuidString`).
- Added dialog to assign new organization admins (user picker + permissions).
- Menu entry and translations (EN/DE).

## How to verify

1. Log in as `admin@example.com` → open **Manage admins** from the menu or `/manage/admin-users`.
2. Expand a row, toggle organization permissions and EduHub super-admin status.
3. Add a new organization admin via the add button.
4. Log in as a seeded org admin with `canManageSettings` (see `OrganizationAdmin` seeds) → confirm scoped access to their organization(s) only.

Closes #1202
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-21534645-3ca0-4944-af61-0daa55ec8aef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-21534645-3ca0-4944-af61-0daa55ec8aef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

