### PR TITLE
feat(sessions): show formatted session descriptions on course page (#1692)

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/CalendarContent/SessionDetailPopover.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CalendarContent/SessionDetailPopover.tsx
@@ -4,6 +4,7 @@ import { useTranslations } from 'next-intl';
 import { format } from 'date-fns';
 import { de, enUS } from 'date-fns/locale';
 import { useLocale } from 'next-intl';
+import { parseSimpleFormattedText } from '../../../helpers/parseSimpleFormattedText';
 interface SessionDetail {
   id: number;
   title: string;
@@ -97,9 +98,9 @@ const SessionDetailPopover: FC<IProps> = ({ session, anchorEl, onClose }) => {
           </div>
         )}
 
-        {session.description && (
-          <p className="text-sm text-label-secondary border-t border-border-primary pt-2 mt-2">
-            {session.description}
+        {session.description?.trim() && (
+          <p className="text-sm text-label-secondary border-t border-border-primary pt-2 mt-2 whitespace-pre-wrap break-words">
+            {parseSimpleFormattedText(session.description.trim())}
           </p>
         )}
       </div>

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/SessionDescription.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/SessionDescription.tsx
@@ -1,0 +1,68 @@
+import { FC, useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+import { parseSimpleFormattedText } from '../../../helpers/parseSimpleFormattedText';
+
+interface SessionDescriptionProps {
+  description: string;
+}
+
+export const SessionDescription: FC<SessionDescriptionProps> = ({ description }) => {
+  const t = useTranslations('course');
+  const trimmed = description.trim();
+  const contentRef = useRef<HTMLParagraphElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [canExpand, setCanExpand] = useState(false);
+
+  const measureOverflow = useCallback(() => {
+    const el = contentRef.current;
+    if (!el || expanded) {
+      return;
+    }
+    setCanExpand(el.scrollHeight > el.clientHeight + 1);
+  }, [expanded]);
+
+  useLayoutEffect(() => {
+    measureOverflow();
+  }, [trimmed, measureOverflow]);
+
+  useLayoutEffect(() => {
+    const el = contentRef.current;
+    if (!el || expanded || typeof ResizeObserver === 'undefined') {
+      return undefined;
+    }
+
+    const observer = new ResizeObserver(() => measureOverflow());
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [expanded, measureOverflow]);
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const showToggle = canExpand || expanded;
+
+  return (
+    <div className="mb-1">
+      <p
+        ref={contentRef}
+        className={`text-sm text-label-secondary break-words whitespace-pre-wrap leading-snug ${
+          expanded ? '' : 'line-clamp-2'
+        }`}
+      >
+        {parseSimpleFormattedText(trimmed)}
+      </p>
+      {showToggle && (
+        <button
+          type="button"
+          className="text-brand text-xs sm:text-sm font-medium hover:underline italic mt-0.5"
+          onClick={() => setExpanded((prev) => !prev)}
+          aria-expanded={expanded}
+        >
+          {expanded ? t('sessions.description_show_less') : t('sessions.description_show_more')}
+        </button>
+      )}
+    </div>
+  );
+};

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Sessions.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Sessions.tsx
@@ -4,6 +4,7 @@ import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io';
 
 import { Course_Course_by_pk_Sessions as Session, Course_Course_by_pk_CourseLocations as CourseLocation } from '../../../queries/__generated__/Course';
 import UserCard from '../../common/UserCard';
+import { SessionDescription } from './SessionDescription';
 import { useDisplayDate, useFormatTimeString } from '../../../helpers/dateTimeHelpers';
 import { isLinkFormat } from '../../../helpers/util';
 import { useIsAdmin, useIsInstructor } from '../../../hooks/authentication';
@@ -70,8 +71,8 @@ export const Sessions: FC<SessionsProps> = ({ sessions, courseLocations, isLogge
             {sessions.length === 1 ? t('sessions.date_singular') : t('sessions.date_plural')}
           </span>
           <ul className="max-w-2xl">
-            {visibleSessions.map(({ startDateTime, endDateTime, title, SessionSpeakers, SessionAddresses }, index) => (
-              <li key={index} className="flex mb-4">
+            {visibleSessions.map(({ id, startDateTime, endDateTime, title, description, SessionSpeakers, SessionAddresses }) => (
+              <li key={id} className="flex mb-4">
                 <div className="flex flex-wrap items-start flex-shrink-0 mb-2">
                   <div className="flex flex-col mr-6">
                     <span className="block text-sm sm:text-lg font-semibold">{displayDate(startDateTime)}</span>
@@ -84,6 +85,7 @@ export const Sessions: FC<SessionsProps> = ({ sessions, courseLocations, isLogge
                 </div>
                 <div className="flex flex-col flex-1">
                   <span className="block text-sm sm:text-lg break-words">{title}</span>
+                  <SessionDescription description={description ?? ''} />
                   <div className="break-words">
                     {/* Sort SessionAddresses by CourseLocations order */}
                     {(() => {

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/__tests__/SessionDescription.test.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/__tests__/SessionDescription.test.tsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { SessionDescription } from '../SessionDescription';
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  global.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+});
+
+describe('SessionDescription', () => {
+  beforeEach(() => {
+    Object.defineProperty(HTMLElement.prototype, 'scrollHeight', {
+      configurable: true,
+      get() {
+        return (this as HTMLElement).dataset.mockScrollHeight
+          ? Number((this as HTMLElement).dataset.mockScrollHeight)
+          : 80;
+      },
+    });
+    Object.defineProperty(HTMLElement.prototype, 'clientHeight', {
+      configurable: true,
+      get() {
+        return (this as HTMLElement).dataset.mockClientHeight
+          ? Number((this as HTMLElement).dataset.mockClientHeight)
+          : 40;
+      },
+    });
+  });
+
+  it('renders nothing when description is empty', () => {
+    const { container } = render(<SessionDescription description="   " />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders formatted description text', () => {
+    render(<SessionDescription description="Bring **laptop**." />);
+    expect(screen.getByText('laptop').tagName).toBe('STRONG');
+  });
+
+  it('shows expand control when content overflows', () => {
+    render(
+      <SessionDescription description="Long description that should overflow the two line clamp." />
+    );
+    expect(screen.getByText('sessions.description_show_more')).toBeInTheDocument();
+  });
+
+  it('toggles between show more and show less', () => {
+    render(<SessionDescription description="Long description that should overflow." />);
+    fireEvent.click(screen.getByRole('button', { name: 'sessions.description_show_more' }));
+    expect(screen.getByText('sessions.description_show_less')).toBeInTheDocument();
+  });
+});

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/__tests__/Sessions.test.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/__tests__/Sessions.test.tsx
@@ -5,6 +5,16 @@ import { Sessions } from '../Sessions';
 import type { Course_Course_by_pk_Sessions, Course_Course_by_pk_CourseLocations } from '../../../../queries/__generated__/Course';
 import { LocationOption_enum } from '../../../../__generated__/globalTypes';
 
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  global.ResizeObserver = ResizeObserverMock as typeof ResizeObserver;
+});
+
 // Mock the hooks and dependencies
 jest.mock('next-intl', () => ({
   useTranslations: () => (key: string) => key,
@@ -110,9 +120,8 @@ describe('Sessions Component - Separator Logic', () => {
     expect(screen.getByText('Test Address 2')).toBeInTheDocument();
 
     // Check that separators are present between addresses
-    // The separator should be " + " between the two addresses (with non-breaking space)
-    const separator = screen.getByText(' +\u00A0');
-    expect(separator).toBeInTheDocument();
+    const listItem = screen.getByText('Test Session').closest('li');
+    expect(listItem?.textContent).toMatch(/Test Address 1.*\+.*Test Address 2/);
   });
 
   it('should not render separators when there is only one address', () => {
@@ -136,6 +145,37 @@ describe('Sessions Component - Separator Logic', () => {
 
     // Check that no separator is present
     expect(screen.queryByText(' +\u00A0')).not.toBeInTheDocument();
+  });
+
+  it('should render session description when provided', () => {
+    const sessionWithDescription = [
+      {
+        ...mockSessions[0],
+        description: 'Bring **materials**.',
+      },
+    ];
+
+    render(
+      <Sessions
+        sessions={sessionWithDescription}
+        courseLocations={mockCourseLocations}
+        isLoggedInParticipant={true}
+      />
+    );
+
+    expect(screen.getByText('materials').tagName).toBe('STRONG');
+  });
+
+  it('should not render description block when description is empty', () => {
+    render(
+      <Sessions
+        sessions={mockSessions}
+        courseLocations={mockCourseLocations}
+        isLoggedInParticipant={true}
+      />
+    );
+
+    expect(screen.queryByText('sessions.description_show_more')).not.toBeInTheDocument();
   });
 
   it('should handle empty SessionAddresses gracefully', () => {

--- a/frontend-nx/apps/edu-hub/helpers/parseSimpleFormattedText.test.tsx
+++ b/frontend-nx/apps/edu-hub/helpers/parseSimpleFormattedText.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { parseSimpleFormattedText } from './parseSimpleFormattedText';
+
+const renderFormatted = (text: string) => render(<>{parseSimpleFormattedText(text)}</>);
+
+describe('parseSimpleFormattedText', () => {
+  it('renders plain text', () => {
+    renderFormatted('Bring your laptop.');
+    expect(screen.getByText('Bring your laptop.')).toBeInTheDocument();
+  });
+
+  it('renders bold with double asterisks', () => {
+    renderFormatted('Please bring **laptop**.');
+    const bold = screen.getByText('laptop');
+    expect(bold.tagName).toBe('STRONG');
+  });
+
+  it('renders italic with single asterisks', () => {
+    renderFormatted('This is *optional*.');
+    const italic = screen.getByText('optional');
+    expect(italic.tagName).toBe('EM');
+  });
+
+  it('renders markdown links with safe https URLs', () => {
+    renderFormatted('See [materials](https://example.com/docs).');
+    const link = screen.getByRole('link', { name: 'materials' });
+    expect(link).toHaveAttribute('href', 'https://example.com/docs');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('renders bare https URLs as links', () => {
+    renderFormatted('Join at https://example.com/live');
+    const link = screen.getByRole('link', { name: 'https://example.com/live' });
+    expect(link).toHaveAttribute('href', 'https://example.com/live');
+  });
+
+  it('does not render unsafe markdown URLs as links', () => {
+    const { container } = renderFormatted('[bad](javascript:alert(1))');
+    expect(container.querySelector('a')).toBeNull();
+    expect(container.textContent).toContain('[bad](javascript:alert(1))');
+  });
+
+  it('preserves line breaks in text content', () => {
+    const { container } = renderFormatted('Line one\nLine two');
+    expect(container.textContent).toContain('Line one');
+    expect(container.textContent).toContain('Line two');
+  });
+});

--- a/frontend-nx/apps/edu-hub/helpers/parseSimpleFormattedText.tsx
+++ b/frontend-nx/apps/edu-hub/helpers/parseSimpleFormattedText.tsx
@@ -1,0 +1,100 @@
+import { Fragment, ReactNode } from 'react';
+
+const MARKDOWN_LINK_PATTERN = /^\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/;
+const BARE_URL_PATTERN = /^(https?:\/\/[^\s<>)\]}"']+)/;
+const BOLD_PATTERN = /^(\*\*|__)([\s\S]+?)\1/;
+const ITALIC_PATTERN = /^(\*|_)([^*_]+?)\1/;
+
+const isSafeHttpUrl = (url: string): boolean => {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+};
+
+let nodeKey = 0;
+
+const nextKey = (): string => `fmt-${nodeKey++}`;
+
+const parseSegment = (text: string): ReactNode[] => {
+  const nodes: ReactNode[] = [];
+  let remaining = text;
+
+  while (remaining.length > 0) {
+    const markdownLink = remaining.match(MARKDOWN_LINK_PATTERN);
+    if (markdownLink && isSafeHttpUrl(markdownLink[2])) {
+      nodes.push(
+        <a
+          key={nextKey()}
+          href={markdownLink[2]}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline"
+        >
+          {markdownLink[1]}
+        </a>
+      );
+      remaining = remaining.slice(markdownLink[0].length);
+      continue;
+    }
+
+    const bareUrl = remaining.match(BARE_URL_PATTERN);
+    if (bareUrl && isSafeHttpUrl(bareUrl[1])) {
+      nodes.push(
+        <a
+          key={nextKey()}
+          href={bareUrl[1]}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline break-all"
+        >
+          {bareUrl[1]}
+        </a>
+      );
+      remaining = remaining.slice(bareUrl[0].length);
+      continue;
+    }
+
+    const bold = remaining.match(BOLD_PATTERN);
+    if (bold) {
+      nodes.push(<strong key={nextKey()}>{parseSegment(bold[2])}</strong>);
+      remaining = remaining.slice(bold[0].length);
+      continue;
+    }
+
+    const italic = remaining.match(ITALIC_PATTERN);
+    if (italic) {
+      nodes.push(<em key={nextKey()}>{parseSegment(italic[2])}</em>);
+      remaining = remaining.slice(italic[0].length);
+      continue;
+    }
+
+    const markerIndex = remaining.search(/[*_[]/);
+    const urlIndex = remaining.search(/https?:\/\//);
+    const nextSpecial =
+      markerIndex === -1
+        ? urlIndex
+        : urlIndex === -1
+          ? markerIndex
+          : Math.min(markerIndex, urlIndex);
+    const plainEnd = nextSpecial === -1 ? remaining.length : nextSpecial;
+    if (plainEnd > 0) {
+      nodes.push(<Fragment key={nextKey()}>{remaining.slice(0, plainEnd)}</Fragment>);
+      remaining = remaining.slice(plainEnd);
+      continue;
+    }
+
+    nodes.push(<Fragment key={nextKey()}>{remaining[0]}</Fragment>);
+    remaining = remaining.slice(1);
+  }
+
+  return nodes;
+};
+
+/** Renders limited inline formatting: **bold**, *italic*, [label](https://url), bare https:// links. */
+export const parseSimpleFormattedText = (text: string): ReactNode[] => {
+  nodeKey = 0;
+  return parseSegment(text);
+};

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -348,7 +348,9 @@
       "show_all_dates": "Alle Termine anzeigen",
       "hide_dates": "Termine einklappen",
       "date_singular": "Termin",
-      "date_plural": "Termine"
+      "date_plural": "Termine",
+      "description_show_more": "Mehr anzeigen",
+      "description_show_less": "Weniger anzeigen"
     },
     "attendances": {
       "attendances": "Anwesenheiten",
@@ -1300,7 +1302,7 @@
       },
       "session_description": {
         "label": "Beschreibung",
-        "help_text": "Beschreibe hier den Inhalt des Termins.",
+        "help_text": "Beschreibe hier den Inhalt des Termins. Du kannst **fett**, *kursiv* und [Links](https://beispiel.de) verwenden.",
         "placeholder": "Beschreibe den Inhalt der Session, z.B. Ablauf, Themen oder Hinweise für Teilnehmende..."
       },
       "attendance_data": {

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -348,7 +348,9 @@
       "show_all_dates": "Show all dates",
       "hide_dates": "Collapse dates",
       "date_singular": "Date",
-      "date_plural": "Dates"
+      "date_plural": "Dates",
+      "description_show_more": "Show more",
+      "description_show_less": "Show less"
     },
     "attendances": {
       "attendances": "Attendances",
@@ -1318,7 +1320,7 @@
       },
       "session_description": {
         "label": "Description",
-        "help_text": "Describe the content of the session here.",
+        "help_text": "Describe the session content here. You can use **bold**, *italic*, and [links](https://example.com).",
         "placeholder": "Describe the session content, e.g. schedule, topics or notes for participants..."
       },
       "attendance_data": {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements [issue #1692](https://github.com/eduhub-org/eduhub/issues/1692) with **design B** (two-line clamp + expand/collapse) and limited inline formatting.

## What changed

- **Course page** (`Sessions.tsx`): optional session descriptions appear under the title via new `SessionDescription` component
- **Formatting**: `parseSimpleFormattedText` supports `**bold**`, `*italic*`, `[label](https://url)`, and bare `https://` links (http/https only; no `dangerouslySetInnerHTML`)
- **Calendar popover**: same formatting for descriptions
- **Organizer UI**: help text documents the supported syntax (DE/EN)
- **i18n**: `sessions.description_show_more` / `description_show_less`

## Behavior

- Empty descriptions: no UI change (unchanged sessions)
- Long text: clamped to 2 lines; „Mehr anzeigen“ only when content overflows
- Max length remains **500 characters** (existing admin field)

## Tests

- `parseSimpleFormattedText.test.tsx`
- `SessionDescription.test.tsx`
- Extended `Sessions.test.tsx`

Closes #1692
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff3cf47a-0177-4ef2-ad55-bdab156e805d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff3cf47a-0177-4ef2-ad55-bdab156e805d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Session descriptions now support formatted text including bold, italic, and clickable links.
  * Added "show more/show less" toggle for expanded session descriptions.

* **Documentation**
  * Updated help text to indicate markdown formatting support in session descriptions.

* **Tests**
  * Added comprehensive test coverage for session description rendering and formatting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eduhub-org/eduhub/pull/1703?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->