### PR TITLE
Add dialog to create organization admins with permissions

### DIFF
--- a/frontend-nx/apps/edu-hub/components/common/dialogs/CreateOrganizationAdminDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/dialogs/CreateOrganizationAdminDialog.tsx
@@ -1,0 +1,226 @@
+import React, { useState, useCallback } from 'react';
+import { Dialog, DialogTitle, Checkbox, FormControlLabel } from '@mui/material';
+import { MdClose } from 'react-icons/md';
+import { useTranslations } from 'next-intl';
+
+import { Button } from '../Button';
+import { SelectUserDialog } from './SelectUserDialog';
+import { SelectOrganizationDialog } from './SelectOrganizationDialog';
+import NotificationSnackbar from './NotificationSnackbar';
+import { ErrorMessageDialog } from './ErrorMessageDialog';
+
+import { useAdminMutation } from '../../../hooks/authedMutation';
+import { INSERT_ORGANIZATION_ADMIN } from '../../../queries/organizationAdmin';
+import { UserSelectionWithFilter_User } from '../../../queries/__generated__/UserSelectionWithFilter';
+import { OrganizationList_Organization } from '../../../queries/__generated__/OrganizationList';
+
+interface CreateOrganizationAdminDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export const CreateOrganizationAdminDialog: React.FC<CreateOrganizationAdminDialogProps> = ({
+  open,
+  onClose,
+  onSuccess,
+}) => {
+  const t = useTranslations('manageAdminUsers');
+  const tCommon = useTranslations('common');
+
+  const [selectedUser, setSelectedUser] = useState<UserSelectionWithFilter_User | null>(null);
+  const [selectedOrganization, setSelectedOrganization] = useState<OrganizationList_Organization | null>(null);
+  const [canManageCourses, setCanManageCourses] = useState(false);
+  const [canManageEvents, setCanManageEvents] = useState(false);
+  const [canManageSettings, setCanManageSettings] = useState(false);
+
+  const [userDialogOpen, setUserDialogOpen] = useState(false);
+  const [orgDialogOpen, setOrgDialogOpen] = useState(false);
+  const [serverError, setServerError] = useState<string | null>(null);
+  const [showSuccess, setShowSuccess] = useState(false);
+
+  const resetForm = useCallback(() => {
+    setSelectedUser(null);
+    setSelectedOrganization(null);
+    setCanManageCourses(false);
+    setCanManageEvents(false);
+    setCanManageSettings(false);
+  }, []);
+
+  const [insertOrganizationAdmin, { loading }] = useAdminMutation(INSERT_ORGANIZATION_ADMIN, {
+    onCompleted: () => {
+      setShowSuccess(true);
+      resetForm();
+      onSuccess();
+      onClose();
+    },
+    onError: (err) => {
+      const message = err.message?.includes('Uniqueness violation')
+        ? t('create_admin.error_already_exists')
+        : err.message || t('create_admin.error');
+      setServerError(message);
+    },
+  });
+
+  const handleClose = useCallback(() => {
+    if (loading) return;
+    resetForm();
+    onClose();
+  }, [loading, onClose, resetForm]);
+
+  const handleUserDialogClose = useCallback(
+    (confirmed: boolean, user: UserSelectionWithFilter_User | null) => {
+      setUserDialogOpen(false);
+      if (confirmed && user) setSelectedUser(user);
+    },
+    []
+  );
+
+  const handleOrgDialogClose = useCallback(
+    (confirmed: boolean, organization: OrganizationList_Organization | null) => {
+      setOrgDialogOpen(false);
+      if (confirmed && organization) setSelectedOrganization(organization);
+    },
+    []
+  );
+
+  const handleSubmit = useCallback(() => {
+    if (!selectedUser || !selectedOrganization) return;
+    setServerError(null);
+    insertOrganizationAdmin({
+      variables: {
+        userId: selectedUser.id,
+        organizationId: selectedOrganization.id,
+        canManageCourses,
+        canManageEvents,
+        canManageSettings,
+      },
+    });
+  }, [
+    selectedUser,
+    selectedOrganization,
+    canManageCourses,
+    canManageEvents,
+    canManageSettings,
+    insertOrganizationAdmin,
+  ]);
+
+  const isFormValid = !!selectedUser && !!selectedOrganization;
+
+  return (
+    <>
+      <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+        <DialogTitle className="light">
+          <div className="flex justify-between items-center">
+            <span className="text-label-primary">{t('create_admin.dialog_title')}</span>
+            <button
+              onClick={handleClose}
+              className="p-1 rounded-full hover:bg-gray-200 transition-colors text-label-primary"
+              aria-label={tCommon('close')}
+              disabled={loading}
+            >
+              <MdClose className="text-xl" />
+            </button>
+          </div>
+        </DialogTitle>
+
+        <div className="px-6 pb-6 light">
+          <div className="mb-6 space-y-4">
+            <div>
+              <div className="text-label-primary text-sm mb-1">{t('create_admin.user_label')}</div>
+              <div className="flex items-center gap-3">
+                <div className="flex-1 px-3 py-2 border border-gray-300 rounded bg-gray-50 text-label-primary">
+                  {selectedUser
+                    ? `${selectedUser.firstName} ${selectedUser.lastName} (${selectedUser.email})`
+                    : t('create_admin.user_placeholder')}
+                </div>
+                <Button onClick={() => setUserDialogOpen(true)} disabled={loading}>
+                  {t('create_admin.select_user')}
+                </Button>
+              </div>
+            </div>
+
+            <div>
+              <div className="text-label-primary text-sm mb-1">{t('create_admin.organization_label')}</div>
+              <div className="flex items-center gap-3">
+                <div className="flex-1 px-3 py-2 border border-gray-300 rounded bg-gray-50 text-label-primary">
+                  {selectedOrganization ? selectedOrganization.name : t('create_admin.organization_placeholder')}
+                </div>
+                <Button onClick={() => setOrgDialogOpen(true)} disabled={loading}>
+                  {t('create_admin.select_organization')}
+                </Button>
+              </div>
+            </div>
+
+            <div className="pt-2">
+              <div className="text-label-primary text-sm mb-2">{t('create_admin.permissions_label')}</div>
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={canManageEvents}
+                    onChange={(e) => setCanManageEvents(e.target.checked)}
+                    color="primary"
+                  />
+                }
+                label={t('can_manage_events')}
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={canManageCourses}
+                    onChange={(e) => setCanManageCourses(e.target.checked)}
+                    color="primary"
+                  />
+                }
+                label={t('can_manage_courses')}
+              />
+              <FormControlLabel
+                control={
+                  <Checkbox
+                    checked={canManageSettings}
+                    onChange={(e) => setCanManageSettings(e.target.checked)}
+                    color="primary"
+                  />
+                }
+                label={t('can_manage_users_and_settings')}
+              />
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2">
+            <Button onClick={handleClose} disabled={loading}>
+              {tCommon('cancel')}
+            </Button>
+            <Button filled onClick={handleSubmit} disabled={!isFormValid || loading}>
+              {loading ? t('create_admin.creating') : t('create_admin.submit')}
+            </Button>
+          </div>
+        </div>
+      </Dialog>
+
+      <SelectUserDialog
+        open={userDialogOpen}
+        onClose={handleUserDialogClose}
+        title={t('create_admin.select_user_title')}
+      />
+
+      <SelectOrganizationDialog
+        open={orgDialogOpen}
+        onClose={handleOrgDialogClose}
+        title={t('create_admin.select_organization_title')}
+      />
+
+      <NotificationSnackbar
+        open={showSuccess}
+        onClose={() => setShowSuccess(false)}
+        message={t('create_admin.success')}
+      />
+
+      <ErrorMessageDialog
+        errorMessage={serverError ?? ''}
+        open={!!serverError}
+        onClose={() => setServerError(null)}
+      />
+    </>
+  );
+};

--- a/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
@@ -22,6 +22,7 @@ import { PageBlock } from '../../common/PageBlock';
 import CommonPageHeader from '../../common/CommonPageHeader';
 import { useIsAdmin } from '../../../hooks/authentication';
 import { OrganizationAdminList_OrganizationAdmin } from '../../../queries/__generated__/OrganizationAdminList';
+import { CreateOrganizationAdminDialog } from '../../common/dialogs/CreateOrganizationAdminDialog';
 
 const ExpandableUserRow: FC<{
   row: OrganizationAdminList_OrganizationAdmin;
@@ -34,15 +35,16 @@ const ExpandableUserRow: FC<{
   const [setAdminStatus] = useAdminMutation(UPDATE_USER_ADMIN_STATUS);
 
   const handleAdminToggle = async (checked: boolean) => {
+    if (!row.User?.id) return;
     try {
       const response = await setAdminStatus({
         variables: {
-          userId: row.id,
+          userId: row.User.id,
           isAdmin: checked,
         },
       });
 
-      if (response.data?.success) {
+      if (response.data?.updateUserAdminStatus?.success) {
         onAdminStatusChange();
       }
     } catch (error) {
@@ -60,7 +62,7 @@ const ExpandableUserRow: FC<{
             checked={row.canManageEvents}
             updateValueMutation={UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_EVENTS}
             identifierVariables={{ itemId: row.id }}
-            refetchQueries={['GetAdminUsers']}
+            refetchQueries={['OrganizationAdminList']}
           />
         </div>
         <div className="pl-3 col-span-3">
@@ -70,7 +72,7 @@ const ExpandableUserRow: FC<{
             checked={row.canManageCourses}
             updateValueMutation={UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_COURSES}
             identifierVariables={{ itemId: row.id }}
-            refetchQueries={['GetAdminUsers']}
+            refetchQueries={['OrganizationAdminList']}
           />
         </div>
         <div className="pl-3 col-span-4">
@@ -80,7 +82,7 @@ const ExpandableUserRow: FC<{
             checked={row.canManageSettings}
             updateValueMutation={UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_SETTINGS}
             identifierVariables={{ itemId: row.id }}
-            refetchQueries={['GetAdminUsers']}
+            refetchQueries={['OrganizationAdminList']}
           />
         </div>
       </div>
@@ -91,7 +93,7 @@ const ExpandableUserRow: FC<{
             label={t('is_super_admin')}
             checked={isSuperAdmin}
             onValueUpdated={handleAdminToggle}
-            refetchQueries={['GetAdminUsers']}
+            refetchQueries={['AdminUsers']}
           />
         </div>
       )}
@@ -103,6 +105,7 @@ const ManageAdminUsersContent: FC = () => {
   const t = useTranslations('manageAdminUsers');
   const [adminUserIds, setAdminUserIds] = useState<string[]>([]);
   const [adminError, setAdminError] = useState<Error | null>(null);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
 
   useAdminQuery(ADMIN_USERS, {
     onCompleted: (data) => {
@@ -195,10 +198,10 @@ const ManageAdminUsersContent: FC = () => {
               searchFilter={searchFilter}
               onSearchFilterChange={setSearchFilter}
               deleteMutation={DELETE_ORGANIZATION_ADMIN}
-              deleteIdType="uuidString"
+              deleteIdType="number"
               error={error}
               loading={loading}
-              refetchQueries={['UsersByLastName', 'GetAdminUsers']}
+              refetchQueries={['OrganizationAdminList', 'AdminUsers']}
               generateDeletionConfirmationQuestion={generateDeletionConfirmation}
               expandableRowComponent={({ row }) => (
                 <ExpandableUserRow
@@ -207,10 +210,17 @@ const ManageAdminUsersContent: FC = () => {
                   onAdminStatusChange={() => refetch()}
                 />
               )}
+              addButtonText={t('create_admin.button')}
+              onAddButtonClick={() => setCreateDialogOpen(true)}
             />
           </div>
         )}
       </div>
+      <CreateOrganizationAdminDialog
+        open={createDialogOpen}
+        onClose={() => setCreateDialogOpen(false)}
+        onSuccess={() => refetch()}
+      />
     </PageBlock>
   );
 };

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1524,7 +1524,26 @@
     "is_super_admin": "Ist Super-Admin",
     "can_manage_events": "Kann Events verwalten",
     "can_manage_courses": "Kann Kurse verwalten",
-    "can_manage_users_and_settings": "Kann Benutzer und Einstellungen verwalten"
+    "can_manage_users_and_settings": "Kann Benutzer und Einstellungen verwalten",
+    "error_loading_admin_users": "Admin-Benutzer konnten nicht geladen werden.",
+    "create_admin": {
+      "button": "Admin hinzufügen",
+      "dialog_title": "Organisations-Adminrechte vergeben",
+      "user_label": "Benutzer",
+      "user_placeholder": "Kein Benutzer ausgewählt",
+      "select_user": "Benutzer auswählen",
+      "select_user_title": "Benutzer auswählen",
+      "organization_label": "Organisation",
+      "organization_placeholder": "Keine Organisation ausgewählt",
+      "select_organization": "Organisation auswählen",
+      "select_organization_title": "Organisation auswählen",
+      "permissions_label": "Berechtigungen",
+      "submit": "Adminrechte vergeben",
+      "creating": "Speichern...",
+      "success": "Adminrechte wurden erfolgreich vergeben.",
+      "error": "Adminrechte konnten nicht vergeben werden.",
+      "error_already_exists": "Dieser Benutzer ist bereits Admin der ausgewählten Organisation."
+    }
   },
   "manageAppSettings": {
     "app_settings": "App Einstellungen",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1535,7 +1535,30 @@
     "last_name": "Last Name",
     "email": "Email",
     "organization": "Organization",
-    "deletion_confirmation_question": "Are you sure you want to delete the admin rights of {firstName} {lastName} for the organization {organization}?"
+    "deletion_confirmation_question": "Are you sure you want to delete the admin rights of {firstName} {lastName} for the organization {organization}?",
+    "is_super_admin": "Is super admin",
+    "can_manage_events": "Can manage events",
+    "can_manage_courses": "Can manage courses",
+    "can_manage_users_and_settings": "Can manage users and settings",
+    "error_loading_admin_users": "Could not load admin users.",
+    "create_admin": {
+      "button": "Add admin",
+      "dialog_title": "Grant organization admin rights",
+      "user_label": "User",
+      "user_placeholder": "No user selected",
+      "select_user": "Select user",
+      "select_user_title": "Select a user",
+      "organization_label": "Organization",
+      "organization_placeholder": "No organization selected",
+      "select_organization": "Select organization",
+      "select_organization_title": "Select an organization",
+      "permissions_label": "Permissions",
+      "submit": "Grant admin rights",
+      "creating": "Saving...",
+      "success": "Admin rights granted successfully.",
+      "error": "Could not grant admin rights.",
+      "error_already_exists": "This user is already an admin of the selected organization."
+    }
   },
   "manageAppSettings": {
     "backgroundImageURL": "Background image URL",

--- a/frontend-nx/apps/edu-hub/queries/organizationAdmin.ts
+++ b/frontend-nx/apps/edu-hub/queries/organizationAdmin.ts
@@ -36,6 +36,41 @@ export const ORGANIZATION_ADMIN_LIST = gql`
   }
 `;
 
+export const INSERT_ORGANIZATION_ADMIN = gql`
+  mutation InsertOrganizationAdmin(
+    $userId: uuid!
+    $organizationId: Int!
+    $canManageCourses: Boolean = false
+    $canManageEvents: Boolean = false
+    $canManageSettings: Boolean = false
+  ) {
+    insert_OrganizationAdmin_one(
+      object: {
+        userId: $userId
+        organizationId: $organizationId
+        canManageCourses: $canManageCourses
+        canManageEvents: $canManageEvents
+        canManageSettings: $canManageSettings
+      }
+    ) {
+      id
+      User {
+        id
+        firstName
+        lastName
+        email
+      }
+      Organization {
+        id
+        name
+      }
+      canManageCourses
+      canManageEvents
+      canManageSettings
+    }
+  }
+`;
+
 export const DELETE_ORGANIZATION_ADMIN = gql`
   mutation DeleteOrganizationAdmin($id: Int!) {
     delete_OrganizationAdmin_by_pk(id: $id) {


### PR DESCRIPTION
## Summary
This PR adds functionality to create new organization admins through a dedicated dialog interface. Users can now select a user and organization, assign specific permissions (manage events, courses, and settings), and grant admin rights in a single workflow.

## Key Changes
- **New Component**: `CreateOrganizationAdminDialog` - A comprehensive dialog for creating organization admins with:
  - User selection via `SelectUserDialog`
  - Organization selection via `SelectOrganizationDialog`
  - Three permission checkboxes (manage events, courses, settings)
  - Form validation and error handling
  - Success/error notifications

- **GraphQL Mutation**: Added `INSERT_ORGANIZATION_ADMIN` mutation to `organizationAdmin.ts` for creating new organization admin records with specified permissions

- **UI Integration**: Updated `ManageAdminUsersContent` to:
  - Include "Add admin" button that opens the creation dialog
  - Fixed refetch query names for consistency (`GetAdminUsers` → `OrganizationAdminList`, `AdminUsers`)
  - Corrected delete ID type from `uuidString` to `number`
  - Fixed admin toggle mutation variable reference

- **Localization**: Added comprehensive i18n strings for English and German:
  - Dialog labels and placeholders
  - Permission descriptions
  - Success/error messages
  - Button labels

## Implementation Details
- Form validation ensures both user and organization are selected before submission
- Handles uniqueness constraint violations with user-friendly error messaging
- Resets form state on successful submission
- Disables interactions during mutation loading
- Uses `useAdminMutation` hook for authenticated GraphQL operations

https://claude.ai/code/session_01BvnKLQAVj5WrPYXvwAd8ZX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization admin assignment dialog enabling admins to grant users permissions for managing courses, events, and account settings with error handling for duplicate assignments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eduhub-org/eduhub/pull/1706?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->