### PR TITLE
Fix Keycloak registration back link rendering

### DIFF
--- a/keycloak/themes/edu-hub/account/messages/messages_de.properties
+++ b/keycloak/themes/edu-hub/account/messages/messages_de.properties
@@ -103,7 +103,7 @@ client_broker=Broker
 requiredFields=Erforderliche Felder
 allFieldsRequired=Alle Felder sind erforderlich
 
-backToApplication=&laquo; Zur\u00FCck zur Applikation
+backToApplication=\u00AB Zur\u00FCck zur Applikation
 backTo=Zur\u00FCck zu {0}
 
 date=Datum

--- a/keycloak/themes/edu-hub/account/messages/messages_en.properties
+++ b/keycloak/themes/edu-hub/account/messages/messages_en.properties
@@ -103,7 +103,7 @@ client_broker=Broker
 requiredFields=Required fields
 allFieldsRequired=All fields required
 
-backToApplication=&laquo; Back to application
+backToApplication=\u00AB Back to application
 backTo=Back to {0}
 
 date=Date

--- a/keycloak/themes/edu-hub/login/messages/messages_de.properties
+++ b/keycloak/themes/edu-hub/login/messages/messages_de.properties
@@ -134,7 +134,7 @@ emailLinkIdp3=um eine neue E-Mail versenden zu lassen.
 emailLinkIdp4=Wenn Sie die E-Mail bereits in einem anderen Browser verifiziert haben
 emailLinkIdp5=um fortzufahren.
 
-backToLogin=&laquo; Zur\u00FCck zur Anmeldung
+backToLogin=\u00AB Zur\u00FCck zur Anmeldung
 
 emailInstruction=Geben Sie Ihren Benutzernamen oder Ihre E-Mail Adresse ein und klicken Sie auf Absenden. Danach werden wir Ihnen eine E-Mail mit weiteren Instruktionen zusenden.
 

--- a/keycloak/themes/edu-hub/login/messages/messages_de.properties
+++ b/keycloak/themes/edu-hub/login/messages/messages_de.properties
@@ -289,7 +289,7 @@ confirmAccountLinking=Best\u00E4tigen Sie den Account {0} des Identity Provider 
 confirmEmailAddressVerification=Best\u00E4tigen Sie, dass die E-Mail-Adresse {0} g\u00FCltig ist.
 confirmExecutionOfActions=F\u00FChren Sie die folgende(n) Aktion(en) aus
 
-backToApplication=&laquo; Zur\u00FCck zur Applikation
+backToApplication=\u00AB Zur\u00FCck zur Applikation
 missingParameterMessage=Fehlender Parameter\: {0}
 clientNotFoundMessage=Client nicht gefunden.
 clientDisabledMessage=Client deaktiviert.

--- a/keycloak/themes/edu-hub/login/messages/messages_en.properties
+++ b/keycloak/themes/edu-hub/login/messages/messages_en.properties
@@ -157,7 +157,7 @@ emailLinkIdp3=to re-send the email.
 emailLinkIdp4=If you already verified the email in different browser
 emailLinkIdp5=to continue.
 
-backToLogin=&laquo; Back to Login
+backToLogin=\u00AB Back to Login
 
 emailInstruction=Enter your username or email address and we will send you instructions on how to create a new password.
 emailInstructionUsername=Enter your username and we will send you instructions on how to create a new password.

--- a/keycloak/themes/edu-hub/login/messages/messages_en.properties
+++ b/keycloak/themes/edu-hub/login/messages/messages_en.properties
@@ -360,7 +360,7 @@ locale_sv=Svenska
 locale_tr=T\u00FCrk\u00E7e
 locale_zh-CN=\u4E2D\u6587\u7B80\u4F53
 
-backToApplication=&laquo; Back to Application
+backToApplication=\u00AB Back to Application
 missingParameterMessage=Missing parameters\: {0}
 clientNotFoundMessage=Client not found.
 clientDisabledMessage=Client disabled.

--- a/keycloak/themes/edu-hub/login/template.ftl
+++ b/keycloak/themes/edu-hub/login/template.ftl
@@ -77,12 +77,10 @@
                         </#if>
                     <#if !(auth?has_content && auth.showUsername() && !auth.showResetCredentials())>
                         <#if displayRequiredFields>
+                            <h1 id="kc-page-title"><#nested "header"></h1>
                             <div class="${properties.kcContentWrapperClass!}">
                                 <div class="${properties.kcLabelWrapperClass!} subtitle">
                                     <span class="subtitle"><span class="required">*</span> ${msg("requiredFields")}</span>
-                                </div>
-                                <div class="col-md-10">
-                                    <h1 id="kc-page-title"><#nested "header"></h1>
                                 </div>
                             </div>
                         <#else>

--- a/keycloak/themes/opencampus/account/messages/messages_de.properties
+++ b/keycloak/themes/opencampus/account/messages/messages_de.properties
@@ -103,7 +103,7 @@ client_broker=Broker
 requiredFields=Erforderliche Felder
 allFieldsRequired=Alle Felder sind erforderlich
 
-backToApplication=&laquo; Zur\u00FCck zur Applikation
+backToApplication=\u00AB Zur\u00FCck zur Applikation
 backTo=Zur\u00FCck zu {0}
 
 date=Datum

--- a/keycloak/themes/opencampus/account/messages/messages_en.properties
+++ b/keycloak/themes/opencampus/account/messages/messages_en.properties
@@ -103,7 +103,7 @@ client_broker=Broker
 requiredFields=Required fields
 allFieldsRequired=All fields required
 
-backToApplication=&laquo; Back to application
+backToApplication=\u00AB Back to application
 backTo=Back to {0}
 
 date=Date

--- a/keycloak/themes/opencampus/login/messages/messages_de.properties
+++ b/keycloak/themes/opencampus/login/messages/messages_de.properties
@@ -134,7 +134,7 @@ emailLinkIdp3=um eine neue E-Mail versenden zu lassen.
 emailLinkIdp4=Wenn Sie die E-Mail bereits in einem anderen Browser verifiziert haben
 emailLinkIdp5=um fortzufahren.
 
-backToLogin=&laquo; Zur\u00FCck zur Anmeldung
+backToLogin=\u00AB Zur\u00FCck zur Anmeldung
 
 emailInstruction=Geben Sie Ihren Benutzernamen oder Ihre E-Mail Adresse ein und klicken Sie auf Absenden. Danach werden wir Ihnen eine E-Mail mit weiteren Instruktionen zusenden.
 
@@ -289,7 +289,7 @@ confirmAccountLinking=Best\u00E4tigen Sie den Account {0} des Identity Provider 
 confirmEmailAddressVerification=Best\u00E4tigen Sie, dass die E-Mail-Adresse {0} g\u00FCltig ist.
 confirmExecutionOfActions=F\u00FChren Sie die folgende(n) Aktion(en) aus
 
-backToApplication=&laquo; Zur\u00FCck zur Applikation
+backToApplication=\u00AB Zur\u00FCck zur Applikation
 missingParameterMessage=Fehlender Parameter\: {0}
 clientNotFoundMessage=Client nicht gefunden.
 clientDisabledMessage=Client deaktiviert.

--- a/keycloak/themes/opencampus/login/messages/messages_en.properties
+++ b/keycloak/themes/opencampus/login/messages/messages_en.properties
@@ -157,7 +157,7 @@ emailLinkIdp3=to re-send the email.
 emailLinkIdp4=If you already verified the email in different browser
 emailLinkIdp5=to continue.
 
-backToLogin=&laquo; Back to Login
+backToLogin=\u00AB Back to Login
 
 emailInstruction=Enter your username or email address and we will send you instructions on how to create a new password.
 emailInstructionUsername=Enter your username and we will send you instructions on how to create a new password.
@@ -360,7 +360,7 @@ locale_sv=Svenska
 locale_tr=T\u00FCrk\u00E7e
 locale_zh-CN=\u4E2D\u6587\u7B80\u4F53
 
-backToApplication=&laquo; Back to Application
+backToApplication=\u00AB Back to Application
 missingParameterMessage=Missing parameters\: {0}
 clientNotFoundMessage=Client not found.
 clientDisabledMessage=Client disabled.


### PR DESCRIPTION
**Summary**
- Replace the `backToLogin` HTML entity with a plain-text Unicode escape in the `edu-hub` Keycloak messages.
- Adjust the shared login layout so registration headings render outside the Bootstrap offset wrapper and line up with the login page.
- Keep the fix in `template.ftl` rather than overriding `register.ftl`, so the inherited registration form stays on the upstream path.

**Testing**
- Verified the rendered registration page in the local `eduhub-keycloak` container: the back link now shows `« Back to Login`, and the heading alignment matches the login page structure.

Closes #1720

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved login page header layout and content hierarchy for clearer visual structure.
  * Replaced HTML-entity quote markers with literal left‑angle quotation characters in English and German texts for consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->