### PR TITLE
Clarify project deletion rules and team confirmation requirements

### DIFF
--- a/backend/metadata/databases/default/tables/public_User.yaml
+++ b/backend/metadata/databases/default/tables/public_User.yaml
@@ -124,6 +124,7 @@ select_permissions:
         - newsletterRegistration
         - occupation
         - picture
+        - status
         - updated_at
         - zipCode
       filter: {}

--- a/docs/PROJECTS_USER_MANUAL.md
+++ b/docs/PROJECTS_USER_MANUAL.md
@@ -496,13 +496,17 @@ REQUESTED rows in that course are auto-DECLINED in the same transaction.
 The restriction lifts once your project reaches a terminal status
 (`COMPLETED`, `INCOMPLETE`, `PUBLISHED`).
 
-**(For proposers) What happens to the pending join requests on my project
-when an instructor confirms the team?**
-At team confirmation (PROPOSED → ONGOING) any `ProjectAuthor` row still
-in REQUESTED status is converted to DECLINED in the same transaction.
-Those applicants will see their request flip from "Pending" to "Declined"
-the next time the project list refreshes, and they regain the ability to
-propose or join another project in the course.
+**(For proposers) I still have pending join requests — what do I need to
+do before I can ask an instructor to confirm my team?**
+Decide every pending request first. The **Request review** button in the
+**My Project** panel stays disabled while any `REQUESTED` row exists on a
+project that is still accepting participants — the proposer must accept
+or decline each applicant via **Manage requests**, or turn off
+**Accepting participants**, before the instructor can be asked to
+confirm the team. (As a safety net, if any REQUESTED rows do reach
+team-confirmation time — e.g. from an instructor override — they are
+automatically set to DECLINED when the project transitions PROPOSED →
+ONGOING.)
 
 **Can I edit my project after it's been submitted?**
 No. Once status is SUBMITTED the project becomes read-only for authors.

--- a/docs/PROJECTS_USER_MANUAL.md
+++ b/docs/PROJECTS_USER_MANUAL.md
@@ -98,7 +98,7 @@ Key transitions in detail:
 | Send back / approve / reject | — | ✓ | ✓ | ✓ |
 | Rate & comment | — | ✓ | ✓ | ✓ |
 | Publish | — | ✓ | ✓ | ✓ |
-| Delete project | — | ✓ (own courses) | — | ✓ |
+| Delete project | ✓ (indirectly, by leaving as the last ACCEPTED author on a PROPOSED/ONGOING project — see §5.4) | ✓ (own courses) | — | ✓ |
 
 ---
 
@@ -485,15 +485,24 @@ project write-up — distinct from the instruction PDF.
 
 ## 9. Frequently asked questions
 
-**Can a participant be in two projects in the same course?**
-Yes — the database has no unique constraint preventing it. In practice,
-an author should usually only be ACCEPTED on a single project per
-course, but you can have one ACCEPTED project and several REQUESTED rows
-on others while you wait for responses.
+**Can I be an author on two projects in the same course at the same time?**
+No. As a participant you can be ACCEPTED on at most one *active* project
+(PROPOSED, ONGOING, or SUBMITTED) per course — the rule is enforced by the
+`enforce_one_active_accepted_project_per_course_per_user` database trigger
+described in §4a. You may, however, hold several REQUESTED rows on other
+projects in the same course while you wait for a response. Once one of
+them accepts you (or you propose your own project), your remaining
+REQUESTED rows in that course are auto-DECLINED in the same transaction.
+The restriction lifts once your project reaches a terminal status
+(`COMPLETED`, `INCOMPLETE`, `PUBLISHED`).
 
-**What happens to my REQUESTED rows if the project's team is confirmed?**
-They are declined automatically. The project disappears from your
-"pending requests" list.
+**(For proposers) What happens to the pending join requests on my project
+when an instructor confirms the team?**
+At team confirmation (PROPOSED → ONGOING) any `ProjectAuthor` row still
+in REQUESTED status is converted to DECLINED in the same transaction.
+Those applicants will see their request flip from "Pending" to "Declined"
+the next time the project list refreshes, and they regain the ability to
+propose or join another project in the course.
 
 **Can I edit my project after it's been submitted?**
 No. Once status is SUBMITTED the project becomes read-only for authors.


### PR DESCRIPTION
## Summary
Updated documentation to clarify project deletion permissions and team confirmation workflows, and exposed the `status` field in the User GraphQL schema for better visibility into user state.

## Key Changes

- **Documentation updates to PROJECTS_USER_MANUAL.md:**
  - Clarified that Student/Proposers can indirectly delete projects by leaving as the last ACCEPTED author on a PROPOSED/ONGOING project (with reference to §5.4)
  - Rewrote FAQ section to better explain the one-active-project-per-course constraint enforced by the `enforce_one_active_accepted_project_per_course_per_user` database trigger
  - Added detailed explanation of how REQUESTED rows are auto-DECLINED when a participant is accepted to another project in the same course
  - Added new FAQ entry explaining team confirmation workflow requirements for proposers, including the disabled "Request review" button behavior and auto-DECLINE of pending requests during PROPOSED → ONGOING transition

- **Schema changes to public_User table:**
  - Exposed `status` field in User select permissions to allow querying user status via GraphQL

## Notable Details
The documentation changes emphasize the automatic enforcement of business rules through database triggers and transaction-level consistency, helping users understand the constraints they'll encounter when managing multiple project participations.

https://claude.ai/code/session_013M61mA9ckiR1gisQvFyCcS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Clarified project deletion permissions for authors under specific project conditions.
* Expanded FAQ with guidance on managing multiple active projects in the same course and team confirmation workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/eduhub-org/eduhub/pull/1723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->