### PR TITLE
fix(course): unify section titles and widen projects table

### DIFF
--- a/frontend-nx/apps/edu-hub/components/common/SectionTitle.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/SectionTitle.tsx
@@ -1,0 +1,16 @@
+import { FC, ReactNode } from 'react';
+
+interface SectionTitleProps {
+  children: ReactNode;
+  /** Extra utility classes (e.g. spacing overrides). Optional. */
+  className?: string;
+  id?: string;
+}
+
+export const SectionTitle: FC<SectionTitleProps> = ({ children, className = '', id }) => (
+  <h2 id={id} className={`text-3xl font-semibold text-label-primary mb-6 ${className}`}>
+    {children}
+  </h2>
+);
+
+export default SectionTitle;

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Attendances.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Attendances.tsx
@@ -2,7 +2,7 @@ import { useTranslations, useLocale } from 'next-intl';
 import { FC } from 'react';
 
 import { CourseWithEnrollment_Course_by_pk } from '../../../queries/__generated__/CourseWithEnrollment';
-import { BlockTitle } from '@opencampus/shared-components';
+import { SectionTitle } from '../../common/SectionTitle';
 import Dot from '../../common/Dot';
 
 import { AttendanceStatus_enum } from '../../../__generated__/globalTypes';
@@ -84,9 +84,7 @@ export const Attendances: FC<AttendancesProps> = ({ course }) => {
 
   return (
     <div className="flex flex-col w-full mb-4 md:mb-0">
-      <div className="mb-2">
-        <BlockTitle>{t('attendances.attendances')}</BlockTitle>
-      </div>
+      <SectionTitle>{t('attendances.attendances')}</SectionTitle>
       <span className="text-lg mb-4">
         {t('attendances.max_missed_sessions_plural', {
           count: course.maxMissedSessions,

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/LearningGoals.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/LearningGoals.tsx
@@ -1,5 +1,6 @@
 import { FC } from 'react';
 import { useTranslations } from 'next-intl';
+import { SectionTitle } from '../../common/SectionTitle';
 
 interface LearningGoalsProps {
   learningGoals: string | null;
@@ -12,7 +13,7 @@ export const LearningGoals: FC<LearningGoalsProps> = ({ learningGoals }) => {
     <>
       {learningGoals !== null && learningGoals.trim() !== '' && (
         <>
-          <span className="text-3xl font-semibold mb-9">{t('learning.you_will_learn')}</span>
+          <SectionTitle className="mb-9">{t('learning.you_will_learn')}</SectionTitle>
           <ul className="list-disc pb-12">
             {learningGoals
               .split('\n')

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/MyProjectPanel.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/MyProjectPanel.tsx
@@ -336,8 +336,7 @@ const MyProjectPanel: FC<MyProjectPanelProps> = ({
 
   return (
     <div className="bg-fill-primary text-label-primary border border-status-confirmed rounded-lg p-6 space-y-4">
-      <div className="flex flex-wrap items-center justify-between gap-3">
-        <h3 className="text-lg font-semibold">{t('projects.my_project.heading')}</h3>
+      <div className="flex flex-wrap items-center justify-end gap-3">
         <div className="flex flex-wrap items-center gap-2">
           {project.status === ProjectStatus_enum.PROPOSED ? (
             <Tooltip

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/index.tsx
@@ -33,6 +33,7 @@ const ACTIVE_PROJECT_STATUSES = new Set<ProjectStatus_enum>([
 ]);
 import NotificationSnackbar from '../../../common/dialogs/NotificationSnackbar';
 import { ContentRow } from '../../../common/ContentRow';
+import { SectionTitle } from '../../../common/SectionTitle';
 import MyProjectPanel from './MyProjectPanel';
 import ProjectsTable from './ProjectsTable';
 import ProposeProjectDialog from './ProposeProjectDialog';
@@ -125,25 +126,26 @@ const Projects: FC<ProjectsProps> = ({
   return (
     <div className="w-full mt-24 mb-24 min-w-0">
       {showMyProjectPanel && userId ? (
-        <ContentRow className="mb-8 text-label-primary bg-fill-primary light px-8 py-8 w-full min-w-0">
-          <div className="flex flex-col w-full min-w-0">
-            <MyProjectPanel
-              project={myProject!}
-              userId={userId}
-              projectTypes={projectTypes}
-              courseDefaultSubmissionDeadline={effectiveSubmissionDeadline}
-              submissionDeadlineDefaultSource={submissionDeadlineDefaultSource}
-              refetchQueries={REFETCH_QUERIES}
-              onActionError={handleActionError}
-            />
-          </div>
-        </ContentRow>
+        <>
+          <SectionTitle>{t('projects.my_project.heading')}</SectionTitle>
+          <ContentRow className="mb-12 text-label-primary bg-fill-primary light px-8 py-8 w-full min-w-0">
+            <div className="flex flex-col w-full min-w-0">
+              <MyProjectPanel
+                project={myProject!}
+                userId={userId}
+                projectTypes={projectTypes}
+                courseDefaultSubmissionDeadline={effectiveSubmissionDeadline}
+                submissionDeadlineDefaultSource={submissionDeadlineDefaultSource}
+                refetchQueries={REFETCH_QUERIES}
+                onActionError={handleActionError}
+              />
+            </div>
+          </ContentRow>
+        </>
       ) : null}
 
-      <div className="w-full min-w-0 px-8">
-        <h2 className="text-2xl font-semibold text-label-primary mb-6">
-          {t('projects.section_heading')}
-        </h2>
+      <div className="w-full min-w-0">
+        <SectionTitle>{t('projects.section_heading')}</SectionTitle>
         <ProjectsTable
           projects={tableProjects}
           loading={projectsQuery.loading}

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Sessions.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Sessions.tsx
@@ -3,6 +3,7 @@ import { useTranslations } from 'next-intl';
 import { IoIosArrowDown, IoIosArrowUp } from 'react-icons/io';
 
 import { Course_Course_by_pk_Sessions as Session, Course_Course_by_pk_CourseLocations as CourseLocation } from '../../../queries/__generated__/Course';
+import { SectionTitle } from '../../common/SectionTitle';
 import UserCard from '../../common/UserCard';
 import { useDisplayDate, useFormatTimeString } from '../../../helpers/dateTimeHelpers';
 import { isLinkFormat } from '../../../helpers/util';
@@ -66,9 +67,9 @@ export const Sessions: FC<SessionsProps> = ({ sessions, courseLocations, isLogge
     <>
       {visibleSessions.length > 0 && (
         <>
-          <span className="text-3xl font-semibold mt-24">
+          <SectionTitle className="mt-24">
             {sessions.length === 1 ? t('sessions.date_singular') : t('sessions.date_plural')}
-          </span>
+          </SectionTitle>
           <ul className="max-w-2xl">
             {visibleSessions.map(({ startDateTime, endDateTime, title, SessionSpeakers, SessionAddresses }, index) => (
               <li key={index} className="flex mb-4">


### PR DESCRIPTION
Replace the five different course-page heading treatments (text-lg, text-2xl, BlockTitle, text-3xl) with one shared <SectionTitle>, hoist titles above their cards so they share one left edge, and let the "Projekte in diesem Kurs" table span the full column width to match the cards above and below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized heading components used throughout course content pages for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->