### PR TITLE
fix(course): hide empty projects table and adjust section title

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/index.tsx
@@ -153,6 +153,19 @@ const Projects: FC<ProjectsProps> = ({
     Boolean(userId) &&
     !isProjectSubmissionDeadlinePassed(null, effectiveSubmissionDeadline);
 
+  const showProjectsTableSection =
+    showMyProjectPanel ||
+    tableProjects.length > 0 ||
+    showProposeButton;
+
+  const projectsSectionHeading = showMyProjectPanel
+    ? t('projects.section_heading')
+    : t('projects.section_heading_all');
+
+  if (!showMyProjectPanel && !showProjectsTableSection) {
+    return null;
+  }
+
   return (
     <div className="mt-24 mb-24 min-w-0 mx-6 xl:mx-0">
       {showMyProjectPanel && userId ? (
@@ -175,23 +188,25 @@ const Projects: FC<ProjectsProps> = ({
         </>
       ) : null}
 
-      <div className="w-full min-w-0">
-        <SectionTitle>{t('projects.section_heading')}</SectionTitle>
-        <ProjectsTable
-          projects={tableProjects}
-          loading={projectsQuery.loading}
-          error={projectsQuery.error}
-          courseId={courseId}
-          userId={userId ?? undefined}
-          showProposeButton={showProposeButton}
-          hasMyProject={hasMyActiveProject}
-          courseDefaultSubmissionDeadline={effectiveSubmissionDeadline}
-          submissionDeadlineDefaultSource={submissionDeadlineDefaultSource}
-          refetchQueries={REFETCH_QUERIES}
-          onProposeClick={() => setProposeDialogOpen(true)}
-          onActionError={handleActionError}
-        />
-      </div>
+      {showProjectsTableSection ? (
+        <div className="w-full min-w-0">
+          <SectionTitle>{projectsSectionHeading}</SectionTitle>
+          <ProjectsTable
+            projects={tableProjects}
+            loading={projectsQuery.loading}
+            error={projectsQuery.error}
+            courseId={courseId}
+            userId={userId ?? undefined}
+            showProposeButton={showProposeButton}
+            hasMyProject={hasMyActiveProject}
+            courseDefaultSubmissionDeadline={effectiveSubmissionDeadline}
+            submissionDeadlineDefaultSource={submissionDeadlineDefaultSource}
+            refetchQueries={REFETCH_QUERIES}
+            onProposeClick={() => setProposeDialogOpen(true)}
+            onActionError={handleActionError}
+          />
+        </div>
+      ) : null}
 
       {userId ? (
         <ProposeProjectDialog

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -363,6 +363,7 @@
     },
     "projects": {
       "section_heading": "Andere Projekte in diesem Kurs",
+      "section_heading_all": "Projekte in diesem Kurs",
       "action_failed": "Aktion fehlgeschlagen",
       "status": {
         "TEMPLATE": "Projektvorlage",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -363,6 +363,7 @@
     },
     "projects": {
       "section_heading": "Other projects in this course",
+      "section_heading_all": "Projects in this course",
       "action_failed": "Action failed",
       "status": {
         "TEMPLATE": "Project template",


### PR DESCRIPTION
Hide the course projects table when there are no projects, proposing is disabled, and the user has no own project. Use a generic section title when Mein Projekt is not shown.