### PR TITLE
fix(manage-courses): hide program-type course groups from the selector

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/index.tsx
@@ -336,12 +336,17 @@ const ManageCoursesContent: FC<IProps> = ({ programs }) => {
   const courseGroupOptions = useMemo(() => {
     if (data && !loading && !error) {
       return (
-        data.CourseGroupOption?.map((option: { id: number; title: string | null }) => ({
-          id: option.id,
-          name: isKnownCourseGroupOptionTitle(option.title)
-            ? tCommon(`course_group_options.${option.title}`)
-            : option.title ?? '—',
-        })) || []
+        data.CourseGroupOption
+          // Program-type based groups (Courses, Events, Degrees) are assigned
+          // automatically via the program type, so they must not be manually
+          // selectable here.
+          ?.filter((option: { programType: string | null }) => option.programType == null)
+          .map((option: { id: number; title: string | null }) => ({
+            id: option.id,
+            name: isKnownCourseGroupOptionTitle(option.title)
+              ? tCommon(`course_group_options.${option.title}`)
+              : option.title ?? '—',
+          })) || []
       );
     } else {
       return [];

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminCourseList.ts
@@ -555,6 +555,10 @@ export interface AdminCourseList_CourseGroupOption {
    * Indicates whether this group option is used in UI sliders (true) or as metadata tags (false)
    */
   sliderGroup: boolean | null;
+  /**
+   * When set, this group automatically includes all published courses of the given program type (e.g. COURSES, EVENTS, DEGREES) instead of relying on manual CourseGroup assignments.
+   */
+  programType: string | null;
 }
 
 export interface AdminCourseList {

--- a/frontend-nx/apps/edu-hub/queries/courseList.ts
+++ b/frontend-nx/apps/edu-hub/queries/courseList.ts
@@ -96,6 +96,7 @@ export const ADMIN_COURSE_LIST = gql`
       title
       order
       sliderGroup
+      programType
     }
   }
 `;


### PR DESCRIPTION
## Summary
Follow-up to #1744. The auto-populated course groups (**Courses, Events, Degrees**) are assigned automatically via the program type, so they should not be manually selectable in the manage-courses course-group dropdown. They are now filtered out of that selector.

## Changes
- `queries/courseList.ts` — the admin course list query now also fetches `programType` on `CourseGroupOption`.
- `components/pages/ManageCoursesContent/index.tsx` — the course-group selector options now exclude any option that has a `programType` set.
- `queries/__generated__/AdminCourseList.ts` — regenerated type includes `programType`.

## Notes
- This filters the **dropdown options** only. Any pre-existing manual assignment to one of these groups would still render as a (removable) chip; new manual assignments to Courses/Events/Degrees are no longer possible.

## Test plan
- [ ] `/manage/courses` → expand a course → open the "Kursgruppe" selector: Courses, Events and Degrees no longer appear in the list; other (manual) groups still do.
- [ ] Homepage Courses/Events/Degrees sliders are still populated automatically by program type.
- [ ] `yarn type-check` and `yarn lint` in `frontend-nx`.

https://claude.ai/code/session_01FVDrDF3igocf1CoeeE4DZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVDrDF3igocf1CoeeE4DZx)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Course group option filtering in the Manage Courses interface has been refined. The system now applies updated filtering criteria that exclude certain course options from the available selection. This change affects which options users encounter when accessing the course selection dropdown in the course management section, providing a more focused list of available courses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->