### PR TITLE
fix(certificates): unwrap signed URL array so downloads don't 500

### DIFF
--- a/frontend-nx/apps/edu-hub/pages/api/certificates/download.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/certificates/download.ts
@@ -20,7 +20,7 @@ type SessionToken = {
 
 type GetSignedUrlResponse = {
   getSignedUrl?: {
-    link?: string | null;
+    link?: string | string[] | null;
   } | null;
 };
 
@@ -97,7 +97,10 @@ export default async function certificateDownload(
       { path: certificatePath }
     );
 
-    const signedUrl = result.getSignedUrl?.link;
+    const link = result.getSignedUrl?.link;
+    // Older signed-URL responses may wrap the URL in a single-element array; normalize to a
+    // string so res.redirect (which rejects non-string URLs) does not throw.
+    const signedUrl = Array.isArray(link) ? link[0] : link;
     if (!signedUrl) {
       return res.status(404).json({ error: 'Certificate not found.' });
     }

--- a/functions/callNodeFunction/lib/cloud-storage.js
+++ b/functions/callNodeFunction/lib/cloud-storage.js
@@ -38,6 +38,12 @@ const getSignedReadUrlConfig = (filePath) => {
   return config;
 };
 
+const getSignedReadUrl = async (file, filePath) => {
+  // Google returns signed URLs as a single-element array.
+  const [signedUrl] = await file.getSignedUrl(getSignedReadUrlConfig(filePath));
+  return signedUrl;
+};
+
 const getRelativePath = (filePath) => {
   if (isPublicLegacy(filePath)) {
     const parsedUrl = url.parse(filePath);
@@ -150,7 +156,7 @@ export const buildCloudStorage = (Storage) => {
           await file.makePublic();
           link = await file.publicUrl();
         } else {
-          link = await file.getSignedUrl(getSignedReadUrlConfig(filename));
+          link = await getSignedReadUrl(file, filename);
         }
         return link;
       },
@@ -164,10 +170,7 @@ export const buildCloudStorage = (Storage) => {
         if (isPublic[0] == true) {
           link = await file.publicUrl();
         } else {
-          // file.getSignedUrl resolves to a single-element array ([url]); unwrap it so
-          // callers (and the getSignedUrl action's `link: String!` field) get a plain string.
-          const [signedUrl] = await file.getSignedUrl(getSignedReadUrlConfig(path));
-          link = signedUrl;
+          link = await getSignedReadUrl(file, path);
         }
         return link;
       },

--- a/functions/callNodeFunction/lib/cloud-storage.js
+++ b/functions/callNodeFunction/lib/cloud-storage.js
@@ -164,7 +164,10 @@ export const buildCloudStorage = (Storage) => {
         if (isPublic[0] == true) {
           link = await file.publicUrl();
         } else {
-          link = await file.getSignedUrl(getSignedReadUrlConfig(path));
+          // file.getSignedUrl resolves to a single-element array ([url]); unwrap it so
+          // callers (and the getSignedUrl action's `link: String!` field) get a plain string.
+          const [signedUrl] = await file.getSignedUrl(getSignedReadUrlConfig(path));
+          link = signedUrl;
         }
         return link;
       },


### PR DESCRIPTION
## Problem

Certificate downloads fail in production with `500 "Certificate download failed."` from `/api/certificates/download`.

Cloud Run logs show the `getSignedUrl` function actually **succeeds** (`File access granted` → `Successfully executed function: getSignedUrl`, HTTP 200). The 500 happens afterwards, back in the Next.js endpoint.

## Root cause

`@google-cloud/storage`'s `file.getSignedUrl()` resolves to a single-element **array** (`["https://…"]`). `loadFromBucket` returned that directly, so the `getSignedUrl` action's `link` came back as an array instead of a string.

The new `/api/certificates/download` endpoint (introduced in the Safari popup-blocking rework) passed `link` straight to `res.redirect(302, link)`. **Next 15's `res.redirect` rejects non-string URLs and throws**, which lands in the `catch` and returns the 500.

The previous flow did `window.open(link)`, which coerced the array to a string — so it worked, masking the latent mismatch with the `link: String!` schema.

## Fix

- **`functions/callNodeFunction/lib/cloud-storage.js`** — unwrap the array in `loadFromBucket` so the action honors its `link: String!` contract (also benefits the `createCertificate` caller).
- **`pages/api/certificates/download.ts`** — defensively normalize `link` (`Array.isArray(link) ? link[0] : link`) and widen the response type, so the endpoint is robust regardless of the action's return shape.

## Deployment note

The two fixes ship via different pipelines and are complementary:
- The **frontend fix** alone resolves the user-facing 500 as soon as the Next.js app deploys (it tolerates the current array form).
- The **cloud-function fix** corrects the source but only takes effect once `call-node-function` is redeployed.

https://claude.ai/code/session_01Cv2wWgsY7FgRgZsqh848bA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cv2wWgsY7FgRgZsqh848bA)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved certificate download reliability by normalizing API response handling
  * Enhanced cloud storage signed URL generation for greater consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->