### PR TITLE
Fix instructor ProjectAuthor insert permissions to allow adding other users

### DIFF
--- a/backend/metadata/databases/default/tables/public_ProjectAuthor.yaml
+++ b/backend/metadata/databases/default/tables/public_ProjectAuthor.yaml
@@ -12,6 +12,13 @@ object_relationships:
     using:
       foreign_key_constraint_on: userId
 insert_permissions:
+  # Instructor add-author flow: an instructor adds one or more authors (any userId)
+  # to a project in a course they teach. userId is supplied by the client, so this
+  # role must NOT use a `set: userId` preset — a preset would strip userId from
+  # ProjectAuthor_insert_input ("field 'userId' not found in type") and force every
+  # author to be the instructor themselves.
+  # Instructors acting as course participants (join-request) use the `user` JWT role
+  # (user_access); the second branch below is a defensive fallback constrained to self.
   - role: instructor_access
     permission:
       check:
@@ -26,6 +33,8 @@ insert_permissions:
           - _and:
               - participationStatus:
                   _eq: REQUESTED
+              - userId:
+                  _eq: X-Hasura-User-Id
               - Project:
                   _and:
                     - status:
@@ -40,8 +49,6 @@ insert_permissions:
                             User:
                               id:
                                 _eq: X-Hasura-User-Id
-      set:
-        userId: x-hasura-user-id
       columns:
         - participationStatus
         - projectId


### PR DESCRIPTION
## Summary
Fixed the instructor_access role permissions for inserting ProjectAuthor records to properly support the instructor add-author flow, where instructors can add any user as an author to a project.

## Key Changes
- **Removed the `set: userId` preset** that was forcing all authors to be the instructor themselves, which prevented instructors from adding other users as authors
- **Added explicit `userId` constraint** to the defensive fallback branch (join-request flow) to ensure instructors can only add themselves when acting as course participants
- **Clarified permission logic** with detailed comments explaining the two distinct flows:
  - Primary flow: Instructors adding any user as an author (no userId preset)
  - Fallback flow: Instructors joining as participants (constrained to self via userId check)

## Implementation Details
The `set: userId` preset was problematic because it would strip the `userId` field from the input, causing a "field 'userId' not found in type" error. By removing this preset from the main permission block and adding an explicit `userId: _eq: X-Hasura-User-Id` constraint only to the join-request fallback, the permissions now correctly:
1. Allow instructors to specify any userId when adding authors
2. Maintain security by constraining the fallback self-join flow to the instructor's own user ID

https://claude.ai/code/session_01KRrhGYytxxisgfxyNhDJe8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for instructor author assignments to projects. The system now enforces stricter identity verification when instructors add authors, preventing unauthorized user modifications and protecting against user ID injection attacks. These changes ensure that only authorized instructors can modify project author records and maintain system data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->