### PR TITLE
fix(auth): allow org_admin to sort OrganizationAdmin by updated_at

### DIFF
--- a/backend/metadata/databases/default/tables/public_OrganizationAdmin.yaml
+++ b/backend/metadata/databases/default/tables/public_OrganizationAdmin.yaml
@@ -22,6 +22,8 @@ select_permissions:
         - canManageEvents
         - canManageDegrees
         - canManageSettings
+        - created_at
+        - updated_at
       filter:
         _or:
           - userId:
@@ -33,6 +35,7 @@ select_permissions:
                       _eq: X-Hasura-User-Id
                   - canManageSettings:
                       _eq: true
+      allow_aggregations: true
 insert_permissions:
   # An org admin with canManageSettings may add admins to organizations they manage. The check pins
   # the new row's organization to one they hold canManageSettings on; id is serial and userId/flags

--- a/backend/metadata/databases/default/tables/public_User.yaml
+++ b/backend/metadata/databases/default/tables/public_User.yaml
@@ -181,6 +181,28 @@ select_permissions:
                         - status:
                             _eq: CONFIRMED
       limit: 100
+  # Org admins with canManageSettings may read contact details of users they administer (and their
+  # own record) when managing an organization's admin team on /manage/admin-users.
+  - role: org_admin_access
+    permission:
+      columns:
+        - id
+        - firstName
+        - lastName
+        - email
+      filter:
+        _or:
+          - id:
+              _eq: X-Hasura-User-Id
+          - OrganizationAdmins:
+              Organization:
+                OrganizationAdmins:
+                  _and:
+                    - userId:
+                        _eq: X-Hasura-User-Id
+                    - canManageSettings:
+                        _eq: true
+      limit: 100
 update_permissions:
   - role: user_access
     permission:

--- a/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
+++ b/frontend-nx/apps/edu-hub/hooks/authedQuery.ts
@@ -26,6 +26,31 @@ const getErrorMessage = (error: unknown): string | undefined => {
   return undefined;
 };
 
+const isGraphQLSchemaError = (error: unknown): boolean => {
+  const message = getErrorMessage(error) ?? '';
+  if (
+    message.includes('not found in type') ||
+    message.includes('Cannot query field') ||
+    message.includes('validation-failed')
+  ) {
+    return true;
+  }
+
+  if (typeof error === 'object' && error !== null && 'graphQLErrors' in error) {
+    const graphQLErrors = (error as { graphQLErrors?: Array<{ extensions?: { code?: string } }> })
+      .graphQLErrors;
+    return (
+      graphQLErrors?.some(
+        (graphQLError) =>
+          graphQLError.extensions?.code === 'validation-failed' ||
+          graphQLError.extensions?.code === 'access-denied'
+      ) ?? false
+    );
+  }
+
+  return false;
+};
+
 const useErrorHandler = () => {
   const t = useTranslations();
   const { showAuthError } = useAuthError();
@@ -43,6 +68,9 @@ const useErrorHandler = () => {
     } else if (message?.includes('NetworkError') || message?.includes('Failed to fetch')) {
       // NetworkError (e.g. aborted on page refresh, offline) — don't show auth dialog; log only
       console.warn('GraphQL network error (may be transient):', error);
+    } else if (isGraphQLSchemaError(error)) {
+      // Role-scoped schema / permission mismatches are query errors, not auth failures.
+      console.error('GraphQL query error in query hook:', error);
     } else {
       console.error('Authentication error in query hook:', error);
       // Show a generic user-facing auth dialog; internal details stay in logs only.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two console errors on `/manage/admin-users` when logged in as an org admin (`orgadmin@example.com`):

1. **`Field 'updated_at' not found in type: 'OrganizationAdmin_order_by'`** — The `org_admin_access` select permission on `OrganizationAdmin` did not include `created_at` / `updated_at`, so Hasura did not expose those fields in the role-scoped `order_by` input. `TableGrid` defaults to sorting by `updated_at`.
2. **`Auth error: Authentifizierungsfehler`** — This was a misleading side effect: the shared query error handler treated the GraphQL validation failure above as an authentication error and opened the auth dialog.

## Changes

- **Hasura metadata (`OrganizationAdmin`)**: add `created_at`, `updated_at`, and `allow_aggregations` to `org_admin_access` select permissions.
- **Hasura metadata (`User`)**: add `org_admin_access` select permission for `id`, `firstName`, `lastName`, `email` so nested user fields on the admin-users table resolve under the org-admin role.
- **Frontend (`authedQuery.ts`)**: classify GraphQL schema/validation errors separately from auth failures so permission/schema mismatches no longer trigger the auth dialog.

## Verification

- GraphQL introspection as `org_admin` now includes `updated_at` in `OrganizationAdmin_order_by`.
- `OrganizationAdminList` query with `order_by: { updated_at: desc }` succeeds as `orgadmin@example.com` with role `org_admin`.
- Browser login as orgadmin no longer shows the `updated_at` or auth-dialog errors from the original report.

## Apply locally

After pulling, reload Hasura metadata (or restart Hasura):

```bash
cd backend && hasura metadata apply
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a120a74-d8e0-4b03-9590-2defc8f42731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a120a74-d8e0-4b03-9590-2defc8f42731"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

