### PR TITLE
fix: admin delete broken + bump Node.js runtime to 22

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 
   node_functions:
     container_name: eduhub-node-functions
-    image: node:18-bullseye
+    image: node:22-bullseye
     user: "node"
     working_dir: /functions
     volumes:

--- a/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
@@ -294,7 +294,7 @@ const ManageAdminUsersContent: FC = () => {
               searchFilter={searchFilter}
               onSearchFilterChange={setSearchFilter}
               deleteMutation={DELETE_ORGANIZATION_ADMIN}
-              deleteIdType="uuidString"
+              deleteIdType="number"
               role={manageRole}
               error={error}
               loading={loading}

--- a/infrastructure/application/06_cloud-functions.tf
+++ b/infrastructure/application/06_cloud-functions.tf
@@ -292,7 +292,7 @@ resource "google_cloudfunctions2_function" "call_node_function" {
   description = "Calls a node function specificed via the function header."
 
   build_config {
-    runtime     = "nodejs20"
+    runtime     = "nodejs22"
     entry_point = "callNodeFunction"
     environment_variables = {
       # Causes a re-deploy of the function when the source changes
@@ -446,7 +446,7 @@ resource "google_cloudfunctions2_function" "send_mail" {
   description = "Sends an email as defined in the Hasura mail log table"
 
   build_config {
-    runtime     = "nodejs20"
+    runtime     = "nodejs22"
     entry_point = "sendMail"
     environment_variables = {
       # Causes a re-deploy of the function when the source changes
@@ -538,7 +538,7 @@ resource "google_cloudfunctions2_function" "add_keycloak_role" {
   description = "Adds role mapping for given role for keycloak hasura client"
 
   build_config {
-    runtime     = "nodejs20"
+    runtime     = "nodejs22"
     entry_point = "addKeycloakRole"
     environment_variables = {
       # Causes a re-deploy of the function when the source changes
@@ -602,7 +602,7 @@ resource "google_cloudfunctions2_function" "remove_keycloak_role" {
   description = "Removes role mapping for given role from keycloak hasura client once the backing grant is gone"
 
   build_config {
-    runtime     = "nodejs20"
+    runtime     = "nodejs22"
     entry_point = "removeKeycloakRole"
     environment_variables = {
       # Causes a re-deploy of the function when the source changes
@@ -674,7 +674,7 @@ resource "google_cloudfunctions2_function" "update_from_keycloak" {
   description = "Looks up keycloak user of given uuid and creates new hasura user if necessary or updates existing"
 
   build_config {
-    runtime     = "nodejs20"
+    runtime     = "nodejs22"
     entry_point = "updateFromKeycloak"
     environment_variables = {
       # Causes a re-deploy of the function when the source changes
@@ -747,7 +747,7 @@ resource "google_cloudfunctions2_function" "send_questionaires" {
   description = "send out questionaires for published past sessions"
 
   build_config {
-    runtime     = "nodejs20"
+    runtime     = "nodejs22"
     entry_point = "sendQuestionaires"
     environment_variables = {
       # Causes a re-deploy of the function when the source changes


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Fix silent delete failure** in the admin users table: `deleteIdType="uuidString"` was set on `TableGrid`, but `OrganizationAdmin.id` is a serial `Int`. `TableGridDeleteButton` validated the integer row id as a UUID, logged `"Invalid UUID string: <n>"`, and returned early — so the delete mutation never fired, the row stayed visible, and the Keycloak role was never removed. Fixed to `deleteIdType="number"` to match the `DELETE_ORGANIZATION_ADMIN` mutation signature (`$id: Int!`).
- **Bump Node.js runtime to 22** for all 6 Node.js Cloud Functions in Terraform (`nodejs20` → `nodejs22`) and the local Docker Compose dev container (`node:18-bullseye` → `node:22-bullseye`). Node.js 20 was deprecated Apr 2026 and is decommissioned Oct 2026.

## Test plan

- [ ] Add an org admin via the "Admin hinzufügen" dialog — user appears in the table
- [ ] Delete the org admin — row disappears and the `org_admin` Keycloak role is removed from the user
- [ ] Verify no "Invalid UUID string" errors in the browser console on delete
- [ ] Apply Terraform (`terraform apply`) — Cloud Functions redeploy with `nodejs22`
- [ ] Restart local dev stack (`docker compose pull && docker compose up`) — `node_functions` container runs Node 22

https://claude.ai/code/session_01Fm7trGq1UGHp9qSw8XoKHt
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fm7trGq1UGHp9qSw8XoKHt)_