### PR TITLE
fix(projects): resolve participant project type from project.ProjectType

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/MyProjectPanel.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/MyProjectPanel.tsx
@@ -54,7 +54,7 @@ import ManageRequestsDialog from './ManageRequestsDialog';
 import ProjectPreviewLayout from './ProjectPreviewLayout';
 import ProjectFormFieldSection from './ProjectFormFieldSection';
 import ProjectSubmissionDeadlineBelowTitle from './ProjectSubmissionDeadlineBelowTitle';
-import { ProjectRow, ProjectTypeRow } from './types';
+import { ProjectRow } from './types';
 import { PROJECT_FALLBACK_TITLE } from './projectDefaults';
 /** Extensions only — MIME variants are derived for validation; avoids raw MIME labels in the UI. */
 const PROJECT_DOCUMENTATION_ACCEPT = '.pdf,.doc,.docx,.odt';
@@ -65,7 +65,6 @@ interface MyProjectPanelProps {
   userId: string;
   /** The viewer was EXCLUDED from this project's final submission (read-only view). */
   isExcludedAuthor?: boolean;
-  projectTypes: ProjectTypeRow[];
   /** Course/program fallback when `project.submissionDeadline` is null. */
   courseDefaultSubmissionDeadline: string | null | undefined;
   submissionDeadlineDefaultSource: CourseProjectSubmissionDefaultSource;
@@ -77,7 +76,6 @@ const MyProjectPanel: FC<MyProjectPanelProps> = ({
   project,
   userId,
   isExcludedAuthor = false,
-  projectTypes,
   courseDefaultSubmissionDeadline,
   submissionDeadlineDefaultSource,
   refetchQueries,
@@ -206,10 +204,11 @@ const MyProjectPanel: FC<MyProjectPanelProps> = ({
     setLeaveDialogOpen(true);
   }, [cannotLeaveWhileRequestsPending, onActionError, t]);
 
-  const projectType = useMemo(
-    () => projectTypes.find((pt) => pt.value === project.type) ?? null,
-    [project.type, projectTypes]
-  );
+  // The project's own type (FK-joined, user-readable) is the source of truth for
+  // its deliverable requirements. Resolving it here — instead of from the
+  // instructor-only ProjectType catalog query — keeps the checklist and submit
+  // button working for participants.
+  const projectType = project.ProjectType ?? null;
 
   const isContentEditable =
     project.status === ProjectStatus_enum.PROPOSED ||

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/ProjectNextTodos.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/ProjectNextTodos.tsx
@@ -2,7 +2,7 @@ import { FC, useMemo } from 'react';
 import { useTranslations } from 'next-intl';
 import { MdCheckCircle, MdRadioButtonUnchecked } from 'react-icons/md';
 import { ProjectStatus_enum } from '../../../../__generated__/globalTypes';
-import { ProjectRow, ProjectTypeRow } from './types';
+import { ProjectRow, ProjectTypeRequirements } from './types';
 import { PROJECT_FALLBACK_TITLE } from './projectDefaults';
 import { isProjectResourceUrlPresent, safeProjectInstructionHref } from './projectMandatory';
 import { isOnlineCourseProject } from './projectStatusDisplay';
@@ -19,7 +19,7 @@ type TodoItem =
 
 interface ProjectNextTodosProps {
   project: ProjectRow;
-  projectType: ProjectTypeRow | null | undefined;
+  projectType: ProjectTypeRequirements | null | undefined;
   canEditProjectTitle: boolean;
   requestedJoinCount: number;
   isSubmissionDeadlinePassed?: boolean;

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/SubmissionChecklist.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/SubmissionChecklist.tsx
@@ -1,9 +1,9 @@
-import { ProjectRow, ProjectTypeRow } from './types';
+import { ProjectRow, ProjectTypeRequirements } from './types';
 import { isProjectResourceUrlPresent } from './projectMandatory';
 
 export const isChecklistComplete = (
   project: ProjectRow,
-  projectType: ProjectTypeRow | null | undefined
+  projectType: ProjectTypeRequirements | null | undefined
 ): boolean => {
   if (!projectType) return false;
   if (projectType.requiresDocumentation && !isProjectResourceUrlPresent(project.documentationUrl)) {

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/index.tsx
@@ -6,7 +6,6 @@ import { useUserId } from '../../../../hooks/user';
 import {
   PROJECTS_BY_COURSE,
   MY_PROJECT_BY_COURSE,
-  PROJECT_TYPES,
 } from '../../../../queries/project';
 import {
   ProjectsByCourse,
@@ -16,7 +15,6 @@ import {
   MyProjectByCourse,
   MyProjectByCourseVariables,
 } from '../../../../queries/__generated__/MyProjectByCourse';
-import { ProjectTypes } from '../../../../queries/__generated__/ProjectTypes';
 import {
   ProjectParticipationStatus_enum,
   ProjectStatus_enum,
@@ -78,8 +76,6 @@ const Projects: FC<ProjectsProps> = ({
       skip: !userId,
     }
   );
-
-  const projectTypesQuery = useRoleQuery<ProjectTypes>(PROJECT_TYPES);
 
   const myAcceptedProject = useMemo(
     () =>
@@ -149,8 +145,6 @@ const Projects: FC<ProjectsProps> = ({
     );
   }
 
-  const projectTypes = projectTypesQuery.data?.ProjectType ?? [];
-
   const showMyProjectPanel = Boolean(myProject && userId);
 
   const showProposeButton =
@@ -183,7 +177,6 @@ const Projects: FC<ProjectsProps> = ({
                 project={myProject!}
                 userId={userId}
                 isExcludedAuthor={isExcludedFromMyProject}
-                projectTypes={projectTypes}
                 courseDefaultSubmissionDeadline={effectiveSubmissionDeadline}
                 submissionDeadlineDefaultSource={submissionDeadlineDefaultSource}
                 refetchQueries={REFETCH_QUERIES}

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/projectMandatory.ts
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/projectMandatory.ts
@@ -1,4 +1,4 @@
-import { ProjectRow, ProjectTypeRow } from './types';
+import { ProjectRow, ProjectTypeRequirements } from './types';
 import { getSafeFileHref } from '../../../../helpers/filehandling';
 
 /** Static path prefix for migration-seeded default instruction PDFs in `public/`. */
@@ -52,28 +52,28 @@ export function safeProjectInstructionHref(instructionUrl?: string | null): stri
 
 export function isProjectDocumentationIncomplete(
   project: ProjectRow,
-  projectType: ProjectTypeRow | null | undefined
+  projectType: ProjectTypeRequirements | null | undefined
 ): boolean {
   return Boolean(projectType?.requiresDocumentation && !isProjectResourceUrlPresent(project.documentationUrl));
 }
 
 export function isProjectPresentationIncomplete(
   project: ProjectRow,
-  projectType: ProjectTypeRow | null | undefined
+  projectType: ProjectTypeRequirements | null | undefined
 ): boolean {
   return Boolean(projectType?.requiresPresentation && !isProjectResourceUrlPresent(project.presentationUrl));
 }
 
 export function isProjectExternalUrlIncomplete(
   project: ProjectRow,
-  projectType: ProjectTypeRow | null | undefined
+  projectType: ProjectTypeRequirements | null | undefined
 ): boolean {
   return Boolean(projectType?.requiresExternalUrl && !isProjectResourceUrlPresent(project.externalUrl));
 }
 
 export function isProjectCoverImageIncomplete(
   project: ProjectRow,
-  projectType: ProjectTypeRow | null | undefined
+  projectType: ProjectTypeRequirements | null | undefined
 ): boolean {
   return Boolean(projectType?.requiresCoverImage && !project.coverImageUrl?.trim());
 }

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/types.ts
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/types.ts
@@ -7,3 +7,19 @@ export type ProjectRow = ProjectsByCourse_Project & {
 export type ProjectAuthorRow = ProjectRow['ProjectAuthors'][number];
 export type ProjectMentorRow = ProjectRow['ProjectMentors'][number];
 export type ProjectTypeRow = ProjectTypes_ProjectType;
+
+/**
+ * The deliverable-requirement fields shared by the project-type catalog row
+ * (`ProjectTypeRow`) and the type embedded on a project (`project.ProjectType`).
+ * Checklist / next-step logic only needs these flags, so accepting this narrower
+ * shape lets callers pass the project's own (user-readable) type without the
+ * instructor-only catalog fields.
+ */
+export type ProjectTypeRequirements = Pick<
+  ProjectTypeRow,
+  | 'value'
+  | 'requiresDocumentation'
+  | 'requiresPresentation'
+  | 'requiresExternalUrl'
+  | 'requiresCoverImage'
+>;


### PR DESCRIPTION
The participant My Project panel resolved the project type from the PROJECT_TYPES catalog query, which requests the instructor-only nested CertificateTemplate. For the user role that query is rejected, so the type stayed null: "Nächste Schritte" only showed "Projekttyp wird durch die Kursleitung gesetzt", the documentation instruction link was hidden, and the submit button was disabled for every participant project.

Resolve the type from the project's own (user-readable) ProjectType relationship instead and drop the failing catalog query from the participant flow. Checklist/next-step helpers now accept a narrower ProjectTypeRequirements shape shared by both type sources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified project type requirement handling by deriving project types directly from project data instead of requiring external catalog dependency. Streamlined internal type system to focus only on deliverable requirement fields, reducing data dependencies while maintaining existing checklist and submission validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->