### PR TITLE
Add admin project management page with publish/unpublish controls

### DIFF
--- a/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
+++ b/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
@@ -8750,6 +8750,60 @@ export interface Project_avg_order_by {
 /**
  * Boolean expression to filter rows from the table "Project". All fields are combined with a logical 'AND'.
  */
+export interface ProjectRating_order_by {
+  Projects_aggregate?: Project_aggregate_order_by | null;
+  comment?: order_by | null;
+  value?: order_by | null;
+}
+
+export interface ProjectStatus_order_by {
+  Projects_aggregate?: Project_aggregate_order_by | null;
+  comment?: order_by | null;
+  value?: order_by | null;
+}
+
+export interface Project_order_by {
+  ChildProjects_aggregate?: Project_aggregate_order_by | null;
+  Organization?: Organization_order_by | null;
+  ParentProject?: Project_order_by | null;
+  ProjectAuthors_aggregate?: ProjectAuthor_aggregate_order_by | null;
+  ProjectCourses_aggregate?: ProjectCourse_aggregate_order_by | null;
+  ProjectDocumentationInstruction?: ProjectDocumentationInstruction_order_by | null;
+  ProjectMentors_aggregate?: ProjectMentor_aggregate_order_by | null;
+  ProjectRating?: ProjectRating_order_by | null;
+  ProjectStatus?: ProjectStatus_order_by | null;
+  ProjectType?: ProjectType_order_by | null;
+  ProposedByUser?: User_order_by | null;
+  SubmittedByUser?: User_order_by | null;
+  acceptingParticipants?: order_by | null;
+  coverImageUrl?: order_by | null;
+  created_at?: order_by | null;
+  csvResults?: order_by | null;
+  description?: order_by | null;
+  documentationInstructionId?: order_by | null;
+  documentationUrl?: order_by | null;
+  externalUrl?: order_by | null;
+  id?: order_by | null;
+  legacyAchievementOptionId?: order_by | null;
+  legacyAchievementRecordId?: order_by | null;
+  organizationId?: order_by | null;
+  parentProjectId?: order_by | null;
+  presentationUrl?: order_by | null;
+  projectReviewRequestedAt?: order_by | null;
+  proposedByUserId?: order_by | null;
+  rating?: order_by | null;
+  ratingComment?: order_by | null;
+  status?: order_by | null;
+  submissionDeadline?: order_by | null;
+  submittedAt?: order_by | null;
+  submittedBy?: order_by | null;
+  suggestedForPublication?: order_by | null;
+  tagline?: order_by | null;
+  title?: order_by | null;
+  type?: order_by | null;
+  updated_at?: order_by | null;
+}
+
 export interface Project_bool_exp {
   ChildProjects?: Project_bool_exp | null;
   ChildProjects_aggregate?: Project_aggregate_bool_exp | null;

--- a/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
+++ b/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
@@ -108,6 +108,14 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
       )}
 
       {isAdmin && (
+        <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/projects')}>
+          <Link className="w-full text-lg" href="/manage/projects">
+            {t('menu.projects')}
+          </Link>
+        </MenuItem>
+      )}
+
+      {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/users')}>
           <Link className="w-full text-lg" href="/manage/users">
             {t('menu.user')}

--- a/frontend-nx/apps/edu-hub/components/pages/ManageProjectsContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageProjectsContent/index.tsx
@@ -294,7 +294,7 @@ const ManageProjectsContent: FC = () => {
           return (
             <div className="flex flex-col items-center gap-2">
               <span
-                className={`w-3 h-3 rounded-full ${published ? 'bg-green-500' : 'bg-gray-300'}`}
+                className={`w-3 h-3 rounded-full ${published ? 'bg-success' : 'bg-fill-disabled'}`}
                 title={published ? t('table.published') : t('table.not_published')}
               />
               {publishBlocked ? (

--- a/frontend-nx/apps/edu-hub/components/pages/ManageProjectsContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageProjectsContent/index.tsx
@@ -1,0 +1,400 @@
+import { FC, useCallback, useMemo, useState } from 'react';
+import { ColumnDef } from '@tanstack/react-table';
+import Tooltip from '@mui/material/Tooltip';
+import { useTranslations } from 'next-intl';
+
+import { useAdminMutation } from '../../../hooks/authedMutation';
+import { useAdminQuery } from '../../../hooks/authedQuery';
+import {
+  order_by,
+  ProjectParticipationStatus_enum,
+  ProjectStatus_enum,
+} from '../../../__generated__/globalTypes';
+import { ADMIN_PROJECT_LIST, UPDATE_PROJECT_STATUS } from '../../../queries/adminProjectList';
+import { PROGRAMS_WITH_MINIMUM_PROPERTIES } from '../../../queries/programList';
+import { COURSE_GROUP_OPTIONS } from '../../../queries/courseGroupOptions';
+import { AdminProjectList, AdminProjectList_Project } from '../../../queries/__generated__/AdminProjectList';
+import {
+  UpdateProjectStatus,
+  UpdateProjectStatusVariables,
+} from '../../../queries/__generated__/UpdateProjectStatus';
+import { Programs } from '../../../queries/__generated__/Programs';
+import { CourseGroupOptions } from '../../../queries/__generated__/CourseGroupOptions';
+
+import TableGrid from '../../common/TableGrid';
+import { useTableGrid } from '../../common/TableGrid/hooks';
+import { createMultiWordSearchCondition } from '../../common/TableGrid/utils';
+import NotificationSnackbar from '../../common/dialogs/NotificationSnackbar';
+import CommonPageHeader from '../../common/CommonPageHeader';
+import DropDownSelector from '../../inputs/DropDownSelector';
+import { Button } from '../../common/Button';
+
+import StatusChip from '../CourseContent/Projects/StatusChip';
+import ProjectPreviewLayout from '../CourseContent/Projects/ProjectPreviewLayout';
+import { getDisplayAuthors, isAcceptedAuthor } from '../CourseContent/Projects/projectAuthors';
+import {
+  getProjectStatusChipKey,
+  PROJECT_TYPE_ONLINE_COURSE,
+  shouldShowProjectResourceDownloadLinks,
+} from '../CourseContent/Projects/projectStatusDisplay';
+import { ProjectRow } from '../CourseContent/Projects/types';
+import { formatTruncatedList, makeFullName } from '../../../helpers/util';
+import { isKnownCourseGroupOptionTitle } from '../../../helpers/courseGroupOptions';
+
+const QUERY_LIMIT = 50;
+
+// Rows shown on the cross-course overview (see plan / product decision):
+//   1. COMPLETED projects that are NOT online courses,
+//   2. template projects (PROPOSED with no ACCEPTED author), any type,
+//   3. every PUBLISHED project (so a row stays visible to be unpublished again).
+const PROJECT_LIST_SCOPE_WHERE = {
+  _or: [
+    { status: { _eq: ProjectStatus_enum.PUBLISHED } },
+    {
+      _and: [
+        { status: { _eq: ProjectStatus_enum.COMPLETED } },
+        { _not: { type: { _eq: PROJECT_TYPE_ONLINE_COURSE } } },
+      ],
+    },
+    {
+      _and: [
+        { status: { _eq: ProjectStatus_enum.PROPOSED } },
+        {
+          _not: {
+            ProjectAuthors: { participationStatus: { _eq: ProjectParticipationStatus_enum.ACCEPTED } },
+          },
+        },
+      ],
+    },
+  ],
+};
+
+const hasAcceptedAuthor = (project: Pick<ProjectRow, 'ProjectAuthors'>): boolean =>
+  (project.ProjectAuthors ?? []).some(isAcceptedAuthor);
+
+const ManageProjectsContent: FC = () => {
+  const t = useTranslations('manageProjects');
+  const tCommon = useTranslations('common');
+
+  const [programFilter, setProgramFilter] = useState('');
+  const [courseGroupFilter, setCourseGroupFilter] = useState('');
+
+  // Notification state
+  const [showSuccessNotification, setShowSuccessNotification] = useState(false);
+  const [successMessage, setSuccessMessage] = useState('');
+  const [showErrorNotification, setShowErrorNotification] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  // Filter dropdown option sources
+  const { data: programsData } = useAdminQuery<Programs>(PROGRAMS_WITH_MINIMUM_PROPERTIES);
+  const { data: courseGroupData } = useAdminQuery<CourseGroupOptions>(COURSE_GROUP_OPTIONS);
+
+  const courseGroupLabel = useCallback(
+    (title: string | null) => {
+      if (!title) return '';
+      return isKnownCourseGroupOptionTitle(title) ? tCommon(`course_group_options.${title}`) : title;
+    },
+    [tCommon]
+  );
+
+  const programOptions = useMemo(
+    () =>
+      (programsData?.Program ?? []).map((program) => ({
+        value: String(program.id),
+        label: program.shortTitle || program.title || String(program.id),
+      })),
+    [programsData?.Program]
+  );
+
+  const courseGroupOptions = useMemo(
+    () =>
+      (courseGroupData?.CourseGroupOption ?? []).map((option) => ({
+        value: String(option.id),
+        label: courseGroupLabel(option.title),
+      })),
+    [courseGroupData?.CourseGroupOption, courseGroupLabel]
+  );
+
+  const { data, loading, error, searchFilter, pageIndex, sorting, setSearchFilter, setPageIndex, setSorting } =
+    useTableGrid({
+      queryHook: useAdminQuery,
+      query: ADMIN_PROJECT_LIST,
+      pageSize: QUERY_LIMIT,
+      debounceMs: 1000,
+      defaultSort: [{ updated_at: order_by.desc }],
+      sortColumnMapper: (columnId) => {
+        const mapping: Record<string, string> = {
+          title: 'title',
+          status: 'status',
+        };
+        return mapping[columnId] || null;
+      },
+      refetchFilter: useCallback(
+        (searchTerm: string) => {
+          const conditions: Record<string, any>[] = [PROJECT_LIST_SCOPE_WHERE];
+          if (programFilter) {
+            conditions.push({ ProjectCourses: { Course: { programId: { _eq: Number(programFilter) } } } });
+          }
+          if (courseGroupFilter) {
+            conditions.push({
+              ProjectCourses: {
+                Course: { CourseGroups: { CourseGroupOption: { id: { _eq: Number(courseGroupFilter) } } } },
+              },
+            });
+          }
+          const searchCondition = createMultiWordSearchCondition(searchTerm, [
+            'title',
+            'description',
+            'ProjectAuthors.User.firstName',
+            'ProjectAuthors.User.lastName',
+            'ProjectAuthors.User.email',
+          ]);
+          if (Object.keys(searchCondition).length > 0) {
+            conditions.push(searchCondition);
+          }
+          return { where: { _and: conditions } };
+        },
+        [programFilter, courseGroupFilter]
+      ),
+    });
+
+  const projects: AdminProjectList_Project[] = useMemo(
+    () => (data as AdminProjectList | undefined)?.Project ?? [],
+    [data]
+  );
+  const totalCount = (data as AdminProjectList | undefined)?.Project_aggregate?.aggregate?.count || 0;
+
+  const [updateStatus] = useAdminMutation<UpdateProjectStatus, UpdateProjectStatusVariables>(
+    UPDATE_PROJECT_STATUS,
+    { refetchQueries: ['AdminProjectList'] }
+  );
+
+  const handleTogglePublish = useCallback(
+    async (project: AdminProjectList_Project) => {
+      const publishing = project.status !== ProjectStatus_enum.PUBLISHED;
+      // Unpublish reverts graded projects to COMPLETED and templates to PROPOSED.
+      const targetStatus = publishing
+        ? ProjectStatus_enum.PUBLISHED
+        : hasAcceptedAuthor(project)
+          ? ProjectStatus_enum.COMPLETED
+          : ProjectStatus_enum.PROPOSED;
+      try {
+        await updateStatus({ variables: { itemId: project.id, status: targetStatus } });
+        setSuccessMessage(publishing ? t('notifications.publish_success') : t('notifications.unpublish_success'));
+        setShowSuccessNotification(true);
+      } catch (err) {
+        console.error('Error updating project publication status:', err);
+        setErrorMessage(t('notifications.action_failed'));
+        setShowErrorNotification(true);
+      }
+    },
+    [updateStatus, t]
+  );
+
+  const handleProgramFilterChange = useCallback(
+    (value: string) => {
+      setProgramFilter(value);
+      setPageIndex(0);
+    },
+    [setPageIndex]
+  );
+
+  const handleCourseGroupFilterChange = useCallback(
+    (value: string) => {
+      setCourseGroupFilter(value);
+      setPageIndex(0);
+    },
+    [setPageIndex]
+  );
+
+  const columns = useMemo<ColumnDef<AdminProjectList_Project>[]>(
+    () => [
+      {
+        id: 'title',
+        header: t('table.title'),
+        accessorKey: 'title',
+        enableSorting: true,
+        size: 320,
+        minSize: 200,
+        cell: ({ row }) => (
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="font-medium">{row.original.title}</span>
+            <StatusChip
+              displayKey={getProjectStatusChipKey(row.original as ProjectRow)}
+              status={row.original.status}
+              ratingComment={row.original.ratingComment}
+            />
+          </div>
+        ),
+      },
+      {
+        id: 'authors',
+        header: t('table.authors'),
+        enableSorting: false,
+        size: 240,
+        cell: ({ row }) => {
+          const authors = getDisplayAuthors(row.original.ProjectAuthors, { includeExcluded: true });
+          if (authors.length === 0) {
+            return <span className="text-label-secondary">{t('table.no_authors')}</span>;
+          }
+          return (
+            <span>
+              {formatTruncatedList(authors, (a) =>
+                makeFullName(a.User?.firstName ?? '', a.User?.lastName ?? '')
+              )}
+            </span>
+          );
+        },
+      },
+      {
+        id: 'program',
+        header: t('table.program'),
+        enableSorting: false,
+        size: 200,
+        cell: ({ row }) => {
+          const course = row.original.ProjectCourses?.[0]?.Course;
+          if (!course) {
+            return <span className="text-label-secondary">—</span>;
+          }
+          const program = course.Program;
+          return (
+            <div className="flex flex-col">
+              <span className="font-medium">{program?.shortTitle || program?.title || '—'}</span>
+              <span className="text-xs text-label-secondary">{course.title}</span>
+            </div>
+          );
+        },
+      },
+      {
+        id: 'published',
+        header: t('table.published'),
+        enableSorting: false,
+        size: 160,
+        meta: { className: 'text-center' },
+        cell: ({ row }) => {
+          const project = row.original;
+          const published = project.status === ProjectStatus_enum.PUBLISHED;
+          // Leaving PROPOSED is rejected by the DB check constraint
+          // (Project_ongoing_requires_type_and_template_check) unless both a
+          // project type and a documentation instruction are set. Templates
+          // missing those therefore cannot be published yet.
+          const publishBlocked =
+            !published &&
+            project.status === ProjectStatus_enum.PROPOSED &&
+            (!project.type || project.documentationInstructionId == null);
+          const button = (
+            <Button
+              onClick={() => handleTogglePublish(project)}
+              disabled={publishBlocked}
+              className="w-full"
+            >
+              {published ? t('actions.unpublish') : t('actions.publish')}
+            </Button>
+          );
+          return (
+            <div className="flex flex-col items-center gap-2">
+              <span
+                className={`w-3 h-3 rounded-full ${published ? 'bg-green-500' : 'bg-gray-300'}`}
+                title={published ? t('table.published') : t('table.not_published')}
+              />
+              {publishBlocked ? (
+                <Tooltip title={t('actions.publish_blocked_incomplete')}>
+                  <span className="inline-flex w-full">{button}</span>
+                </Tooltip>
+              ) : (
+                button
+              )}
+            </div>
+          );
+        },
+      },
+    ],
+    [handleTogglePublish, t]
+  );
+
+  const expandableRowComponent = useCallback(
+    ({ row }: { row: AdminProjectList_Project }) => (
+      <div className="p-4">
+        <ProjectPreviewLayout
+          project={row as ProjectRow}
+          showResourceLinks={shouldShowProjectResourceDownloadLinks(row.status)}
+          includeExcludedAuthors
+          titleRow={
+            <div className="flex flex-wrap items-center gap-2 mb-1">
+              <h4 className="text-xl font-semibold text-label-primary min-w-0 break-words">{row.title}</h4>
+              <StatusChip
+                displayKey={getProjectStatusChipKey(row as ProjectRow)}
+                status={row.status}
+                ratingComment={row.ratingComment}
+              />
+            </div>
+          }
+        />
+      </div>
+    ),
+    []
+  );
+
+  return (
+    <div className="max-w-screen-xl mx-auto">
+      <CommonPageHeader headline={t('headline')} />
+
+      <div className="flex flex-col sm:flex-row gap-4 mb-4">
+        <DropDownSelector
+          variant="material"
+          label={t('filter.program_label')}
+          value={programFilter}
+          options={programOptions}
+          nullable
+          nullableLabel={t('filter.all_programs')}
+          onValueUpdated={handleProgramFilterChange}
+          className="min-w-[14rem]"
+        />
+        <DropDownSelector
+          variant="material"
+          label={t('filter.course_group_label')}
+          value={courseGroupFilter}
+          options={courseGroupOptions}
+          nullable
+          nullableLabel={t('filter.all_course_groups')}
+          onValueUpdated={handleCourseGroupFilterChange}
+          className="min-w-[14rem]"
+        />
+      </div>
+
+      <TableGrid<AdminProjectList_Project>
+        columns={columns}
+        data={projects}
+        loading={loading}
+        error={error}
+        enablePagination={true}
+        totalCount={totalCount}
+        pageIndex={pageIndex}
+        onPageChange={setPageIndex}
+        pageSize={QUERY_LIMIT}
+        searchFilter={searchFilter}
+        onSearchFilterChange={setSearchFilter}
+        sorting={sorting}
+        onSortingChange={setSorting}
+        refetchQueries={['AdminProjectList']}
+        expandableRowComponent={expandableRowComponent}
+        rounded
+      />
+
+      <NotificationSnackbar
+        open={showSuccessNotification}
+        onClose={() => setShowSuccessNotification(false)}
+        message={successMessage}
+        duration={4000}
+      />
+      <NotificationSnackbar
+        open={showErrorNotification}
+        onClose={() => setShowErrorNotification(false)}
+        message={errorMessage}
+        duration={6000}
+      />
+    </div>
+  );
+};
+
+export default ManageProjectsContent;

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -44,6 +44,7 @@
       "admin_users": "Admin-Benutzer",
       "experts": "Experten",
       "courses": "Kurse",
+      "projects": "Projekte",
       "programs": "Programme",
       "organizations": "Organisationen",
       "location_addresses": "Veranstaltungsadressen",
@@ -1719,6 +1720,34 @@
         "option_enabled": "Ja",
         "option_disabled": "Nein"
       }
+    }
+  },
+  "manageProjects": {
+    "headline": "Projekte",
+    "search_placeholder": "Projekte suchen",
+    "filter": {
+      "program_label": "Programm",
+      "all_programs": "Alle Programme",
+      "course_group_label": "Kursgruppe",
+      "all_course_groups": "Alle Kursgruppen"
+    },
+    "table": {
+      "title": "Titel",
+      "authors": "Autor:innen",
+      "no_authors": "Keine Autor:innen",
+      "program": "Programm / Kurs",
+      "published": "Veröffentlicht",
+      "not_published": "Nicht veröffentlicht"
+    },
+    "actions": {
+      "publish": "Veröffentlichen",
+      "unpublish": "Zurückziehen",
+      "publish_blocked_incomplete": "Bitte Projekttyp und Dokumentationsanleitung festlegen, bevor dieses Projekt veröffentlicht werden kann."
+    },
+    "notifications": {
+      "publish_success": "Projekt veröffentlicht",
+      "unpublish_success": "Projekt zurückgezogen",
+      "action_failed": "Die Aktion konnte nicht abgeschlossen werden. Bitte erneut versuchen."
     }
   },
   "managePrograms": {

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -44,6 +44,7 @@
       "admin_users": "Admin Users",
       "experts": "Experts",
       "courses": "Courses",
+      "projects": "Projects",
       "programs": "Programs",
       "organizations": "Organizations",
       "location_addresses": "Location Addresses",
@@ -1734,6 +1735,34 @@
         "option_enabled": "Yes",
         "option_disabled": "No"
       }
+    }
+  },
+  "manageProjects": {
+    "headline": "Projects",
+    "search_placeholder": "Search projects",
+    "filter": {
+      "program_label": "Program",
+      "all_programs": "All programs",
+      "course_group_label": "Course group",
+      "all_course_groups": "All course groups"
+    },
+    "table": {
+      "title": "Title",
+      "authors": "Authors",
+      "no_authors": "No authors",
+      "program": "Program / Course",
+      "published": "Published",
+      "not_published": "Not published"
+    },
+    "actions": {
+      "publish": "Publish",
+      "unpublish": "Unpublish",
+      "publish_blocked_incomplete": "Set a project type and documentation instruction before this project can be published."
+    },
+    "notifications": {
+      "publish_success": "Project published",
+      "unpublish_success": "Project unpublished",
+      "action_failed": "The action could not be completed. Please try again."
     }
   },
   "managePrograms": {

--- a/frontend-nx/apps/edu-hub/pages/manage/projects/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/projects/index.tsx
@@ -5,14 +5,11 @@ path.resolve('./next.config.js');
 import Head from 'next/head';
 import { FC } from 'react';
 import { Page } from '../../../components/layout/Page';
-import { useIsAdmin, useIsLoggedIn } from '../../../hooks/authentication';
+import { OnlyAdmin } from '../../../components/common/OnlyLoggedIn';
 
 import ManageProjectsContent from '../../../components/pages/ManageProjectsContent';
 
 const ManageProjects: FC = () => {
-  const isAdmin = useIsAdmin();
-  const isLoggedIn = useIsLoggedIn();
-
   return (
     <>
       <Head>
@@ -21,7 +18,11 @@ const ManageProjects: FC = () => {
       </Head>
       <div className="max-w-screen-xl mx-auto">
         <Page>
-          <div className="min-h-[77vh]">{isLoggedIn && isAdmin && <ManageProjectsContent />}</div>
+          <div className="min-h-[77vh]">
+            <OnlyAdmin showFeedback={true}>
+              <ManageProjectsContent />
+            </OnlyAdmin>
+          </div>
         </Page>
       </div>
     </>

--- a/frontend-nx/apps/edu-hub/pages/manage/projects/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/projects/index.tsx
@@ -1,0 +1,31 @@
+// do not remove this https://github.com/nrwl/nx/issues/9017#issuecomment-1140066503
+import path from 'path';
+path.resolve('./next.config.js');
+
+import Head from 'next/head';
+import { FC } from 'react';
+import { Page } from '../../../components/layout/Page';
+import { useIsAdmin, useIsLoggedIn } from '../../../hooks/authentication';
+
+import ManageProjectsContent from '../../../components/pages/ManageProjectsContent';
+
+const ManageProjects: FC = () => {
+  const isAdmin = useIsAdmin();
+  const isLoggedIn = useIsLoggedIn();
+
+  return (
+    <>
+      <Head>
+        <title>EduHub | opencampus.sh</title>
+        <link rel="icon" href="/favicon.png" />
+      </Head>
+      <div className="max-w-screen-xl mx-auto">
+        <Page>
+          <div className="min-h-[77vh]">{isLoggedIn && isAdmin && <ManageProjectsContent />}</div>
+        </Page>
+      </div>
+    </>
+  );
+};
+
+export default ManageProjects;

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminProjectList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminProjectList.ts
@@ -1,0 +1,315 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { Project_bool_exp, Project_order_by, ProjectStatus_enum, ProjectRating_enum, ProjectParticipationStatus_enum } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL query operation: AdminProjectList
+// ====================================================
+
+export interface AdminProjectList_Project_Organization {
+  __typename: "Organization";
+  id: number;
+  name: string;
+}
+
+export interface AdminProjectList_Project_ProjectType {
+  __typename: "ProjectType";
+  value: string;
+  /**
+   * When true, project.documentationUrl must be present before the project can be submitted.
+   */
+  requiresDocumentation: boolean;
+  /**
+   * When true, project.presentationUrl must be present before the project can be submitted.
+   */
+  requiresPresentation: boolean;
+  /**
+   * When true, project.externalUrl must be present before the project can be submitted (e.g. repository or live demo).
+   */
+  requiresExternalUrl: boolean;
+  /**
+   * When true, project.coverImageUrl must be present before submission and for showcase publication.
+   */
+  requiresCoverImage: boolean;
+}
+
+export interface AdminProjectList_Project_ProjectDocumentationInstruction {
+  __typename: "ProjectDocumentationInstruction";
+  id: number;
+  /**
+   * Admin-facing label in instruction dropdowns.
+   */
+  title: string;
+  /**
+   * Instruction PDF location: static app path (e.g. /project-documentation-instructions/…) or GCS object path after admin upload. Nullable until a file is attached.
+   */
+  url: string | null;
+}
+
+export interface AdminProjectList_Project_SubmittedByUser {
+  __typename: "User";
+  id: any;
+  /**
+   * The user's first name
+   */
+  firstName: string;
+  /**
+   * The user's last name
+   */
+  lastName: string;
+}
+
+export interface AdminProjectList_Project_ProjectAuthors_User_Organization {
+  __typename: "Organization";
+  id: number;
+  name: string;
+}
+
+export interface AdminProjectList_Project_ProjectAuthors_User {
+  __typename: "User";
+  id: any;
+  /**
+   * The user's first name
+   */
+  firstName: string;
+  /**
+   * The user's last name
+   */
+  lastName: string;
+  /**
+   * The user's profile picture
+   */
+  picture: string | null;
+  /**
+   * A link to an external profile, for example in LinkedIn or Xing
+   */
+  externalProfile: string | null;
+  /**
+   * An object relationship
+   */
+  Organization: AdminProjectList_Project_ProjectAuthors_User_Organization | null;
+}
+
+export interface AdminProjectList_Project_ProjectAuthors {
+  __typename: "ProjectAuthor";
+  id: number;
+  userId: any;
+  participationStatus: ProjectParticipationStatus_enum;
+  /**
+   * An object relationship
+   */
+  User: AdminProjectList_Project_ProjectAuthors_User;
+}
+
+export interface AdminProjectList_Project_ProjectMentors_User {
+  __typename: "User";
+  id: any;
+  /**
+   * The user's first name
+   */
+  firstName: string;
+  /**
+   * The user's last name
+   */
+  lastName: string;
+}
+
+export interface AdminProjectList_Project_ProjectMentors {
+  __typename: "ProjectMentor";
+  id: number;
+  /**
+   * FK to User.id of the mentor.
+   */
+  userId: any;
+  /**
+   * An object relationship
+   */
+  User: AdminProjectList_Project_ProjectMentors_User;
+}
+
+export interface AdminProjectList_Project_ProjectConsentEvents_ActorUser {
+  __typename: "User";
+  id: any;
+  /**
+   * The user's first name
+   */
+  firstName: string;
+  /**
+   * The user's last name
+   */
+  lastName: string;
+}
+
+export interface AdminProjectList_Project_ProjectConsentEvents {
+  __typename: "ProjectConsentEvent";
+  id: number;
+  eventType: string;
+  actorUserId: any;
+  created_at: any;
+  termsVersion: string;
+  /**
+   * An object relationship
+   */
+  ActorUser: AdminProjectList_Project_ProjectConsentEvents_ActorUser;
+}
+
+export interface AdminProjectList_Project_ProjectCourses_Course_Program {
+  __typename: "Program";
+  id: number;
+  title: string;
+  shortTitle: string | null;
+}
+
+export interface AdminProjectList_Project_ProjectCourses_Course_CourseGroups_CourseGroupOption {
+  __typename: "CourseGroupOption";
+  id: number;
+  title: string;
+}
+
+export interface AdminProjectList_Project_ProjectCourses_Course_CourseGroups {
+  __typename: "CourseGroup";
+  id: number;
+  /**
+   * An object relationship
+   */
+  CourseGroupOption: AdminProjectList_Project_ProjectCourses_Course_CourseGroups_CourseGroupOption;
+}
+
+export interface AdminProjectList_Project_ProjectCourses_Course {
+  __typename: "Course";
+  id: number;
+  title: string;
+  programId: number | null;
+  /**
+   * An object relationship
+   */
+  Program: AdminProjectList_Project_ProjectCourses_Course_Program | null;
+  /**
+   * An array relationship
+   */
+  CourseGroups: AdminProjectList_Project_ProjectCourses_Course_CourseGroups[];
+}
+
+export interface AdminProjectList_Project_ProjectCourses {
+  __typename: "ProjectCourse";
+  courseId: number;
+  /**
+   * An object relationship
+   */
+  Course: AdminProjectList_Project_ProjectCourses_Course;
+}
+
+export interface AdminProjectList_Project {
+  __typename: "Project";
+  id: number;
+  title: string;
+  tagline: string | null;
+  description: string | null;
+  coverImageUrl: string | null;
+  documentationUrl: string | null;
+  presentationUrl: string | null;
+  externalUrl: string | null;
+  /**
+   * FK to ProjectDocumentationInstruction.id. Must match Project.type (trigger Project_instruction_matches_type_trg). Instruction PDF describes deliverable composition; enforced uploads are only those required by the project type.
+   */
+  documentationInstructionId: number | null;
+  status: ProjectStatus_enum;
+  /**
+   * FK to ProjectType.value. Required with documentationInstructionId before leaving PROPOSED (check constraint). Drives mandatory deliverables and workflow (e.g. ONLINE_COURSE template claim may insert ONGOING directly).
+   */
+  type: string | null;
+  rating: ProjectRating_enum | null;
+  /**
+   * Optional comment from course staff or project mentor accompanying rating (UNRATED/PASSED/FAILED).
+   */
+  ratingComment: string | null;
+  /**
+   * Course staff flag: a completed project is suggested for showcase publication. Toggling this does not publish the project (status PUBLISHED is set separately).
+   */
+  suggestedForPublication: boolean;
+  acceptingParticipants: boolean;
+  organizationId: number | null;
+  proposedByUserId: any;
+  parentProjectId: number | null;
+  /**
+   * Timestamp at which the project most recently transitioned to SUBMITTED. Cleared when a reviewer sends the project back to ONGOING so the student-side "sent back for revisions" banner remains accurate.
+   */
+  submittedAt: any | null;
+  /**
+   * User who issued the most recent SUBMITTED transition. Set via a Hasura permission preset (x-hasura-user-id) so the client cannot impersonate another author.
+   */
+  submittedBy: any | null;
+  /**
+   * Timestamp when project authors asked course staff to review the proposed project (still PROPOSED until staff confirm the team).
+   */
+  projectReviewRequestedAt: any | null;
+  /**
+   * Optional per-project submission deadline. When null, the effective deadline is taken from the course (projectSubmissionDeadline) or program defaults.
+   */
+  submissionDeadline: any | null;
+  created_at: any;
+  updated_at: any;
+  /**
+   * An object relationship
+   */
+  Organization: AdminProjectList_Project_Organization | null;
+  /**
+   * An object relationship
+   */
+  ProjectType: AdminProjectList_Project_ProjectType | null;
+  /**
+   * An object relationship
+   */
+  ProjectDocumentationInstruction: AdminProjectList_Project_ProjectDocumentationInstruction | null;
+  /**
+   * An object relationship
+   */
+  SubmittedByUser: AdminProjectList_Project_SubmittedByUser | null;
+  /**
+   * An array relationship
+   */
+  ProjectAuthors: AdminProjectList_Project_ProjectAuthors[];
+  /**
+   * An array relationship
+   */
+  ProjectMentors: AdminProjectList_Project_ProjectMentors[];
+  /**
+   * An array relationship
+   */
+  ProjectConsentEvents: AdminProjectList_Project_ProjectConsentEvents[];
+  /**
+   * An array relationship
+   */
+  ProjectCourses: AdminProjectList_Project_ProjectCourses[];
+}
+
+export interface AdminProjectList_Project_aggregate_aggregate {
+  __typename: "Project_aggregate_fields";
+  count: number;
+}
+
+export interface AdminProjectList_Project_aggregate {
+  __typename: "Project_aggregate";
+  aggregate: AdminProjectList_Project_aggregate_aggregate | null;
+}
+
+export interface AdminProjectList {
+  /**
+   * fetch data from the table: "Project"
+   */
+  Project: AdminProjectList_Project[];
+  /**
+   * fetch aggregated fields from the table: "Project"
+   */
+  Project_aggregate: AdminProjectList_Project_aggregate;
+}
+
+export interface AdminProjectListVariables {
+  where?: Project_bool_exp | null;
+  order_by?: Project_order_by[] | null;
+  limit?: number | null;
+  offset?: number | null;
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateProjectStatus.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateProjectStatus.ts
@@ -1,0 +1,28 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { ProjectStatus_enum } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL mutation operation: UpdateProjectStatus
+// ====================================================
+
+export interface UpdateProjectStatus_update_Project_by_pk {
+  __typename: "Project";
+  id: number;
+  status: ProjectStatus_enum;
+}
+
+export interface UpdateProjectStatus {
+  /**
+   * update single row of the table: "Project"
+   */
+  update_Project_by_pk: UpdateProjectStatus_update_Project_by_pk | null;
+}
+
+export interface UpdateProjectStatusVariables {
+  itemId: number;
+  status: ProjectStatus_enum;
+}

--- a/frontend-nx/apps/edu-hub/queries/adminProjectList.ts
+++ b/frontend-nx/apps/edu-hub/queries/adminProjectList.ts
@@ -1,0 +1,67 @@
+import { gql } from '@apollo/client';
+import { PROJECT_FRAGMENT_DETAILED } from './project';
+
+// Cross-course project overview for the admin "/manage/projects" page.
+//
+// Reuses PROJECT_FRAGMENT_DETAILED (the same selection the course-page project
+// preview renders) and additionally pulls the owning course, its program and
+// course-group options so the list can show and be filtered by them.
+//
+// Author name / email search is applied through the `where` variable
+// (server-side, admin role) and therefore does NOT need to select the email
+// column — so the shared fragment stays usable under the user/anonymous roles
+// that lack the email column permission.
+export const ADMIN_PROJECT_LIST = gql`
+  ${PROJECT_FRAGMENT_DETAILED}
+  query AdminProjectList(
+    $where: Project_bool_exp
+    $order_by: [Project_order_by!]
+    $limit: Int
+    $offset: Int
+  ) {
+    Project(where: $where, order_by: $order_by, limit: $limit, offset: $offset) {
+      ...ProjectFragmentDetailed
+      ProjectCourses {
+        courseId
+        Course {
+          id
+          title
+          programId
+          Program {
+            id
+            title
+            shortTitle
+          }
+          CourseGroups {
+            id
+            CourseGroupOption {
+              id
+              title
+            }
+          }
+        }
+      }
+    }
+    Project_aggregate(where: $where) {
+      aggregate {
+        count
+      }
+    }
+  }
+`;
+
+// Generic status update used for both publish (status: PUBLISHED) and unpublish
+// (status reverted to COMPLETED for graded projects or PROPOSED for templates).
+// Admin-only page: the admin role bypasses Hasura row/column permissions, so a
+// direct status write is allowed and trips no Project triggers.
+export const UPDATE_PROJECT_STATUS = gql`
+  mutation UpdateProjectStatus($itemId: Int!, $status: ProjectStatus_enum!) {
+    update_Project_by_pk(
+      pk_columns: { id: $itemId }
+      _set: { status: $status }
+    ) {
+      id
+      status
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
This PR introduces a new admin-only project management page at `/manage/projects` that allows administrators to view, search, filter, and control the publication status of projects across the platform.

## Key Changes

- **New Admin Page**: Created `/manage/projects` page with role-based access control (admin-only)
- **Project Management Component**: Implemented `ManageProjectsContent` component featuring:
  - Paginated table view of projects with sortable columns (title, status)
  - Search functionality across project titles, descriptions, and author details
  - Filtering by program and course group
  - Expandable row details showing full project preview
  - Publish/unpublish toggle with validation (blocks publishing incomplete templates)
  - Status indicators and chips showing project state
  - Success/error notifications for user actions

- **GraphQL Queries & Mutations**:
  - `ADMIN_PROJECT_LIST`: Fetches projects with course, program, and course group information
  - `UPDATE_PROJECT_STATUS`: Mutation to update project publication status
  - Generated TypeScript types for both operations

- **Project Filtering Logic**: 
  - Displays PUBLISHED projects, COMPLETED non-online-course projects, and template projects (PROPOSED without accepted authors)
  - Unpublishing reverts graded projects to COMPLETED or templates to PROPOSED based on author status

- **Localization**: Added German and English translations for the new page including table headers, filter labels, action buttons, and notification messages

- **Navigation**: Added "Projects" menu item to admin navigation menu

## Implementation Details

- Reuses existing `PROJECT_FRAGMENT_DETAILED` for consistent project data selection
- Leverages `TableGrid` component for pagination, sorting, and search
- Implements proper error handling with user-facing notifications
- Validates project completeness before allowing publication (requires type and documentation instruction)
- Uses admin-authenticated queries/mutations with role-based access control

https://claude.ai/code/session_01DpFaN6MMVg8tQimDwXXGkU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an admin-only “Projects” entry to the navigation menu.
  * Introduced a manage-projects page with a searchable, filterable admin project table.
  * Enabled admins to publish/unpublish projects from the table, with publishing disabled for incomplete proposed projects (with an explanatory tooltip).
  * Improved the table with expandable project previews plus clearer title/status, authors, program, and publish-state controls.
* **Localization**
  * Added English and German UI strings for the new projects section and admin project management screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->