### PR TITLE
perf(keycloak): pre-build augmented image to skip startup augmentation

### DIFF
--- a/.cursor/rules/README.md
+++ b/.cursor/rules/README.md
@@ -66,6 +66,7 @@ This directory contains comprehensive development rules and guidelines for the E
 | Rule | Description | Applied When |
 |------|-------------|-------------|
 | [DevOps and Monitoring](devops-monitoring.mdc) | DevOps practices, monitoring, logging, deployment, and observability | Working with deployment, monitoring, or DevOps processes |
+| [Docker Image Rebuild Guard](docker-rebuild.mdc) | When `docker compose build` / `pull` / `restart` is required so containers don't run a stale image | Changing Dockerfiles, compose image tags, Keycloak providers/version, or serverless function dependencies |
 
 ### 🚀 Release Management
 | Rule | Description | Applied When |

--- a/.cursor/rules/docker-rebuild.mdc
+++ b/.cursor/rules/docker-rebuild.mdc
@@ -1,0 +1,56 @@
+---
+description: "Apply when changing Dockerfiles, docker-compose images, Keycloak providers/version, or serverless function dependencies — decides when `docker compose build` / pull / restart is required so containers don't run a stale image"
+globs: "docker-compose.yml,**/Dockerfile,**/Dockerfile-dev,keycloak/libs/**,keycloak/spi/**,functions/**,backend/dockerfile-dev-entrypoint.sh,backend/wait-for-it.sh,backend/config.yaml,frontend-nx/dev.sh"
+alwaysApply: false
+---
+# Docker image rebuild guard
+
+`docker compose up` only builds an image **if it does not already exist**. It
+does **not** detect Dockerfile or baked-content changes. So after changing
+anything that is baked into an image, the running stack will silently keep using
+the **old** image until you rebuild, pull, or restart the right service.
+
+After making a change, pick the matching action below and tell the user which
+command to run (and why).
+
+## Decision table
+
+| What you changed | Service | Required action |
+|---|---|---|
+| Any `Dockerfile` / `Dockerfile-dev` | that service | `docker compose build <svc>` then `up` (or `up --build`) |
+| `keycloak/libs/*.jar` (bcrypt, matrix-handle-listener) or the Keycloak image version | `keycloak` | **rebuild** — re-runs `kc.sh build` (the augmentation baked into the image) |
+| `keycloak/themes/**` | `keycloak` | **nothing** — themes are volume-mounted and theme caching is off, so they hot-reload |
+| `functions/Dockerfile` (Python base image / apt packages) | `python_functions` | **rebuild** |
+| `functions/**/requirements.txt` (pip deps) | `python_functions` | `docker compose restart python_functions` — pip installs at container start, no rebuild |
+| `functions/**` Node deps (`package.json`) | `node_functions` | `docker compose restart node_functions` — deps install at container start; this service has **no build context**, so `build` does nothing |
+| Pinned `image:` tag bump in `docker-compose.yml` (e.g. `node:22-bullseye`, `postgres:12`) | `node_functions`, `db_hasura` | `docker compose pull <svc>` then `docker compose up -d --force-recreate <svc>` — **not** `build` |
+| `backend/dockerfile-dev-entrypoint.sh`, `backend/wait-for-it.sh`, `backend/config.yaml` (COPY'd in `backend/Dockerfile-dev`) | `hasura` | **rebuild** |
+| `frontend-nx` deps (`package.json`) | `frontend-nx` | `docker compose restart frontend-nx` — `dev.sh` runs `yarn install` at start; only a base-image change needs a rebuild |
+| App code (`.ts`/`.tsx`, queries, metadata, migrations) | — | **nothing** — hot reload / Hasura CLI handles it |
+
+## Which services even have a build
+
+- **Build context** (rebuildable): `frontend-nx`, `hasura`, `python_functions`, `keycloak`.
+- **Pinned image, no build**: `node_functions` (`node:22-bullseye`), `db_hasura` (`postgres:12`). For these, "update the Node/Postgres version" means editing the `image:` tag and doing `pull` + `--force-recreate`, not `build`.
+
+## Commands
+
+```bash
+docker compose build <svc>                       # rebuild one image (layer cache keeps it cheap)
+docker compose up --build                         # rebuild any changed images, then start
+docker compose up -d --force-recreate --no-deps <svc>   # recreate one container from its current image
+docker compose pull <svc> && docker compose up -d --force-recreate <svc>  # adopt a new pinned image tag
+docker compose restart <svc>                      # re-run a container's start script (re-installs runtime deps)
+```
+
+## Notes
+
+- Docker's layer cache makes `--build` near-instant when nothing changed, so
+  recommending `docker compose up --build` as the default start command is a safe
+  habit that guarantees baked changes are picked up.
+- A bare `docker compose up` after a `git pull` can run a **stale** image. If a
+  teammate reports old behavior after pulling image-affecting changes, suspect a
+  missing `--build`.
+- Keycloak specifically: provider/version changes need a rebuild because the
+  Quarkus augmentation is baked in at build time (`start --optimized`); theme
+  edits do not.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,11 @@ Pre-existing repo issue: `yarn test` may fail with `Requires Babel "^7.22.0"`
    merges. Semantic-release only runs on pushes to `production`.
 8. **Branch flow**: `develop` → `staging` → `production`. Never edit version
    fields in any `package.json` or `CHANGELOG.md` by hand.
+9. **Docker image rebuilds**: `docker compose up` reuses an existing image and
+   does NOT detect Dockerfile/baked-content changes. After changing a
+   `Dockerfile`, Keycloak provider jars/version, a pinned `image:` tag, or
+   serverless function dependencies, run the right `build` / `pull` / `restart`
+   and tell the user. Full decision table: `.cursor/rules/docker-rebuild.mdc`.
 
 ## Behavioral guidelines (Karpathy)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,16 +163,21 @@ services:
       dockerfile: Dockerfile-dev
     entrypoint: ["/bin/sh", "-c"]
     command:
+      # --optimized reuses the augmentation baked into the image (see
+      # Dockerfile-dev), skipping the ~90s Quarkus build on every startup.
+      # The SPI theme-cache flags keep live theme reloading that `start-dev`
+      # used to provide automatically.
       - >-
         unset KC_BOOTSTRAP_ADMIN_USERNAME KC_BOOTSTRAP_ADMIN_PASSWORD &&
-        /opt/keycloak/bin/kc.sh import --file /opt/keycloak/data/import/master.json --override true &&
-        exec /opt/keycloak/bin/kc.sh start-dev --import-realm
+        /opt/keycloak/bin/kc.sh import --optimized --file /opt/keycloak/data/import/master.json --override true &&
+        exec /opt/keycloak/bin/kc.sh start --optimized --import-realm --spi-theme-cache-themes=false --spi-theme-cache-templates=false
     ports:
       - 28080:8080
     environment:
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       KC_HOSTNAME_STRICT: "false"
+      KC_HTTP_ENABLED: "true"
       KC_HTTP_HOST: "0.0.0.0"
     volumes:
       - ./keycloak/imports-dev/master.json:/opt/keycloak/data/import/master.json

--- a/keycloak/Dockerfile-dev
+++ b/keycloak/Dockerfile-dev
@@ -10,13 +10,13 @@ COPY ./themes/edu-hub /opt/keycloak/themes/edu-hub
 RUN /opt/keycloak/bin/kc.sh build
 
 FROM quay.io/keycloak/keycloak:26.6.1
-COPY --from=builder /opt/keycloak/lib/quarkus/ /opt/keycloak/lib/quarkus/
-COPY ./libs/keycloak-bcrypt-1.6.0.jar /opt/keycloak/providers/
-COPY ./libs/matrix-handle-listener.jar /opt/keycloak/providers/
+# Copy the full pre-built (augmented) server so `start --optimized` can skip the
+# Quarkus augmentation at runtime instead of rebuilding on every container boot.
+COPY --from=builder /opt/keycloak/ /opt/keycloak/
 WORKDIR /opt/keycloak
 
 ENV KC_HOSTNAME_STRICT=false
 ENV KC_HTTP_ENABLED=true
 ENV KC_HTTP_HOST=0.0.0.0
 
-ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start-dev", "--import-realm"]
+ENTRYPOINT ["/opt/keycloak/bin/kc.sh", "start", "--optimized", "--import-realm"]


### PR DESCRIPTION
## Summary

- Pre-build the augmented Keycloak server in `keycloak/Dockerfile-dev` (copy the full `/opt/keycloak/` from the builder stage) and run `import`/`start` with `--optimized`, so the ~90s Quarkus augmentation no longer runs on every container boot. Local Keycloak startup dropped from **~6 min to ~1 min**.
- Because Keycloak is now ready well within Hasura's 400s `wait-for-it` window, this fixes the startup race where Hasura failed to fetch the JWK from Keycloak and was left `unhealthy` (causing the app's initial page load to hang).
- Switched `start-dev` → `start --optimized`; added `KC_HTTP_ENABLED` (prod-mode `start` doesn't auto-enable HTTP) and `--spi-theme-cache-themes/templates=false` to preserve live theme reloading.
- Added a `docker-rebuild` Cursor rule (+ `AGENTS.md` note and README index entry) documenting when a `build` / `pull` / `restart` is required after image-affecting changes — including the Keycloak provider/version case and the serverless function dependency cases.

## Notes

- Since the augmentation is baked at build time, picking up the change requires a one-time `docker compose build keycloak` (or `docker compose up --build`). Theme edits still hot-reload (volume-mounted, caching disabled).
- Verified locally: Keycloak JWKS endpoint returns `200`, Hasura `/healthz` returns `200` (healthy), no augmentation passes in the Keycloak logs.

## Test plan

- [ ] `docker compose up --build` from repo root
- [ ] Keycloak reaches `Listening on: http://0.0.0.0:8080` in ~1 min (no "installing your custom providers" augmentation in logs)
- [ ] `curl http://localhost:8080/healthz` → 200 (Hasura healthy, no JWK error)
- [ ] App initial page load works; login via Keycloak succeeds
- [ ] Edit a file under `keycloak/themes/**` and confirm it hot-reloads without a rebuild

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keycloak now starts in optimized mode with realm import enabled, improving startup consistency.
  * Docker rebuild guidance was added to help ensure image and service changes take effect correctly.

* **Bug Fixes**
  * Reduced the risk of running stale container images after updates to Docker, Keycloak, or serverless dependencies.
  * Updated Keycloak startup behavior to better support built-in themes and imported realms.

* **Documentation**
  * Added clear rebuild/restart instructions and examples for common Docker-related change scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->