### PR TITLE
fix: defer project author deadline trigger (fix self-propose creation)

### DIFF
--- a/backend/migrations/default/1783022127000_defer_project_author_deadline_trigger/down.sql
+++ b/backend/migrations/default/1783022127000_defer_project_author_deadline_trigger/down.sql
@@ -1,0 +1,12 @@
+-- Revert to the immediate BEFORE INSERT deadline gate.
+
+DROP TRIGGER IF EXISTS "project_author_after_insert_reject_join_after_deadline"
+  ON public."ProjectAuthor";
+
+DROP TRIGGER IF EXISTS "project_author_before_insert_reject_join_after_deadline"
+  ON public."ProjectAuthor";
+
+CREATE TRIGGER "project_author_before_insert_reject_join_after_deadline"
+BEFORE INSERT ON public."ProjectAuthor"
+FOR EACH ROW
+EXECUTE PROCEDURE public.reject_project_author_join_after_submission_deadline();

--- a/backend/migrations/default/1783022127000_defer_project_author_deadline_trigger/up.sql
+++ b/backend/migrations/default/1783022127000_defer_project_author_deadline_trigger/up.sql
@@ -1,0 +1,27 @@
+-- Hotfix: self-propose project creation failed with
+-- 'project_submission_deadline_passed' even when the deadline was open.
+--
+-- Cause: the deadline gate ran as an immediate BEFORE INSERT trigger on
+-- ProjectAuthor. During self-propose creation the frontend sends a single
+-- nested Hasura insert (Project + ProjectAuthor + ProjectCourse). The
+-- ProjectAuthor row is inserted before its sibling ProjectCourse row, so the
+-- trigger's "is there a linked course with an open deadline?" lookup found no
+-- ProjectCourse row yet and raised the exception.
+--
+-- Fix: keep the same logic/function but defer the check to transaction commit
+-- using a DEFERRABLE INITIALLY DEFERRED constraint trigger. By commit time both
+-- the ProjectAuthor and ProjectCourse rows exist in the same transaction, so the
+-- linked-course deadline lookup is correct for creation, join requests, and
+-- genuine after-deadline attempts alike.
+
+DROP TRIGGER IF EXISTS "project_author_before_insert_reject_join_after_deadline"
+  ON public."ProjectAuthor";
+
+DROP TRIGGER IF EXISTS "project_author_after_insert_reject_join_after_deadline"
+  ON public."ProjectAuthor";
+
+CREATE CONSTRAINT TRIGGER "project_author_after_insert_reject_join_after_deadline"
+AFTER INSERT ON public."ProjectAuthor"
+DEFERRABLE INITIALLY DEFERRED
+FOR EACH ROW
+EXECUTE PROCEDURE public.reject_project_author_join_after_submission_deadline();


### PR DESCRIPTION
## Summary
- Self-proposing a project failed with a `project_submission_deadline_passed` check-constraint violation **even when the course submission deadline was open** (reproduced with course 632, effective deadline 2026-08-01).
- Root cause: the deadline gate was an **immediate `BEFORE INSERT` trigger** on `ProjectAuthor`. During self-propose creation the frontend sends one nested Hasura insert (`Project` + `ProjectAuthor` + `ProjectCourse`). The `ProjectAuthor` row is inserted before its sibling `ProjectCourse` row, so the trigger's "is there a linked course with an open deadline?" lookup found no `ProjectCourse` row yet and raised the exception. Regression introduced by `1779600000000_block_self_propose_after_submission_deadline` (which added the `ACCEPTED` self-propose path).
- Fix: convert the gate into a `DEFERRABLE INITIALLY DEFERRED` **constraint trigger** so it evaluates at transaction commit, when both the `ProjectAuthor` and `ProjectCourse` rows exist. The `reject_project_author_join_after_submission_deadline()` function logic is unchanged.

Trigger-only change: no Hasura metadata, GraphQL document, or generated-type changes required.

## Test plan
- [ ] Apply migration on staging (`hasura migrate apply`).
- [ ] Self-propose a project on a course with an **open** deadline → succeeds.
- [ ] Self-propose a project on a course with a **passed** deadline → still blocked with `project_submission_deadline_passed`.
- [ ] Request to join (`REQUESTED`) an existing project after the deadline → still blocked (unchanged behavior).
- [ ] `hasura migrate apply --down 1` restores the previous `BEFORE INSERT` trigger cleanly.

Made with [Cursor](https://cursor.com)