### PR TITLE
Improve menu link click targets with better padding

### DIFF
--- a/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
+++ b/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
@@ -88,20 +88,20 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
       }}
     >
       <MenuItem onClick={closeMenu} selected={isActiveRoute('/profile')}>
-        <Link className="w-full text-lg" href="/profile">
+        <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/profile">
           {t('menu.profile')}
         </Link>
       </MenuItem>
 
       <MenuItem onClick={closeMenu} selected={isActiveRoute('/my-certificates')}>
-        <Link className="w-full text-lg" href="/my-certificates">
+        <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/my-certificates">
           {t('menu.my_certificates')}
         </Link>
       </MenuItem>
 
       {isAdminOrOrgAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/courses')}>
-          <Link className="w-full text-lg" href="/manage/courses">
+          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/courses">
             {t('menu.courses')}
           </Link>
         </MenuItem>
@@ -109,7 +109,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/projects')}>
-          <Link className="w-full text-lg" href="/manage/projects">
+          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/projects">
             {t('menu.projects')}
           </Link>
         </MenuItem>
@@ -117,7 +117,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/users')}>
-          <Link className="w-full text-lg" href="/manage/users">
+          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/users">
             {t('menu.user')}
           </Link>
         </MenuItem>
@@ -125,7 +125,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/experts')}>
-          <Link className="w-full text-lg" href="/manage/experts">
+          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/experts">
             {t('menu.experts')}
           </Link>
         </MenuItem>
@@ -133,7 +133,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/organizations')}>
-          <Link className="w-full text-lg" href="/manage/organizations">
+          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/organizations">
             {t('menu.organizations')}
           </Link>
         </MenuItem>
@@ -141,7 +141,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/location-addresses')}>
-          <Link className="w-full text-lg" href="/manage/location-addresses">
+          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/location-addresses">
             {t('menu.location_addresses')}
           </Link>
         </MenuItem>
@@ -149,7 +149,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/calendar')}>
-          <Link className="w-full text-lg" href="/manage/calendar">
+          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/calendar">
             {t('menu.calendar')}
           </Link>
         </MenuItem>
@@ -157,7 +157,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/statistics')}>
-          <Link className="w-full text-lg" href="/statistics">
+          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/statistics">
             {t('menu.statistics')}
           </Link>
         </MenuItem>
@@ -168,7 +168,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
           onClick={closeMenu}
           selected={isActiveRoute('/manage/settings') || router.pathname.startsWith('/manage/settings/')}
         >
-          <Link className="w-full text-lg" href="/manage/settings">
+          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/settings">
             {t('menu.settings')}
           </Link>
         </MenuItem>
@@ -177,7 +177,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
       {isInstructorOrAdmin && (
         <MenuItem onClick={closeMenu}>
           <Link
-            className="w-full text-lg"
+            className="block -my-3 -mx-4 py-3 px-4 text-lg"
             href="https://opencampus.gitbook.io/kursleitungshandbuch/"
             target="_blank"
             rel="noopener noreferrer"
@@ -188,7 +188,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
       )}
 
       <MenuItem onClick={closeMenu}>
-        <Link className="w-full text-lg" href="https://opencampus.gitbook.io/faq/" target="_blank">
+        <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="https://opencampus.gitbook.io/faq/" target="_blank">
           {t('menu.faq')}
         </Link>
       </MenuItem>


### PR DESCRIPTION
## Summary
Updated all menu link styles to improve clickability and user experience by expanding the interactive area of menu items.

## Key Changes
- Replaced `w-full` class with `block -my-3 -mx-4 py-3 px-4` on all menu Link components
- Applied consistent styling across 13 menu items (profile, certificates, courses, projects, users, experts, organizations, locations, calendar, statistics, settings, instructor handbook, and FAQ)
- The new approach uses negative margins to extend the clickable area beyond the text, while maintaining proper padding for visual spacing

## Implementation Details
The change transforms the link styling from a simple full-width approach to a more sophisticated padding/margin strategy:
- `block`: Makes the link a block-level element for proper spacing
- `-my-3 -mx-4`: Negative margins extend the clickable area
- `py-3 px-4`: Positive padding creates visual spacing around the text
- `text-lg`: Maintains the existing large text size

This pattern is applied consistently across all menu navigation items, improving the overall usability of the menu interface.

https://claude.ai/code/session_01X6MALxNZEdVzdLa1oUqkaf