### PR TITLE
Add ESLint configuration for StuJo app

### DIFF
--- a/frontend-nx/apps/stujo/.eslintrc.json
+++ b/frontend-nx/apps/stujo/.eslintrc.json
@@ -1,0 +1,25 @@
+{
+  "extends": [
+    "next", // Base Next.js rules
+    "next/core-web-vitals", // Next.js recommended rules including React Hooks
+    "../../.eslintrc.json" // Extend from the shared root configuration
+  ],
+  "ignorePatterns": [".next", "next-env.d.ts"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {
+        // Off: StuJo intentionally links to /api/auth/* endpoints with plain
+        // <a> tags, which must be full-page navigations rather than <Link />.
+        "@next/next/no-html-link-for-pages": "off",
+        "@next/next/no-img-element": "off",
+        "react/react-in-jsx-scope": "off",
+        "react/prop-types": "off",
+        "@typescript-eslint/no-require-imports": "off"
+      }
+    }
+  ],
+  "rules": {
+    "@next/next/no-html-link-for-pages": "off"
+  }
+}


### PR DESCRIPTION
## Summary
Added a new ESLint configuration file for the StuJo application that extends Next.js and shared root ESLint rules with app-specific overrides.

## Key Changes
- Created `.eslintrc.json` for the StuJo app with:
  - Extension of Next.js base rules and core web vitals recommendations
  - Extension of the shared root ESLint configuration
  - Configured ignore patterns for Next.js generated files (`.next`, `next-env.d.ts`)
  - Disabled `@next/next/no-html-link-for-pages` rule to allow plain `<a>` tags for full-page navigation to `/api/auth/*` endpoints
  - Disabled additional rules for `@next/next/no-img-element`, `react/react-in-jsx-scope`, `react/prop-types`, and `@typescript-eslint/no-require-imports`

## Implementation Details
The configuration includes a documented exception for the `no-html-link-for-pages` rule, explaining that StuJo intentionally uses plain HTML anchor tags for authentication endpoints that require full-page navigation rather than client-side routing via Next.js `<Link />` component.

https://claude.ai/code/session_01N17VEPR8DguAtK2BScWkDR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added project-specific linting configuration for the StuJo application.
  * Improved code-quality checks across application scripts and templates.
  * Reduced unnecessary lint warnings for supported authentication links, images, JSX, and TypeScript patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->