### PR TITLE
feat(stujo): interim white-label portal hosts on opencampus.sh

### DIFF
--- a/infrastructure/application/00_variables.tf
+++ b/infrastructure/application/00_variables.tf
@@ -13,6 +13,27 @@ locals {
   # stujo-staging.opencampus.sh (staging); override via var.stujo_domain.
   stujo_service_name = "${var.stujo_service_name_root}${var.service_name_extension}"
   stujo_domain       = var.stujo_domain != "" ? var.stujo_domain : "${local.stujo_service_name}.opencampus.sh"
+
+  # Interim white-label StuJo portals. Each portal is served by its own tiny
+  # Cloud Run service (same image, scales to zero) so the load balancer
+  # url_mask can route <service>.opencampus.sh to it. The service sets
+  # APP_NAME, which apps/stujo/lib/portal.ts uses to resolve the portal
+  # branding without an AppSettings.domain match. This makes every portal
+  # testable under stujo-<portal>.opencampus.sh (production) and
+  # stujo-<portal>-staging.opencampus.sh (staging, via
+  # service_name_extension) before the real stujo.net domains are migrated.
+  #
+  # The map key is the portal appName and MUST exist in the AppSettings /
+  # JobPortal seed data (see backend/migrations .../insert_stujo_app_settings
+  # and .../create_table_public_JobPortal). The root "stujo" portal is served
+  # by the google_cloud_run_service.stujo resource, so it is not repeated here.
+  stujo_portal_app_names = ["stujo-cau", "stujo-haw-kiel", "stujo-flensburg"]
+  stujo_portals = {
+    for app_name in local.stujo_portal_app_names : app_name => {
+      service_name = "${app_name}${var.service_name_extension}"
+      domain       = "${app_name}${var.service_name_extension}.opencampus.sh"
+    }
+  }
 }
 
 ######

--- a/infrastructure/application/02_network.tf
+++ b/infrastructure/application/02_network.tf
@@ -70,7 +70,22 @@ module "lb-http" {
   name    = "load-balancer"
   project = var.project_id
 
-  # Create Google-managed SSL certificates for the specified domains. 
+  # Create Google-managed SSL certificates for the specified domains.
+  #
+  # This is a single multi-SAN managed cert. A managed cert's domain list is
+  # immutable, so changing it (e.g. adding the stujo portal hosts below)
+  # provisions a brand-new cert; random_certificate_suffix + the module's
+  # create-before-destroy make the swap gap-free. The new cert only reaches
+  # ACTIVE once EVERY listed domain validates, and validation requires each
+  # domain's Cloudflare A record (created further down from this LB's IP) to
+  # resolve to the LB. Those records depend on module.lb-http.external_ip, so
+  # they can only be created after this module — the cert cannot be ordered
+  # to wait for them. This is self-healing (GCP retries validation; Cloudflare
+  # propagates in seconds), but the practical consequence when applying a
+  # domain change is a provisioning window (can be tens of minutes) during
+  # which the affected hosts serve no valid HTTPS. Apply domain changes in a
+  # low-traffic window and confirm the new cert is ACTIVE and the new records
+  # resolve before treating the new hosts as live.
   ssl                             = "true"
   managed_ssl_certificate_domains = concat(["${local.keycloak_service_name}.opencampus.sh", "${local.hasura_service_name}.opencampus.sh", "${local.eduhub_service_name}.opencampus.sh", "${local.eduhub_api_service_name}.opencampus.sh", local.stujo_domain], [for portal in local.stujo_portals : portal.domain])
   https_redirect                  = "true"

--- a/infrastructure/application/02_network.tf
+++ b/infrastructure/application/02_network.tf
@@ -72,7 +72,7 @@ module "lb-http" {
 
   # Create Google-managed SSL certificates for the specified domains. 
   ssl                             = "true"
-  managed_ssl_certificate_domains = ["${local.keycloak_service_name}.opencampus.sh", "${local.hasura_service_name}.opencampus.sh", "${local.eduhub_service_name}.opencampus.sh", "${local.eduhub_api_service_name}.opencampus.sh", local.stujo_domain]
+  managed_ssl_certificate_domains = concat(["${local.keycloak_service_name}.opencampus.sh", "${local.hasura_service_name}.opencampus.sh", "${local.eduhub_service_name}.opencampus.sh", "${local.eduhub_api_service_name}.opencampus.sh", local.stujo_domain], [for portal in local.stujo_portals : portal.domain])
   https_redirect                  = "true"
   random_certificate_suffix       = "true"
 
@@ -146,6 +146,19 @@ resource "cloudflare_record" "eduhub_api" {
 resource "cloudflare_record" "stujo" {
   zone_id = var.cloudflare_zone_id
   name    = trimsuffix(local.stujo_domain, ".opencampus.sh")
+  type    = "A"
+  value   = module.lb-http.external_ip
+}
+
+# Add domain records for the interim white-label StuJo portal hosts on
+# opencampus.sh (stujo-<portal>[-staging].opencampus.sh). Each maps to its
+# own Cloud Run service via the load balancer url_mask (see
+# local.stujo_portals in 00_variables.tf and 08_stujo.tf).
+resource "cloudflare_record" "stujo_portals" {
+  for_each = local.stujo_portals
+
+  zone_id = var.cloudflare_zone_id
+  name    = trimsuffix(each.value.domain, ".opencampus.sh")
   type    = "A"
   value   = module.lb-http.external_ip
 }

--- a/infrastructure/application/08_stujo.tf
+++ b/infrastructure/application/08_stujo.tf
@@ -117,3 +117,129 @@ resource "google_cloud_run_service" "stujo" {
     google_secret_manager_secret_version.keycloak_hasura_client_secret,
   ]
 }
+
+# Apply the public (no-auth) invoker policy to each white-label portal service.
+resource "google_cloud_run_service_iam_policy" "stujo_portal_noauth_invoker" {
+  for_each = google_cloud_run_service.stujo_portals
+
+  location    = each.value.location
+  project     = each.value.project
+  service     = each.value.name
+  policy_data = data.google_iam_policy.noauth_invoker.policy_data
+}
+
+# Per-portal StuJo Cloud Run services (see local.stujo_portals in
+# 00_variables.tf). Each is a copy of the root stujo service above that only
+# differs in name (so the load balancer url_mask routes its
+# <service>.opencampus.sh host here) and APP_NAME (which selects the portal
+# branding in apps/stujo/lib/portal.ts). Interim aliases on opencampus.sh so
+# each portal is testable before the stujo.net domains are migrated.
+resource "google_cloud_run_service" "stujo_portals" {
+  for_each = local.stujo_portals
+
+  provider = google-beta
+  name     = each.value.service_name
+  location = var.region
+
+  template {
+    spec {
+      containers {
+        image = "${var.region}-docker.pkg.dev/${var.project_id}/docker-repo/stujo:latest"
+
+        ports {
+          name           = "http1"
+          container_port = 5001
+        }
+        env {
+          name  = "STUJO_SHA"
+          value = var.frontend_sha
+        }
+        env {
+          name  = "GRAPHQL_URI"
+          value = "https://${local.hasura_service_name}.opencampus.sh/v1/graphql"
+        }
+        # Server-side (SSR) GraphQL endpoint for the public pages
+        env {
+          name  = "API_URL"
+          value = "https://${local.hasura_service_name}.opencampus.sh/v1/graphql"
+        }
+        env {
+          name  = "NEXTAUTH_URL"
+          value = "https://${each.value.domain}"
+        }
+        # Portal selector: resolvePortal() falls back to APP_NAME when the
+        # request host has no AppSettings.domain match.
+        env {
+          name  = "APP_NAME"
+          value = each.key
+        }
+        env {
+          name = "HASURA_ADMIN_SECRET"
+          value_from {
+            secret_key_ref {
+              name = google_secret_manager_secret.hasura_graphql_admin_key.secret_id
+              key  = "latest"
+            }
+          }
+        }
+        env {
+          name = "NEXTAUTH_SECRET"
+          value_from {
+            secret_key_ref {
+              name = google_secret_manager_secret.nextauth_secret.secret_id
+              key  = "latest"
+            }
+          }
+        }
+        env {
+          name = "KEYCLOAK_HASURA_CLIENT_SECRET"
+          value_from {
+            secret_key_ref {
+              name = google_secret_manager_secret.keycloak_hasura_client_secret.secret_id
+              key  = "latest"
+            }
+          }
+        }
+        env {
+          name  = "ENVIRONMENT"
+          value = var.environment
+        }
+        env {
+          name  = "STORAGE_BUCKET_URL"
+          value = "https://storage.googleapis.com/storage/v1/${var.project_id}"
+        }
+        env {
+          name  = "NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY"
+          value = var.stripe_publishable_key
+        }
+      }
+    }
+
+    metadata {
+      annotations = {
+        "autoscaling.knative.dev/minScale" = "0"
+        "autoscaling.knative.dev/maxScale" = "1"
+      }
+    }
+  }
+
+  metadata {
+    annotations = {
+      "run.googleapis.com/launch-stage"     = "BETA"
+      "run.googleapis.com/startupProbeType" = null
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations,
+    ]
+  }
+
+  autogenerate_revision_name = true
+  depends_on = [
+    google_secret_manager_secret_version.hasura_graphql_admin_key,
+    google_secret_manager_secret_version.nextauth_secret,
+    google_secret_manager_secret_version.keycloak_hasura_client_secret,
+  ]
+}


### PR DESCRIPTION
## Summary
- Each StuJo white-label portal (CAU, HAW Kiel, Flensburg) gets its own host: `stujo-<portal>.opencampus.sh` (production) / `stujo-<portal>-staging.opencampus.sh` (staging), so portal branding is testable end-to-end before the `stujo.net` domains are migrated.
- Implemented as per-portal Cloud Run services (`for_each` over a new `local.stujo_portals` map): same `stujo` image, scale-to-zero, `APP_NAME` set to the portal appName. This matches the load balancer's `url_mask` host→service routing, so no LB restructuring is needed.
- Adds the new hosts to the managed SSL certificate list and creates Cloudflare A records pointing at the load balancer IP.

No frontend or database changes: `resolvePortal()` already falls back to `APP_NAME`, and the seeded `stujo.net` domains in `AppSettings` stay untouched for the future DNS cutover. Interim scaffolding — intended to be removed when the `stujo.net` migration lands (see follow-up PR introducing `JobPortalDomain`).

## Test plan
- [ ] CI `terraform fmt -check` / `validate` pass (could not run Terraform locally)
- [ ] `terraform plan` on staging shows only: 3 new Cloud Run services + IAM policies, 3 Cloudflare records, cert domain additions
- [ ] After staging apply: `https://stujo-flensburg-staging.opencampus.sh` serves the Flensburg branding (blue/orange, Flensburg logo); CAU and HAW hosts likewise
- [ ] Root portal unchanged under `https://stujo-staging.opencampus.sh`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interim white-label StuJo portals with dedicated portal domains.
  * Added secure HTTPS certificates and DNS routing for each portal.
  * Added independently deployed portal services with customized branding and portal URLs.
  * Enabled public access to portal services for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->