### PR TITLE
feat(stujo): JobPortalDomain table for multi-host portal resolution

### DIFF
--- a/backend/metadata/databases/default/tables/public_JobPortalDomain.yaml
+++ b/backend/metadata/databases/default/tables/public_JobPortalDomain.yaml
@@ -1,0 +1,26 @@
+table:
+  name: JobPortalDomain
+  schema: public
+object_relationships:
+  - name: AppSetting
+    using:
+      foreign_key_constraint_on: appName
+select_permissions:
+  - role: anonymous
+    permission:
+      columns:
+        - appName
+        - hostname
+      filter: {}
+  - role: user_access
+    permission:
+      columns:
+        - appName
+        - hostname
+      filter: {}
+  - role: org_admin_access
+    permission:
+      columns:
+        - appName
+        - hostname
+      filter: {}

--- a/backend/metadata/databases/default/tables/tables.yaml
+++ b/backend/metadata/databases/default/tables/tables.yaml
@@ -36,6 +36,7 @@
 - "!include public_JobAlertSubscription.yaml"
 - "!include public_JobOccupation.yaml"
 - "!include public_JobPortal.yaml"
+- "!include public_JobPortalDomain.yaml"
 - "!include public_JobPosting.yaml"
 - "!include public_JobPostingCredit.yaml"
 - "!include public_JobPostingPrice.yaml"

--- a/backend/migrations/default/1784400000000_create_table_public_JobPortalDomain/down.sql
+++ b/backend/migrations/default/1784400000000_create_table_public_JobPortalDomain/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE "public"."JobPortalDomain";

--- a/backend/migrations/default/1784400000000_create_table_public_JobPortalDomain/up.sql
+++ b/backend/migrations/default/1784400000000_create_table_public_JobPortalDomain/up.sql
@@ -1,0 +1,51 @@
+-- Hostname → portal mapping for the StuJo white-label job board. A single
+-- portal (AppSettings row) can be reached under MANY hostnames at once:
+-- legacy stujo.net subdomains plus the interim opencampus.sh aliases. This
+-- supersedes the single-valued "AppSettings"."domain" column as the primary
+-- portal-resolution source; that column stays for now as a legacy fallback.
+CREATE TABLE "public"."JobPortalDomain" (
+  "id"         serial      NOT NULL,
+  "appName"    text        NOT NULL,
+  "hostname"   text        NOT NULL,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "updated_at" timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY ("id"),
+  UNIQUE ("hostname")
+);
+
+COMMENT ON TABLE "public"."JobPortalDomain" IS E'Maps request hostnames to StuJo portals (many hostnames per portal); supersedes the single "AppSettings"."domain" column, which remains as a legacy fallback.';
+COMMENT ON COLUMN "public"."JobPortalDomain"."hostname" IS 'Lowercase request host (no port) that resolves to this portal';
+
+ALTER TABLE "public"."JobPortalDomain"
+  ADD CONSTRAINT "JobPortalDomain_appName_fkey"
+  FOREIGN KEY ("appName") REFERENCES "public"."AppSettings"("appName")
+  ON UPDATE RESTRICT ON DELETE CASCADE;
+
+CREATE INDEX "JobPortalDomain_appName_idx" ON "public"."JobPortalDomain" ("appName");
+
+CREATE TRIGGER "set_public_JobPortalDomain_updated_at"
+BEFORE UPDATE ON "public"."JobPortalDomain"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."set_current_timestamp_updated_at"();
+
+-- Seed hostname mappings. Staging rows are inert in production and the
+-- production opencampus.sh rows are inert on staging; both are seeded here
+-- because migrations run in every environment.
+INSERT INTO "public"."JobPortalDomain" ("hostname", "appName") VALUES
+  -- Legacy stujo.net hosts
+  ('stujo.net', 'stujo'),
+  ('www.stujo.net', 'stujo'),
+  ('cau.stujo.net', 'stujo-cau'),
+  ('haw-kiel.stujo.net', 'stujo-haw-kiel'),
+  ('fh-kiel.stujo.net', 'stujo-haw-kiel'),
+  ('flensburg.stujo.net', 'stujo-flensburg'),
+  -- Interim opencampus.sh aliases (production)
+  ('stujo.opencampus.sh', 'stujo'),
+  ('stujo-cau.opencampus.sh', 'stujo-cau'),
+  ('stujo-haw-kiel.opencampus.sh', 'stujo-haw-kiel'),
+  ('stujo-flensburg.opencampus.sh', 'stujo-flensburg'),
+  -- Interim opencampus.sh aliases (staging)
+  ('stujo-staging.opencampus.sh', 'stujo'),
+  ('stujo-cau-staging.opencampus.sh', 'stujo-cau'),
+  ('stujo-haw-kiel-staging.opencampus.sh', 'stujo-haw-kiel'),
+  ('stujo-flensburg-staging.opencampus.sh', 'stujo-flensburg');

--- a/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
+++ b/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
@@ -1390,6 +1390,36 @@ export enum JobRegion_update_column {
 }
 
 /**
+ * unique or primary key constraints on table "JobSliderJobType"
+ */
+export enum JobSliderJobType_constraint {
+  JobSliderJobType_jobSliderOptionId_jobType_key = "JobSliderJobType_jobSliderOptionId_jobType_key",
+  JobSliderJobType_pkey = "JobSliderJobType_pkey",
+}
+
+/**
+ * select columns of table "JobSliderJobType"
+ */
+export enum JobSliderJobType_select_column {
+  created_at = "created_at",
+  id = "id",
+  jobSliderOptionId = "jobSliderOptionId",
+  jobType = "jobType",
+  updated_at = "updated_at",
+}
+
+/**
+ * update columns of table "JobSliderJobType"
+ */
+export enum JobSliderJobType_update_column {
+  created_at = "created_at",
+  id = "id",
+  jobSliderOptionId = "jobSliderOptionId",
+  jobType = "jobType",
+  updated_at = "updated_at",
+}
+
+/**
  * unique or primary key constraints on table "Language"
  */
 export enum Language_constraint {
@@ -5153,6 +5183,8 @@ export interface CourseGroupOption_bool_exp {
   ProgramType?: ProgramType_bool_exp | null;
   SelectedCourseGroups?: ProjectSliderCourseGroup_bool_exp | null;
   SelectedCourseGroups_aggregate?: ProjectSliderCourseGroup_aggregate_bool_exp | null;
+  SelectedJobTypes?: JobSliderJobType_bool_exp | null;
+  SelectedJobTypes_aggregate?: JobSliderJobType_aggregate_bool_exp | null;
   SelectedProjectGroups?: ProjectSliderProjectGroup_bool_exp | null;
   SelectedProjectGroups_aggregate?: ProjectSliderProjectGroup_aggregate_bool_exp | null;
   _and?: CourseGroupOption_bool_exp[] | null;
@@ -5177,6 +5209,7 @@ export interface CourseGroupOption_insert_input {
   Organization?: Organization_obj_rel_insert_input | null;
   ProgramType?: ProgramType_obj_rel_insert_input | null;
   SelectedCourseGroups?: ProjectSliderCourseGroup_arr_rel_insert_input | null;
+  SelectedJobTypes?: JobSliderJobType_arr_rel_insert_input | null;
   SelectedProjectGroups?: ProjectSliderProjectGroup_arr_rel_insert_input | null;
   contentType?: string | null;
   created_at?: any | null;
@@ -7772,6 +7805,63 @@ export interface JobRegion_on_conflict {
   constraint: JobRegion_constraint;
   update_columns: JobRegion_update_column[];
   where?: JobRegion_bool_exp | null;
+}
+
+export interface JobSliderJobType_aggregate_bool_exp {
+  count?: JobSliderJobType_aggregate_bool_exp_count | null;
+}
+
+export interface JobSliderJobType_aggregate_bool_exp_count {
+  arguments?: JobSliderJobType_select_column[] | null;
+  distinct?: boolean | null;
+  filter?: JobSliderJobType_bool_exp | null;
+  predicate: Int_comparison_exp;
+}
+
+/**
+ * input type for inserting array relation for remote table "JobSliderJobType"
+ */
+export interface JobSliderJobType_arr_rel_insert_input {
+  data: JobSliderJobType_insert_input[];
+  on_conflict?: JobSliderJobType_on_conflict | null;
+}
+
+/**
+ * Boolean expression to filter rows from the table "JobSliderJobType". All fields are combined with a logical 'AND'.
+ */
+export interface JobSliderJobType_bool_exp {
+  JobPostingType?: JobPostingType_bool_exp | null;
+  JobSliderOption?: CourseGroupOption_bool_exp | null;
+  _and?: JobSliderJobType_bool_exp[] | null;
+  _not?: JobSliderJobType_bool_exp | null;
+  _or?: JobSliderJobType_bool_exp[] | null;
+  created_at?: timestamptz_comparison_exp | null;
+  id?: Int_comparison_exp | null;
+  jobSliderOptionId?: Int_comparison_exp | null;
+  jobType?: JobPostingType_enum_comparison_exp | null;
+  updated_at?: timestamptz_comparison_exp | null;
+}
+
+/**
+ * input type for inserting data into table "JobSliderJobType"
+ */
+export interface JobSliderJobType_insert_input {
+  JobPostingType?: JobPostingType_obj_rel_insert_input | null;
+  JobSliderOption?: CourseGroupOption_obj_rel_insert_input | null;
+  created_at?: any | null;
+  id?: number | null;
+  jobSliderOptionId?: number | null;
+  jobType?: JobPostingType_enum | null;
+  updated_at?: any | null;
+}
+
+/**
+ * on_conflict condition type for table "JobSliderJobType"
+ */
+export interface JobSliderJobType_on_conflict {
+  constraint: JobSliderJobType_constraint;
+  update_columns: JobSliderJobType_update_column[];
+  where?: JobSliderJobType_bool_exp | null;
 }
 
 /**

--- a/frontend-nx/apps/edu-hub/queries/__generated__/AdminJobSliders.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/AdminJobSliders.ts
@@ -12,6 +12,9 @@ import { JobPostingType_enum } from "./../../__generated__/globalTypes";
 export interface AdminJobSliders_CourseGroupOption_SelectedJobTypes {
   __typename: "JobSliderJobType";
   id: number;
+  /**
+   * The JobPostingType value this job slider pulls postings from.
+   */
   jobType: JobPostingType_enum;
 }
 

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CourseGroupOptions.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CourseGroupOptions.ts
@@ -24,6 +24,9 @@ export interface CourseGroupOptions_CourseGroupOption_SelectedProjectGroups {
 export interface CourseGroupOptions_CourseGroupOption_SelectedJobTypes {
   __typename: "JobSliderJobType";
   id: number;
+  /**
+   * The JobPostingType value this job slider pulls postings from.
+   */
   jobType: JobPostingType_enum;
 }
 
@@ -37,7 +40,7 @@ export interface CourseGroupOptions_CourseGroupOption {
    */
   sliderGroup: boolean | null;
   /**
-   * Whether this slider row renders courses (COURSE, default) or projects (PROJECT). PROJECT rows compose their membership from the ProjectSliderCourseGroup / ProjectSliderProjectGroup selections.
+   * Whether this slider row renders courses (COURSE, default), projects (PROJECT) or jobs (JOB). PROJECT rows compose their membership from the ProjectSliderCourseGroup / ProjectSliderProjectGroup selections. JOB rows compose their membership from the JobSliderJobType selections.
    */
   contentType: string;
   /**

--- a/frontend-nx/apps/edu-hub/queries/__generated__/HomeJobTilesAll.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/HomeJobTilesAll.ts
@@ -13,6 +13,9 @@ export interface HomeJobTilesAll_JobPosting_Organization {
   __typename: "Organization";
   id: number;
   name: string;
+  /**
+   * Path to the organization logo image file
+   */
   logo: string | null;
 }
 

--- a/frontend-nx/apps/edu-hub/queries/__generated__/HomeJobTilesByOrganization.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/HomeJobTilesByOrganization.ts
@@ -13,6 +13,9 @@ export interface HomeJobTilesByOrganization_JobPosting_Organization {
   __typename: "Organization";
   id: number;
   name: string;
+  /**
+   * Path to the organization logo image file
+   */
   logo: string | null;
 }
 

--- a/frontend-nx/apps/edu-hub/queries/__generated__/HomeJobTilesByTypes.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/HomeJobTilesByTypes.ts
@@ -13,6 +13,9 @@ export interface HomeJobTilesByTypes_JobPosting_Organization {
   __typename: "Organization";
   id: number;
   name: string;
+  /**
+   * Path to the organization logo image file
+   */
   logo: string | null;
 }
 

--- a/frontend-nx/apps/edu-hub/queries/__generated__/JobTileFragment.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/JobTileFragment.ts
@@ -13,6 +13,9 @@ export interface JobTileFragment_Organization {
   __typename: "Organization";
   id: number;
   name: string;
+  /**
+   * Path to the organization logo image file
+   */
   logo: string | null;
 }
 

--- a/frontend-nx/apps/stujo/lib/portal.ts
+++ b/frontend-nx/apps/stujo/lib/portal.ts
@@ -5,9 +5,12 @@ import { fetchAnonymous } from './hasura';
  *
  * Portals are a BRANDING dimension only — all portals share one job pool
  * (see docs/STUJO_INTEGRATION_PLAN.md §2.4). The request host is resolved
- * to a JobPortal row (via AppSettings.domain), falling back to the
- * APP_NAME env var and finally to the root `stujo` portal, so local dev
- * and single-domain deployments work without special DNS.
+ * to a JobPortal row in this order:
+ *   1. JobPortalDomain.hostname (primary source — many hostnames per portal)
+ *   2. AppSettings.domain (legacy single-domain fallback)
+ *   3. the APP_NAME env var
+ *   4. the root `stujo` portal
+ * so local dev and single-domain deployments work without special DNS.
  */
 
 export type PortalBranding = {
@@ -33,6 +36,10 @@ const PORTAL_QUERY = /* GraphQL */ `
       contactEmail
       defaultRegion
     }
+    JobPortalDomain {
+      appName
+      hostname
+    }
     AppSettings {
       appName
       domain
@@ -54,6 +61,10 @@ type PortalQueryResult = {
     contactEmail: string | null;
     defaultRegion: string | null;
   }[];
+  JobPortalDomain: {
+    appName: string;
+    hostname: string;
+  }[];
   AppSettings: {
     appName: string;
     domain: string | null;
@@ -72,8 +83,10 @@ export async function resolvePortal(host: string | undefined): Promise<PortalBra
   const data = await fetchAnonymous<PortalQueryResult>(PORTAL_QUERY);
 
   const hostname = (host || '').split(':')[0].toLowerCase();
+  const domainMapping = data.JobPortalDomain.find((d) => d.hostname === hostname);
   const settingsByDomain = data.AppSettings.find((s) => s.domain === hostname);
-  const appName = settingsByDomain?.appName || FALLBACK_APP_NAME;
+  const appName =
+    domainMapping?.appName || settingsByDomain?.appName || FALLBACK_APP_NAME;
 
   const portal =
     data.JobPortal.find((p) => p.appName === appName) ||

--- a/frontend-nx/apps/stujo/lib/portal.ts
+++ b/frontend-nx/apps/stujo/lib/portal.ts
@@ -11,6 +11,10 @@ import { fetchAnonymous } from './hasura';
  *   3. the APP_NAME env var
  *   4. the root `stujo` portal
  * so local dev and single-domain deployments work without special DNS.
+ *
+ * The JobPortalDomain lookup (step 1) is best-effort: if that table is not
+ * yet available it is skipped and resolution continues from step 2, so a
+ * frontend deployed ahead of its migration degrades gracefully.
  */
 
 export type PortalBranding = {
@@ -36,10 +40,6 @@ const PORTAL_QUERY = /* GraphQL */ `
       contactEmail
       defaultRegion
     }
-    JobPortalDomain {
-      appName
-      hostname
-    }
     AppSettings {
       appName
       domain
@@ -53,6 +53,19 @@ const PORTAL_QUERY = /* GraphQL */ `
   }
 `;
 
+// Queried separately from PORTAL_QUERY (and best-effort — see
+// fetchPortalDomains) so that a frontend deployed ahead of the
+// JobPortalDomain migration/metadata degrades to legacy resolution instead
+// of failing every SSR page.
+const PORTAL_DOMAIN_QUERY = /* GraphQL */ `
+  query PortalDomains {
+    JobPortalDomain {
+      appName
+      hostname
+    }
+  }
+`;
+
 type PortalQueryResult = {
   JobPortal: {
     slug: string;
@@ -60,10 +73,6 @@ type PortalQueryResult = {
     appName: string;
     contactEmail: string | null;
     defaultRegion: string | null;
-  }[];
-  JobPortalDomain: {
-    appName: string;
-    hostname: string;
   }[];
   AppSettings: {
     appName: string;
@@ -77,13 +86,45 @@ type PortalQueryResult = {
   }[];
 };
 
+type PortalDomain = {
+  appName: string;
+  hostname: string;
+};
+
+type PortalDomainQueryResult = {
+  JobPortalDomain: PortalDomain[];
+};
+
+/**
+ * Best-effort hostname → portal mapping. Returns an empty list (rather than
+ * throwing) when the JobPortalDomain table/metadata is not yet available —
+ * e.g. this image deployed ahead of its Hasura migration — so portal
+ * resolution falls back to AppSettings.domain / APP_NAME instead of 500ing
+ * every SSR page during the deploy window.
+ */
+async function fetchPortalDomains(): Promise<PortalDomain[]> {
+  try {
+    const data = await fetchAnonymous<PortalDomainQueryResult>(PORTAL_DOMAIN_QUERY);
+    return data.JobPortalDomain ?? [];
+  } catch (error) {
+    console.warn(
+      'resolvePortal: JobPortalDomain lookup failed, falling back to legacy resolution',
+      error
+    );
+    return [];
+  }
+}
+
 const FALLBACK_APP_NAME = process.env.APP_NAME || 'stujo';
 
 export async function resolvePortal(host: string | undefined): Promise<PortalBranding> {
-  const data = await fetchAnonymous<PortalQueryResult>(PORTAL_QUERY);
+  const [data, portalDomains] = await Promise.all([
+    fetchAnonymous<PortalQueryResult>(PORTAL_QUERY),
+    fetchPortalDomains(),
+  ]);
 
   const hostname = (host || '').split(':')[0].toLowerCase();
-  const domainMapping = data.JobPortalDomain.find((d) => d.hostname === hostname);
+  const domainMapping = portalDomains.find((d) => d.hostname === hostname);
   const settingsByDomain = data.AppSettings.find((s) => s.domain === hostname);
   const appName =
     domainMapping?.appName || settingsByDomain?.appName || FALLBACK_APP_NAME;


### PR DESCRIPTION
## Summary
- New `JobPortalDomain` table (many hostnames per portal, `appName` FK → `AppSettings`, unique `hostname`) replacing the one-domain-per-portal limitation of `AppSettings.domain`. Seeds all `stujo.net` hosts (apex, www, cau, haw-kiel + legacy fh-kiel alias, flensburg) plus the production and staging `opencampus.sh` portal aliases (rows for the other environment are inert).
- Hasura metadata: table tracked with select permissions for `anonymous`, `user_access`, `org_admin_access` on `appName`/`hostname` only (public SSR pages must resolve portals logged out; no admin permissions per repo convention).
- `resolvePortal()` in `apps/stujo` now resolves the request host in this order: `JobPortalDomain.hostname` → legacy `AppSettings.domain` → `APP_NAME` env → root `stujo` portal. Return shape unchanged.
- Separate `chore:` commit: previously uncommitted generated-type drift from the `JobSliderJobType` migration, surfaced by the mandatory type regeneration (no `JobPortalDomain`-related type changes; the stujo app uses raw queries).

Groundwork for the `stujo.net` DNS migration: staging and production now use the same data-driven host resolution, differing only in seeded rows. `AppSettings.domain` stays as a deprecated fallback until cutover cleanup.

## Test plan
- [x] Migration + metadata applied on the local stack (`hasura migrate apply` / `metadata apply`)
- [x] Anonymous GraphQL query (no admin secret) returns all 14 seeded rows — public permission verified
- [x] Function impact scan: no `functions/` consumer of `JobPortalDomain` or `AppSettings.domain`
- [ ] Local branding check: `/etc/hosts` entry `127.0.0.1 flensburg.stujo.net`, then `http://flensburg.stujo.net:5001` shows Flensburg branding
- [ ] Staging: `stujo-*-staging.opencampus.sh` hosts resolve portals via `JobPortalDomain` (requires the portal-hosts infra PR #1794)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hostname-based portal resolution for supported domains and aliases.
  * Added seeded mappings for production and staging portal hostnames.
  * Portal branding now selects the appropriate application based on the incoming hostname.

* **Improvements**
  * Added fallback resolution using existing domain settings or the configured default portal.
  * Portal loading remains resilient when hostname mappings are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->