### PR TITLE
feat(stujo): staging ETL runner + native relative bucket paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,7 @@ next-env.d.ts
 keycloak/spi/*/target/
 # Python bytecode
 __pycache__/
+
+# Local, untracked source-side config for the StuJo ETL wrapper
+# (MySQL DSN, Rails files root, Keycloak admin user). Never commit.
+scripts/.stujo_etl_source.env

--- a/scripts/stujo_etl.py
+++ b/scripts/stujo_etl.py
@@ -505,16 +505,22 @@ def step_companies(hasura: HasuraClient, gcs_bucket, files_root, companies) -> d
             # 'terwixonse') merge into one Organization; record this row's
             # legacy alias too so old URLs keep redirecting.
             mapping[c["id"]] = org["id"]
-            if legacy_alias not in (org.get("aliases") or []):
+            aliases = org.get("aliases") or []
+            if legacy_alias not in aliases:
+                # Compute the new array client-side and _set it: some orgs have
+                # aliases = null, and Postgres `null || jsonb` is null, so a
+                # Hasura _append would silently drop the alias (and .append on
+                # None would crash).
+                new_aliases = aliases + [legacy_alias]
                 hasura.mutate(
                     """
-                    mutation ($id: Int!, $alias: jsonb!) {
-                      update_Organization_by_pk(pk_columns: {id: $id}, _append: {aliases: $alias}) { id }
+                    mutation ($id: Int!, $aliases: jsonb!) {
+                      update_Organization_by_pk(pk_columns: {id: $id}, _set: {aliases: $aliases}) { id }
                     }
                     """,
-                    {"id": org["id"], "alias": [legacy_alias]},
+                    {"id": org["id"], "aliases": new_aliases},
                 )
-                org.setdefault("aliases", []).append(legacy_alias)
+                org["aliases"] = new_aliases
                 by_alias[legacy_alias] = org
             # Backfill a logo onto a matched org that has none (repairs a prior
             # run whose upload failed after the insert; fills a null logo on a

--- a/scripts/stujo_etl.py
+++ b/scripts/stujo_etl.py
@@ -37,7 +37,6 @@ import re
 import sys
 import unicodedata
 from datetime import datetime, timedelta, timezone
-from urllib.parse import quote
 
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
 log = logging.getLogger("stujo-etl")
@@ -488,7 +487,7 @@ def load_source(cnx, retention_years=None):
 def step_companies(hasura: HasuraClient, gcs_bucket, files_root, companies) -> dict:
     """Companies → Organization (CORPORATION). Returns rails_id → org_id."""
     existing = hasura.query(
-        """query { Organization { id name aliases } }"""
+        """query { Organization { id name aliases logo } }"""
     )["Organization"]
     by_norm = {normalize_company_name(o["name"]): o for o in existing}
     by_alias = {}
@@ -517,10 +516,18 @@ def step_companies(hasura: HasuraClient, gcs_bucket, files_root, companies) -> d
                 )
                 org.setdefault("aliases", []).append(legacy_alias)
                 by_alias[legacy_alias] = org
+            # Backfill a logo onto a matched org that has none (repairs a prior
+            # run whose upload failed after the insert; fills a null logo on a
+            # name-matched pre-existing org). Never overwrites an existing logo.
+            if org.get("logo") is None:
+                logo_path = copy_paperclip_logo(gcs_bucket, files_root, org["id"], c)
+                if logo_path:
+                    _set_org_logo(hasura, org["id"], logo_path)
+                    org["logo"] = logo_path
+                    log.info("company %s: backfilled logo on Organization %s", c["id"], org["id"])
             log.info("company %s → existing Organization %s (%s)", c["id"], org["id"], org["name"])
             continue
 
-        logo_url = copy_paperclip_logo(gcs_bucket, files_root, c)
         address_line = " ".join(filter(None, [c.get("street"), c.get("nr")])) or None
         result = hasura.mutate(
             """
@@ -534,7 +541,6 @@ def step_companies(hasura: HasuraClient, gcs_bucket, files_root, companies) -> d
                     "type": "CORPORATION",
                     "description": c.get("description"),
                     "website": normalize_website(c.get("url")),
-                    "logo": logo_url,
                     "addressLine1": address_line,
                     "postalCode": c.get("zip"),
                     "city": c.get("city"),
@@ -544,27 +550,40 @@ def step_companies(hasura: HasuraClient, gcs_bucket, files_root, companies) -> d
         )
         org_id = result["insert_Organization_one"]["id"] if result else -c["id"]
         mapping[c["id"]] = org_id
+        # The logo path needs the new org id, so upload + set it after the
+        # insert (organizations/org-<id>/public/logo/...); in a dry run the
+        # same call is only a pre-flight file check and returns None.
+        logo_path = copy_paperclip_logo(gcs_bucket, files_root, org_id, c)
+        if logo_path:
+            _set_org_logo(hasura, org_id, logo_path)
         # Register the new org in the dedupe maps so later duplicate rows
         # in the same run merge instead of violating Organization_name_key.
-        created = {"id": org_id, "name": c["name"], "aliases": [legacy_alias]}
+        created = {"id": org_id, "name": c["name"], "aliases": [legacy_alias], "logo": logo_path}
         by_norm[norm] = created
         by_alias[legacy_alias] = created
         log.info("company %s '%s' → new Organization %s", c["id"], c["name"], org_id)
     return mapping
 
 
-def public_gcs_url(bucket_name: str, blob_name: str) -> str:
-    """Percent-encoded public URL — legacy Paperclip filenames contain
-    spaces/umlauts, which are valid blob names but not valid URL paths."""
-    return f"https://storage.googleapis.com/{bucket_name}/{quote(blob_name)}"
+def safe_filename(name: str) -> str:
+    """URL-clean leaf/object name. Legacy Paperclip filenames carry spaces and
+    umlauts; the frontend builds file URLs by plain concatenation without
+    percent-encoding (resolveStorageUrl / getPublicUrl), so the stored path
+    must already be URL-safe. One file lives per folder here, so slugifying
+    the stem can't collide."""
+    stem, ext = os.path.splitext(name)
+    return f"{slugify(stem) or 'file'}{ext.lower()}"
 
 
-def copy_paperclip_logo(gcs_bucket, files_root, company) -> str | None:
-    """Copy public/system/logos/:id/original/:filename to GCS.
+def copy_paperclip_logo(gcs_bucket, files_root, org_id, company) -> str | None:
+    """Copy system/logos/:id/original/:filename to
+    organizations/org-<org_id>/public/logo/<file> and return the bucket-
+    RELATIVE path — the native EduHub layout for org logos, keyed by the new
+    Organization.id. The frontend prefixes NEXT_PUBLIC_STORAGE_BUCKET_URL.
 
     Dry runs (gcs_bucket None) still verify the file on disk and feed
-    FILE_STATS when STUJO_FILES_ROOT is set, so a dry run doubles as a
-    pre-flight check of the rsynced Rails public/ dir; only uploads skip.
+    FILE_STATS, so a dry run doubles as a pre-flight check of the rsynced
+    Rails public/ dir; only the upload is skipped.
     """
     if not company.get("logo_file_name") or not files_root:
         return None
@@ -579,14 +598,19 @@ def copy_paperclip_logo(gcs_bucket, files_root, company) -> str | None:
     FILE_STATS["logos_copied"] += 1
     if gcs_bucket is None:  # dry run
         return None
-    blob_name = f"stujo/logos/{company['id']}/{company['logo_file_name']}"
-    blob = gcs_bucket.blob(blob_name)
-    blob.upload_from_filename(src)
-    return public_gcs_url(gcs_bucket.name, blob_name)
+    blob_name = f"organizations/org-{org_id}/public/logo/{safe_filename(company['logo_file_name'])}"
+    # public-read ACL so the object resolves anonymously (bucket UBLA is OFF
+    # and has no allUsers binding — visibility is per object), matching how the
+    # app serves its own uploads under a /public/ path segment.
+    gcs_bucket.blob(blob_name).upload_from_filename(src, predefined_acl="publicRead")
+    return blob_name
 
 
-def copy_paperclip_pdf(gcs_bucket, files_root, job) -> str | None:
-    """Copy the Paperclip job PDF (default id_partition path) to GCS.
+def copy_paperclip_pdf(gcs_bucket, files_root, job_posting_id, job) -> str | None:
+    """Copy the Paperclip job PDF to
+    jobpostings/jobposting-<job_posting_id>/public/<file> and return the
+    bucket-RELATIVE path — the same layout the dashboard uploader
+    (saveJobPostingPdf) writes, keyed by the new JobPosting.id.
 
     Same dry-run/pre-flight semantics as copy_paperclip_logo.
     """
@@ -604,10 +628,31 @@ def copy_paperclip_pdf(gcs_bucket, files_root, job) -> str | None:
     FILE_STATS["pdfs_copied"] += 1
     if gcs_bucket is None:  # dry run
         return None
-    blob_name = f"stujo/job-pdfs/{job['id']}/{job['pdf_file_name']}"
-    blob = gcs_bucket.blob(blob_name)
-    blob.upload_from_filename(src)
-    return public_gcs_url(gcs_bucket.name, blob_name)
+    blob_name = f"jobpostings/jobposting-{job_posting_id}/public/{safe_filename(job['pdf_file_name'])}"
+    gcs_bucket.blob(blob_name).upload_from_filename(src, predefined_acl="publicRead")
+    return blob_name
+
+
+def _set_org_logo(hasura: "HasuraClient", org_id: int, path: str) -> None:
+    hasura.mutate(
+        """
+        mutation ($id: Int!, $logo: String!) {
+          update_Organization_by_pk(pk_columns: {id: $id}, _set: {logo: $logo}) { id }
+        }
+        """,
+        {"id": org_id, "logo": path},
+    )
+
+
+def _set_job_pdf(hasura: "HasuraClient", posting_id: int, path: str) -> None:
+    hasura.mutate(
+        """
+        mutation ($id: Int!, $url: String!) {
+          update_JobPosting_by_pk(pk_columns: {id: $id}, _set: {pdfUrl: $url}) { id }
+        }
+        """,
+        {"id": posting_id, "url": path},
+    )
 
 
 def step_users(hasura: HasuraClient, keycloak, contacts, org_mapping) -> dict:
@@ -737,16 +782,9 @@ def step_jobs(hasura: HasuraClient, gcs_bucket, files_root, jobs, org_mapping,
         prior = existing.get(j["id"])
         if prior:
             if prior["pdfUrl"] is None and j.get("pdf_file_name"):
-                pdf_url = copy_paperclip_pdf(gcs_bucket, files_root, j)
-                if pdf_url:
-                    hasura.mutate(
-                        """
-                        mutation ($id: Int!, $url: String!) {
-                          update_JobPosting_by_pk(pk_columns: {id: $id}, _set: {pdfUrl: $url}) { id }
-                        }
-                        """,
-                        {"id": prior["id"], "url": pdf_url},
-                    )
+                pdf_path = copy_paperclip_pdf(gcs_bucket, files_root, prior["id"], j)
+                if pdf_path:
+                    _set_job_pdf(hasura, prior["id"], pdf_path)
                     log.info("job %s: backfilled missing pdfUrl on JobPosting %s",
                              j["id"], prior["id"])
             continue
@@ -795,7 +833,7 @@ def step_jobs(hasura: HasuraClient, gcs_bucket, files_root, jobs, org_mapping,
         # (unique constraint JobPostingTag_jobPostingId_name_key).
         tags = list(dict.fromkeys(t for t in (j.get("tag_names") or "").split("|||") if t))
 
-        hasura.mutate(
+        result = hasura.mutate(
             """
             mutation ($obj: JobPosting_insert_input!) {
               insert_JobPosting_one(object: $obj) { id }
@@ -827,7 +865,6 @@ def step_jobs(hasura: HasuraClient, gcs_bucket, files_root, jobs, org_mapping,
                     "international": bool(j.get("international")),
                     "internationalDescription": j.get("international_description"),
                     "customCompany": j.get("custom_Company"),
-                    "pdfUrl": copy_paperclip_pdf(gcs_bucket, files_root, j),
                     "views": j.get("views") or 0,
                     "restrictedToOrganizationId": restricted_to,
                     # Legacy archived jobs were once live, so publishedAt is
@@ -838,6 +875,13 @@ def step_jobs(hasura: HasuraClient, gcs_bucket, files_root, jobs, org_mapping,
                 }
             },
         )
+        posting_id = result["insert_JobPosting_one"]["id"] if result else None
+        # The PDF path needs the new posting id, so upload + set it after the
+        # insert (jobpostings/jobposting-<id>/public/...), matching the
+        # dashboard uploader; a dry run only pre-flights the file (returns None).
+        pdf_path = copy_paperclip_pdf(gcs_bucket, files_root, posting_id, j)
+        if posting_id is not None and pdf_path:
+            _set_job_pdf(hasura, posting_id, pdf_path)
         log.info("job %s '%s' → JobPosting (%s)", j["id"], j["title"], status)
 
 

--- a/scripts/stujo_etl_staging.sh
+++ b/scripts/stujo_etl_staging.sh
@@ -46,10 +46,19 @@ export KEYCLOAK_USER="${KEYCLOAK_USER:-admin}"
 SOURCE_ENV="${STUJO_ETL_SOURCE_ENV:-${SCRIPT_DIR}/.stujo_etl_source.env}"
 if [[ -f "${SOURCE_ENV}" ]]; then
   echo "Loading source config from ${SOURCE_ENV}"
+  # The file may only provide source-side variables (STUJO_MYSQL_DSN,
+  # STUJO_FILES_ROOT, KEYCLOAK_USER, …); it must not be able to silently
+  # redirect the privileged ETL to another target environment, so the staging
+  # target settings configured above are restored after sourcing.
+  _hasura_url="${HASURA_URL}" _keycloak_url="${KEYCLOAK_URL}"
+  _keycloak_realm="${KEYCLOAK_REALM}" _gcs_bucket="${GCS_BUCKET}"
   set -a
   # shellcheck disable=SC1090
   source "${SOURCE_ENV}"
   set +a
+  export HASURA_URL="${_hasura_url}" KEYCLOAK_URL="${_keycloak_url}"
+  export KEYCLOAK_REALM="${_keycloak_realm}" GCS_BUCKET="${_gcs_bucket}"
+  unset _hasura_url _keycloak_url _keycloak_realm _gcs_bucket
 fi
 
 # ---- Fetch staging secrets from Secret Manager (never persisted) -----------
@@ -68,8 +77,9 @@ fetch_secret() {
 }
 
 echo "Fetching staging secrets from Secret Manager (${GCP_PROJECT})…"
-export HASURA_ADMIN_SECRET="$(fetch_secret hasura-graphql-admin-key)"
-export KEYCLOAK_PW="$(fetch_secret keycloak-pw)"
+HASURA_ADMIN_SECRET="$(fetch_secret hasura-graphql-admin-key)"
+KEYCLOAK_PW="$(fetch_secret keycloak-pw)"
+export HASURA_ADMIN_SECRET KEYCLOAK_PW
 
 # ---- Validate the source-side inputs ---------------------------------------
 missing=()
@@ -100,7 +110,7 @@ Target (staging):
   HASURA_URL   ${HASURA_URL}
   KEYCLOAK_URL ${KEYCLOAK_URL} (realm ${KEYCLOAK_REALM}, user ${KEYCLOAK_USER})
   GCS_BUCKET   ${GCS_BUCKET}
-  source DSN   ${STUJO_MYSQL_DSN%%@*}@… (host hidden)
+  source DSN   mysql://[redacted]@${STUJO_MYSQL_DSN##*@}
   files root   ${STUJO_FILES_ROOT}
   etl args     $*
 EOF

--- a/scripts/stujo_etl_staging.sh
+++ b/scripts/stujo_etl_staging.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+#
+# Run the StuJo → EduHub ETL (scripts/stujo_etl.py) against the STAGING
+# environment on Google Cloud (project eduhub-staging-new).
+#
+# It sets the staging *target* endpoints and pulls the two staging secrets
+# (Hasura admin key, Keycloak admin password) from Google Secret Manager at
+# runtime, so no secrets are written to disk. The *source* side (the StuJo
+# MySQL dump, the rsynced Rails public/ dir, and the Keycloak admin user) you
+# provide yourself — either by exporting the vars before calling this, or via
+# an untracked file at scripts/.stujo_etl_source.env (gitignored), e.g.:
+#
+#     STUJO_MYSQL_DSN='mysql://user:pass@127.0.0.1:3306/stujo'
+#     STUJO_FILES_ROOT='/path/to/rails/public'
+#     KEYCLOAK_USER='admin'
+#
+# Prerequisites:
+#   - gcloud authenticated as a user that can read the two secrets.
+#   - For real (non --dry-run) runs that touch logos/PDFs, Application Default
+#     Credentials with WRITE access to gs://eduhub-staging-new. Your user only
+#     has objectViewer directly, so impersonate the compute SA that owns the
+#     app's files:
+#       gcloud auth application-default login \
+#         --impersonate-service-account=638150833190-compute@developer.gserviceaccount.com
+#       gcloud auth application-default set-quota-project eduhub-staging-new
+#   - Python deps: pip install --user mysql-connector-python requests google-cloud-storage
+#
+# All arguments are passed straight through to stujo_etl.py, e.g.:
+#     scripts/stujo_etl_staging.sh --dry-run
+#     scripts/stujo_etl_staging.sh --steps companies
+#     scripts/stujo_etl_staging.sh --steps jobs --haw-org-id 42
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---- Staging target configuration (override via env if ever needed) --------
+GCP_PROJECT="${STUJO_ETL_GCP_PROJECT:-eduhub-staging-new}"
+export HASURA_URL="${HASURA_URL:-https://hasura-staging.opencampus.sh/v1/graphql}"
+export KEYCLOAK_URL="${KEYCLOAK_URL:-https://keycloak-staging.opencampus.sh}"
+export KEYCLOAK_REALM="${KEYCLOAK_REALM:-edu-hub}"
+export GCS_BUCKET="${GCS_BUCKET:-eduhub-staging-new}"
+export KEYCLOAK_USER="${KEYCLOAK_USER:-admin}"
+
+# ---- Optional untracked source-side config ---------------------------------
+SOURCE_ENV="${STUJO_ETL_SOURCE_ENV:-${SCRIPT_DIR}/.stujo_etl_source.env}"
+if [[ -f "${SOURCE_ENV}" ]]; then
+  echo "Loading source config from ${SOURCE_ENV}"
+  set -a
+  # shellcheck disable=SC1090
+  source "${SOURCE_ENV}"
+  set +a
+fi
+
+# ---- Fetch staging secrets from Secret Manager (never persisted) -----------
+fetch_secret() {
+  local name="$1" val
+  if ! val="$(gcloud secrets versions access latest --secret="${name}" --project="${GCP_PROJECT}" 2>/dev/null)"; then
+    echo "ERROR: could not read secret '${name}' from project ${GCP_PROJECT}." >&2
+    echo "       Check 'gcloud auth list' and that you have secretAccessor on it." >&2
+    exit 1
+  fi
+  if [[ -z "${val}" ]]; then
+    echo "ERROR: secret '${name}' is empty." >&2
+    exit 1
+  fi
+  printf '%s' "${val}"
+}
+
+echo "Fetching staging secrets from Secret Manager (${GCP_PROJECT})…"
+export HASURA_ADMIN_SECRET="$(fetch_secret hasura-graphql-admin-key)"
+export KEYCLOAK_PW="$(fetch_secret keycloak-pw)"
+
+# ---- Validate the source-side inputs ---------------------------------------
+missing=()
+[[ -n "${STUJO_MYSQL_DSN:-}" ]]  || missing+=("STUJO_MYSQL_DSN")
+[[ -n "${STUJO_FILES_ROOT:-}" ]] || missing+=("STUJO_FILES_ROOT")
+if [[ ${#missing[@]} -gt 0 ]]; then
+  echo "ERROR: missing required source variable(s): ${missing[*]}" >&2
+  echo "       Export them, or put them in ${SOURCE_ENV}" >&2
+  exit 1
+fi
+
+# ---- Soft pre-flight: warn if a real run has no writable ADC ---------------
+is_dry_run=false
+for arg in "$@"; do [[ "${arg}" == "--dry-run" ]] && is_dry_run=true; done
+if [[ "${is_dry_run}" == false ]]; then
+  adc_file="${CLOUDSDK_CONFIG:-${HOME}/.config/gcloud}/application_default_credentials.json"
+  if [[ ! -f "${adc_file}" ]]; then
+    echo "WARNING: no Application Default Credentials found at ${adc_file}." >&2
+    echo "         GCS logo/PDF uploads will fail. See the header for the" >&2
+    echo "         'gcloud auth application-default login --impersonate…' command." >&2
+  fi
+fi
+
+# ---- Show the resolved target (no secrets) and run -------------------------
+cat <<EOF
+Target (staging):
+  project      ${GCP_PROJECT}
+  HASURA_URL   ${HASURA_URL}
+  KEYCLOAK_URL ${KEYCLOAK_URL} (realm ${KEYCLOAK_REALM}, user ${KEYCLOAK_USER})
+  GCS_BUCKET   ${GCS_BUCKET}
+  source DSN   ${STUJO_MYSQL_DSN%%@*}@… (host hidden)
+  files root   ${STUJO_FILES_ROOT}
+  etl args     $*
+EOF
+
+exec python3 "${SCRIPT_DIR}/stujo_etl.py" "$@"

--- a/scripts/stujo_migrate_gcp.sh
+++ b/scripts/stujo_migrate_gcp.sh
@@ -44,6 +44,15 @@ AP="$(mktemp)"; printf '#!/bin/sh\necho "$STRATO_SSH_PASS"\n' > "$AP"; chmod 700
 export STRATO_SSH_PASS SSH_ASKPASS="$AP" SSH_ASKPASS_REQUIRE=force
 SSH_OPTS="-o StrictHostKeyChecking=accept-new -o ConnectTimeout=20"
 
+# Clean up the askpass helper and the MySQL tunnel on every exit path,
+# including failures under `set -e`.
+TUNNEL_PID=""
+cleanup() {
+  if [ -n "${TUNNEL_PID}" ]; then kill "${TUNNEL_PID}" 2>/dev/null || true; fi
+  rm -f "${AP}"
+}
+trap cleanup EXIT
+
 echo "==> Rsyncing Rails public/system (logos + job PDFs) from prod"
 mkdir -p "${FILES_ROOT}/system"
 setsid -w rsync -a --info=progress2 -e "ssh ${SSH_OPTS}" \
@@ -54,6 +63,7 @@ setsid -w rsync -a --info=progress2 -e "ssh ${SSH_OPTS}" \
 echo "==> Opening SSH tunnel to prod MySQL (13306 -> 127.0.0.1:3306)"
 setsid -w ssh ${SSH_OPTS} -N -L 13306:127.0.0.1:3306 -o ExitOnForwardFailure=yes \
   "${STRATO_SSH_HOST}" </dev/null &
+TUNNEL_PID=$!
 python3 -c "
 import socket,time,sys
 for _ in range(30):
@@ -79,8 +89,11 @@ export KEYCLOAK_USER="${KEYCLOAK_USER:-admin}"
 export GCS_BUCKET='eduhub-staging-new'
 export STUJO_MYSQL_DSN="mysql://${DB_USER}:${DB_PASS}@127.0.0.1:13306/${DB_NAME}"
 export STUJO_FILES_ROOT="${FILES_ROOT}"
-export HASURA_ADMIN_SECRET="$(gcloud secrets versions access latest --secret=hasura-graphql-admin-key --project=${GCP_PROJECT})"
-export KEYCLOAK_PW="$(gcloud secrets versions access latest --secret=keycloak-pw --project=${GCP_PROJECT})"
+HASURA_ADMIN_SECRET="$(gcloud secrets versions access latest --secret=hasura-graphql-admin-key --project="${GCP_PROJECT}")"
+KEYCLOAK_PW="$(gcloud secrets versions access latest --secret=keycloak-pw --project="${GCP_PROJECT}")"
+[ -n "${HASURA_ADMIN_SECRET}" ] && [ -n "${KEYCLOAK_PW}" ] \
+  || { echo 'ERROR: could not fetch staging secrets from Secret Manager'; exit 1; }
+export HASURA_ADMIN_SECRET KEYCLOAK_PW
 
 run_step() {
   local step="$1"; shift
@@ -99,6 +112,4 @@ for step in "${STEPS[@]}"; do
   fi
 done
 
-echo "==> Closing tunnel"
-pkill -f '[1]3306:127.0.0.1:3306' 2>/dev/null || true
-echo "==> DONE"
+echo "==> DONE (tunnel closed by exit trap)"

--- a/scripts/stujo_migrate_gcp.sh
+++ b/scripts/stujo_migrate_gcp.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# Run the full StuJo → EduHub STAGING migration from a GCP VM in the
+# eduhub-staging-new project. Intended to run on a throwaway Debian VM whose
+# attached (default compute) service account has:
+#   - secretAccessor on hasura-graphql-admin-key + keycloak-pw
+#   - objectAdmin on gs://eduhub-staging-new
+# so no ADC login / SA impersonation is needed — GCS writes and Secret Manager
+# reads use the VM's ambient credentials.
+#
+# It rsyncs the Rails public/ files from the prod StuJo server, opens an SSH
+# tunnel to the prod MySQL, then runs the ETL steps in dependency order.
+# stujo_etl.py must sit next to this script.
+#
+# Required env:
+#   STRATO_SSH_PASS   SSH password for the prod StuJo server
+# Optional env (sensible defaults below):
+#   STRATO_SSH_HOST=edu@h2258571.stratoserver.net
+#   HAW_ORG_ID=8            (FH_KIEL / HAW Kiel — mandate restriction target)
+#   GCP_PROJECT=eduhub-staging-new
+#   ETL_STEPS=companies,users,jobs,credits,students
+#
+# Usage on the VM:
+#   export STRATO_SSH_PASS='...'
+#   bash stujo_migrate_gcp.sh 2>&1 | tee migrate.log
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STRATO_SSH_HOST="${STRATO_SSH_HOST:-edu@h2258571.stratoserver.net}"
+HAW_ORG_ID="${HAW_ORG_ID:-8}"
+GCP_PROJECT="${GCP_PROJECT:-eduhub-staging-new}"
+ETL_STEPS="${ETL_STEPS:-companies,users,jobs,credits,students}"
+FILES_ROOT="${HOME}/stujo-files/public"
+: "${STRATO_SSH_PASS:?export STRATO_SSH_PASS (prod StuJo SSH password) first}"
+
+echo "==> Installing OS + Python dependencies"
+sudo apt-get update -qq
+sudo apt-get install -y -qq python3-pip rsync openssh-client >/dev/null
+pip3 install --user --quiet mysql-connector-python requests google-cloud-storage
+
+# askpass so ssh/rsync authenticate non-interactively (no sshpass needed)
+AP="$(mktemp)"; printf '#!/bin/sh\necho "$STRATO_SSH_PASS"\n' > "$AP"; chmod 700 "$AP"
+export STRATO_SSH_PASS SSH_ASKPASS="$AP" SSH_ASKPASS_REQUIRE=force
+SSH_OPTS="-o StrictHostKeyChecking=accept-new -o ConnectTimeout=20"
+
+echo "==> Rsyncing Rails public/system (logos + job PDFs) from prod"
+mkdir -p "${FILES_ROOT}/system"
+setsid -w rsync -a --info=progress2 -e "ssh ${SSH_OPTS}" \
+  "${STRATO_SSH_HOST}:/home/edu/stujo/public/system/logos" \
+  "${STRATO_SSH_HOST}:/home/edu/stujo/public/system/jobs" \
+  "${FILES_ROOT}/system/" </dev/null
+
+echo "==> Opening SSH tunnel to prod MySQL (13306 -> 127.0.0.1:3306)"
+setsid -w ssh ${SSH_OPTS} -N -L 13306:127.0.0.1:3306 -o ExitOnForwardFailure=yes \
+  "${STRATO_SSH_HOST}" </dev/null &
+python3 -c "
+import socket,time,sys
+for _ in range(30):
+    try: socket.create_connection(('127.0.0.1',13306),1).close(); sys.exit(0)
+    except OSError: time.sleep(1)
+sys.exit(1)
+" || { echo 'ERROR: MySQL tunnel did not come up'; exit 1; }
+
+echo "==> Reading prod DB credentials from the Rails config (keeps them out of this script)"
+read_remote() { setsid -w ssh ${SSH_OPTS} "${STRATO_SSH_HOST}" "$1" </dev/null; }
+DB_CFG=/home/edu/stujo/config/database.yml
+DB_NAME="$(read_remote "awk '/^production:/{f=1} f&&/database:/{print \$2; exit}' ${DB_CFG}")"
+DB_USER="$(read_remote "awk '/^production:/{f=1} f&&/username:/{print \$2; exit}' ${DB_CFG}")"
+DB_PASS="$(read_remote "awk '/^production:/{f=1} f&&/password:/{print \$2; exit}' ${DB_CFG}")"
+[ -n "${DB_NAME}" ] && [ -n "${DB_USER}" ] && [ -n "${DB_PASS}" ] \
+  || { echo 'ERROR: could not read prod DB credentials from '"${DB_CFG}"; exit 1; }
+
+echo "==> Configuring staging targets + fetching secrets (VM service account)"
+export HASURA_URL='https://hasura-staging.opencampus.sh/v1/graphql'
+export KEYCLOAK_URL='https://keycloak-staging.opencampus.sh'
+export KEYCLOAK_REALM='edu-hub'
+export KEYCLOAK_USER="${KEYCLOAK_USER:-admin}"
+export GCS_BUCKET='eduhub-staging-new'
+export STUJO_MYSQL_DSN="mysql://${DB_USER}:${DB_PASS}@127.0.0.1:13306/${DB_NAME}"
+export STUJO_FILES_ROOT="${FILES_ROOT}"
+export HASURA_ADMIN_SECRET="$(gcloud secrets versions access latest --secret=hasura-graphql-admin-key --project=${GCP_PROJECT})"
+export KEYCLOAK_PW="$(gcloud secrets versions access latest --secret=keycloak-pw --project=${GCP_PROJECT})"
+
+run_step() {
+  local step="$1"; shift
+  echo "==================================================================="
+  echo "==> STEP: ${step}   ($(date -u +%H:%M:%S) UTC)"
+  echo "==================================================================="
+  python3 "${SCRIPT_DIR}/stujo_etl.py" --steps "${step}" "$@"
+}
+
+IFS=',' read -ra STEPS <<< "${ETL_STEPS}"
+for step in "${STEPS[@]}"; do
+  if [ "${step}" = "jobs" ]; then
+    run_step jobs --haw-org-id "${HAW_ORG_ID}"
+  else
+    run_step "${step}"
+  fi
+done
+
+echo "==> Closing tunnel"
+pkill -f '[1]3306:127.0.0.1:3306' 2>/dev/null || true
+echo "==> DONE"


### PR DESCRIPTION
## Summary
- Align StuJo ETL file storage with EduHub’s native layout: logos/PDFs upload to `organizations/org-<id>/…` and `jobpostings/jobposting-<id>/…` with bucket-relative paths (resolved via `NEXT_PUBLIC_STORAGE_BUCKET_URL`).
- Add staging runners (`stujo_etl_staging.sh`, `stujo_migrate_gcp.sh`) that pull secrets from Secret Manager / ambient GCP creds so nothing sensitive lands on disk.
- Fix null `Organization.aliases` merge (client-side `_set` instead of Hasura `_append`) and backfill missing logos on matched orgs.

## Test plan
- [ ] Dry-run `scripts/stujo_etl_staging.sh --dry-run` against staging and confirm company/job mapping + file preflight stats look sane
- [ ] Run a small non-dry staging pass and verify logos/PDFs land under the native object paths with `publicRead` ACL
- [ ] Confirm stored `Organization.logo` / `JobPosting.pdfUrl` values are bucket-relative and resolve in the frontend
- [ ] Re-run against an org with `aliases = null` and confirm the legacy alias is appended without error
- [ ] Confirm `scripts/.stujo_etl_source.env` remains untracked


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staging tooling to automate StuJo-to-EduHub migrations end-to-end.
  * Improved logo and job PDF import, including safer alias/logo backfilling and deterministic asset destination paths.
* **Bug Fixes**
  * Backfills missing `pdfUrl` for existing job postings and sets media fields only after inserts to ensure correct IDs.
  * Prevents legacy aliases from being lost when aliases are absent.
* **Chores**
  * Updated local config ignore rules to avoid committing source-side ETL environment files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->