### PR TITLE
feat(stripe): add org and course names to checkout metadata

### DIFF
--- a/functions/callNodeFunction/createStripeCheckout/index.js
+++ b/functions/callNodeFunction/createStripeCheckout/index.js
@@ -20,6 +20,7 @@ const GET_COURSE_AND_ADDONS = `
       Program {
         Organization {
           id
+          name
           defaultVatRate
           defaultTaxExemptionNote
           invoiceFooterText
@@ -496,9 +497,12 @@ export default async function createStripeCheckout(req, logger) {
       cancel_url: cancelUrl,
       metadata: {
         courseId: String(courseId),
+        courseName: course.title || '',
         enrollmentId: String(enrollmentId),
         formbricksResponseId: formbricksResponseId || '',
         source: 'eduhub',
+        organizationId: organization?.id != null ? String(organization.id) : '',
+        organizationName: organization?.name || '',
         selectedAddons: (() => {
           if (!enrollmentAddons || enrollmentAddons.length === 0) {
             return '';
@@ -526,7 +530,10 @@ export default async function createStripeCheckout(req, logger) {
       payment_intent_data: {
         metadata: {
           courseId: String(courseId),
-          enrollmentId: String(enrollmentId)
+          courseName: course.title || '',
+          enrollmentId: String(enrollmentId),
+          organizationId: organization?.id != null ? String(organization.id) : '',
+          organizationName: organization?.name || '',
         }
       }
     };

--- a/functions/callNodeFunction/publishJobPosting/index.js
+++ b/functions/callNodeFunction/publishJobPosting/index.js
@@ -398,12 +398,18 @@ export default async function publishJobPosting(req, logger) {
       metadata: {
         jobPostingId: String(posting.id),
         organizationId: String(posting.organizationId),
+        organizationName: posting.Organization?.name || '',
         // The buying user for the Invoice row created by the webhook.
         userId: String(sessionUserId),
         source: 'stujo',
       },
       payment_intent_data: {
-        metadata: { jobPostingId: String(posting.id), source: 'stujo' },
+        metadata: {
+          jobPostingId: String(posting.id),
+          organizationId: String(posting.organizationId),
+          organizationName: posting.Organization?.name || '',
+          source: 'stujo',
+        },
       },
     };
 


### PR DESCRIPTION
## Summary
- Add `organizationId`, `organizationName`, and `courseName` to Stripe Checkout Session and PaymentIntent metadata for course/event payments (`source: eduhub`)
- Add `organizationName` (and org fields on PaymentIntent) for StuJo job posting checkouts so finance can attribute transactions without joining IDs

## Test plan
- [ ] Restart `node_functions` and create a paid course enrollment checkout; confirm Session + PaymentIntent metadata include `organizationId`, `organizationName`, `courseName`, `source: eduhub`
- [ ] Publish a paid StuJo job posting; confirm metadata includes `organizationId`, `organizationName`, `source: stujo`
- [ ] Confirm existing webhook handling still works (metadata keys added only; no consumers removed)


Made with [Cursor](https://cursor.com)