### PR TITLE
StuJo: production migration runner + domain cutover runbook

### DIFF
--- a/docs/STUJO_PROD_CUTOVER.md
+++ b/docs/STUJO_PROD_CUTOVER.md
@@ -1,0 +1,189 @@
+# StuJo → EduHub production cutover
+
+Two independent workstreams: **(A) data** (re-run the ETL against prod) and
+**(B) domains** (move `stujo.net` traffic to the new app). Do A first and QA on
+the `*.opencampus.sh` interim hosts; do B in a low-traffic window.
+
+Prereqs already in place: the ETL (`scripts/stujo_etl.py`) with the
+company/student spam filters + full delta upsert; the legacy 301 middleware
+(`frontend-nx/apps/stujo/middleware.ts`); and the `JobPortalDomain` seed, which
+already contains the `stujo.net` hosts (migration `1784400000000`).
+
+---
+
+## A. Data cutover (ETL against production)
+
+Runner: **`scripts/stujo_migrate_prod.sh`** — a thin wrapper over
+`stujo_migrate_gcp.sh` that sets the prod endpoints (all env-overridable) and
+requires the prod-specific values so it can't be pointed at the wrong place by
+accident. Run on a throwaway VM in the **production** GCP project (same pattern
+as the staging run: VM SA needs `secretAccessor` on `hasura-graphql-admin-key`
++ `keycloak-pw` and `objectAdmin` on the prod uploads bucket).
+
+Values you must supply (no safe defaults):
+
+| Env | What | Note |
+|---|---|---|
+| `GCP_PROJECT` | prod project id | secrets + bucket live here |
+| `GCS_BUCKET` | prod uploads bucket | |
+| `HAW_ORG_ID` | prod `Organization.id` of HAW Kiel | **not 8** (that was staging) — look it up in prod Hasura |
+| `STRATO_SSH_PASS` | prod StuJo SSH password | |
+| `KEYCLOAK_USER` | defaults to `login@opencampus.sh` | staging used `keycloak` |
+
+Steps:
+
+1. **Deploy the new stujo app to prod** (Cloud Run) and QA on
+   `stujo.opencampus.sh` + the `stujo-<portal>.opencampus.sh` hosts.
+2. **Dry run:** `DRY_RUN=1 bash stujo_migrate_prod.sh 2>&1 | tee prod-dryrun.log`
+   — validates source connectivity, previews the filtered scope.
+3. **Full run:** `STUJO_PROD_CONFIRM=PROD bash stujo_migrate_prod.sh 2>&1 | tee prod-migrate.log`
+4. **Verify** counts against prod Hasura (orgs with jobs, org admins, job
+   postings by status, credits) — same queries used on staging.
+5. **Freeze StuJo writes** on the Rails app (maintenance banner).
+6. **Delta run:** re-run step 3. Thanks to the upsert it now reconciles
+   edited/re-posted jobs, status changes and credit balances — not just new rows.
+7. **Tear down the VM** (removes the on-disk SSH password + logs).
+
+---
+
+## B. Domain cutover checklist
+
+| # | Task | Terraform? |
+|---|---|---|
+| 1 | `stujo.net` is a Cloudflare zone; registrar nameservers point at Cloudflare | zone: TF-able (`cloudflare_zone`); NS at registrar: **manual, one-time** |
+| 2 | Add `stujo.net` + subdomains to the managed-cert SAN list | ✅ TF (`02_network.tf`) |
+| 3 | Cloudflare A records for `stujo.net` hosts → LB IP (in the stujo.net zone) | ✅ TF |
+| 4 | LB routes the `stujo.net` hosts to the `stujo` Cloud Run service | ✅ TF (host rules — the non-trivial piece, see below) |
+| 5 | Confirm the new managed cert is **ACTIVE** before flipping traffic | manual verify |
+| 6 | 301 middleware live (already committed) + `/arbeitgeber` route built if you want employer redirects | code |
+| 7 | e-talents domains → static sunset page (plan §7.3) | out of scope here |
+| 8 | Archive Rails DB + `public/system` snapshot; decommission | manual |
+
+**⚠️ Cert re-provisioning window.** The managed cert is a single multi-SAN cert
+whose domain list is immutable, so adding SANs provisions a *new* cert
+(create-before-destroy). It only goes ACTIVE once every listed domain validates,
+which needs the new A records resolving first. Expect a window (tens of minutes)
+— apply off-peak and confirm ACTIVE before treating the new hosts as live. This
+is already documented in `02_network.tf`.
+
+---
+
+## Can it be fully done in Terraform? — Yes.
+
+Cert SANs, DNS records, and LB routing are all already TF-managed in
+`infrastructure/application/`. The only non-TF bits are one-time/manual by
+nature: pointing the `stujo.net` **registrar nameservers** at Cloudflare, and
+**verifying** the cert reached ACTIVE. Everything else below is drop-in TF.
+
+The one piece that is more than a one-liner is **routing**: today a single
+serverless NEG uses `url_mask = "<service>.opencampus.sh"` to derive the Cloud
+Run service from the hostname. `stujo.net` doesn't match that pattern, and the
+host→service names don't line up (`cau.stujo.net` must reach service
+`stujo-cau`). The clean fix relies on a fact about the app: **portal branding is
+resolved from the request host** (`lib/portal.ts` → `JobPortalDomain` seed),
+*independent of which Cloud Run service serves it*. So all `*.stujo.net` can
+point at the single root `stujo` service and still render the right portal. That
+turns routing into "host rules → one backend".
+
+### Terraform code
+
+**1) New variables** (`00_variables.tf`) — inert by default, so committing this
+is a no-op until you set them at cutover:
+
+```hcl
+variable "stujo_net_hostnames" {
+  description = "Real public StuJo hostnames to serve (stujo.net + subdomains). Empty until cutover."
+  type        = list(string)
+  default     = []
+  # cutover value, e.g.:
+  # ["stujo.net","www.stujo.net","cau.stujo.net","haw-kiel.stujo.net","fh-kiel.stujo.net","flensburg.stujo.net"]
+}
+
+variable "cloudflare_zone_id_stujo" {
+  description = "Cloudflare zone id for the stujo.net domain (separate zone from opencampus.sh)."
+  type        = string
+  default     = ""
+}
+```
+
+**2) Cert SANs** — extend the existing `concat(...)` in `02_network.tf`
+(`module.lb-http.managed_ssl_certificate_domains`):
+
+```hcl
+managed_ssl_certificate_domains = concat(
+  [
+    "${local.keycloak_service_name}.opencampus.sh",
+    "${local.hasura_service_name}.opencampus.sh",
+    "${local.eduhub_service_name}.opencampus.sh",
+    "${local.eduhub_api_service_name}.opencampus.sh",
+    local.stujo_domain,
+  ],
+  [for portal in local.stujo_portals : portal.domain],
+  var.stujo_net_hostnames,            # NEW — empty until cutover
+)
+```
+
+**3) Cloudflare A records** in the `stujo.net` zone (`02_network.tf`):
+
+```hcl
+resource "cloudflare_record" "stujo_net" {
+  for_each = toset(var.stujo_net_hostnames)
+
+  zone_id = var.cloudflare_zone_id_stujo
+  name    = each.value == "stujo.net" ? "@" : trimsuffix(each.value, ".stujo.net")
+  type    = "A"
+  value   = module.lb-http.external_ip
+  # match the existing records (unproxied so the managed cert validates directly)
+  proxied = false
+}
+```
+
+**4) Routing — host rules → the root `stujo` service.** Add a serverless NEG
+pinned to the `stujo` service (no url_mask), and route the `stujo.net` hosts to
+it. The `GoogleCloudPlatform/lb-http//modules/serverless_negs` module abstracts
+the URL map, so wiring host rules means using the module's host-rule inputs (or,
+if the version in use doesn't expose them, adding a `google_compute_url_map`
+that references the module's backend service). **Validate this against the module
+version in `.terraform` and rehearse on staging first** — it's the only step
+that touches live routing.
+
+```hcl
+# Pin a NEG to the root stujo service (branding is resolved by the app from the
+# request host, so every *.stujo.net host can share this one backend).
+resource "google_compute_region_network_endpoint_group" "stujo_net" {
+  count                 = length(var.stujo_net_hostnames) > 0 ? 1 : 0
+  provider              = google-beta
+  name                  = "stujo-net-neg"
+  network_endpoint_type = "SERVERLESS"
+  region                = var.region
+  cloud_run {
+    service = local.stujo_service_name   # the root "stujo" Cloud Run service
+  }
+  lifecycle { create_before_destroy = true }
+}
+
+# Then, in the load balancer's URL map, add a host rule matching
+# var.stujo_net_hostnames to a backend service fronting the NEG above. With the
+# lb-http module this is done via its host-rule/backends inputs; confirm the
+# exact interface for the pinned module version before applying.
+```
+
+> Simpler-but-worse alternative: proxy `stujo.net` through Cloudflare and rewrite
+> the `Host` header to `stujo.opencampus.sh` so the existing `url_mask` routes it.
+> Rejected because it collapses every portal host to one, losing per-host portal
+> branding unless the original host is forwarded and the app is taught to read it.
+
+### Suggested apply order at cutover
+
+1. Set `cloudflare_zone_id_stujo` + `stujo_net_hostnames`; `terraform apply` the
+   **A records first** (or same apply — records must resolve for cert validation).
+2. Apply the **cert SAN** change; wait for the new managed cert to be **ACTIVE**
+   (check in the console / `gcloud compute ssl-certificates describe`).
+3. Apply the **routing** (NEG + host rules).
+4. Smoke-test each host over HTTPS, then flip / announce.
+
+### Rollback
+
+DNS is the switch: revert the `stujo.net` A records (or lower TTL beforehand and
+point back at the Rails server) to fall back. The GCP-side resources (cert SANs,
+NEG, host rules) are additive and safe to leave in place.

--- a/docs/STUJO_PROD_CUTOVER.md
+++ b/docs/STUJO_PROD_CUTOVER.md
@@ -11,6 +11,42 @@ already contains the `stujo.net` hosts (migration `1784400000000`).
 
 ---
 
+## Ordering — the switch is controlled by flags + DNS, not by merge timing
+
+The redirect code is **inert until activated**, so you do **not** need to hold
+any PR back to keep redirects from firing early:
+
+- Canonical `*.opencampus.sh → stujo.net` 301s are gated on the build-time flag
+  `NEXT_PUBLIC_STUJO_CANONICAL_REDIRECTS` (off by default).
+- Legacy job 301s only match the old **slug-bearing** `stujo.net` URL shape and
+  fail safe (a missing `legacyStujoId` just falls through) — the new app emits
+  bare-id URLs, which are never touched.
+- edu-hub's outbound links follow `NEXT_PUBLIC_STUJO_URL` (a build var).
+
+So merge/promote everything normally (`develop → staging → production`; note
+promoting is also what applies the Hasura schema + `JobPortalDomain` seed the
+prod ETL depends on), then orchestrate the actual switch with **data → domain →
+flags**:
+
+1. **Promote all StuJo work → production.** Schema live, app on
+   `stujo.opencampus.sh`, redirects inert, `NEXT_PUBLIC_STUJO_URL` still
+   opencampus.sh. Production is unchanged.
+2. **Run the prod ETL** (§A, full run). QA on `stujo.opencampus.sh`.
+3. **Freeze Rails writes → delta ETL** (the upsert reconciles changes).
+4. **Stand up stujo.net** (§B: cert SANs + DNS + routing). Wait for the cert to
+   be **ACTIVE**. stujo.net now serves the app; slug redirects on stujo.net
+   resolve because the data is already migrated.
+5. **Flip the flags** (GitHub Actions Variables, prod) → triggers a
+   rebuild/redeploy:
+   - `NEXT_PUBLIC_STUJO_URL=https://stujo.net`
+   - `NEXT_PUBLIC_STUJO_CANONICAL_REDIRECTS=true` (only now that stujo.net
+     resolves — setting it earlier would 301 `stujo.opencampus.sh` to a dead
+     domain).
+
+Rollback at any point is the DNS switch (§B "Rollback").
+
+---
+
 ## A. Data cutover (ETL against production)
 
 Runner: **`scripts/stujo_migrate_prod.sh`** — a thin wrapper over

--- a/scripts/stujo_migrate_gcp.sh
+++ b/scripts/stujo_migrate_gcp.sh
@@ -91,12 +91,14 @@ DB_PASS="$(read_remote "awk '/^production:/{f=1} f&&/password:/{print \$2; exit}
 [ -n "${DB_NAME}" ] && [ -n "${DB_USER}" ] && [ -n "${DB_PASS}" ] \
   || { echo 'ERROR: could not read prod DB credentials from '"${DB_CFG}"; exit 1; }
 
-echo "==> Configuring staging targets + fetching secrets (VM service account)"
-export HASURA_URL='https://hasura-staging.opencampus.sh/v1/graphql'
-export KEYCLOAK_URL='https://keycloak-staging.opencampus.sh'
-export KEYCLOAK_REALM='edu-hub'
+echo "==> Configuring targets + fetching secrets (VM service account)"
+# Targets default to STAGING but are all env-overridable, so stujo_migrate_prod.sh
+# (or an ad-hoc export) can point this same runner at production without editing it.
+export HASURA_URL="${HASURA_URL:-https://hasura-staging.opencampus.sh/v1/graphql}"
+export KEYCLOAK_URL="${KEYCLOAK_URL:-https://keycloak-staging.opencampus.sh}"
+export KEYCLOAK_REALM="${KEYCLOAK_REALM:-edu-hub}"
 export KEYCLOAK_USER="${KEYCLOAK_USER:-admin}"
-export GCS_BUCKET='eduhub-staging-new'
+export GCS_BUCKET="${GCS_BUCKET:-eduhub-staging-new}"
 export STUJO_MYSQL_DSN="mysql://${DB_USER}:${DB_PASS}@127.0.0.1:13306/${DB_NAME}"
 export STUJO_FILES_ROOT="${FILES_ROOT}"
 HASURA_ADMIN_SECRET="$(gcloud secrets versions access latest --secret=hasura-graphql-admin-key --project="${GCP_PROJECT}")"

--- a/scripts/stujo_migrate_prod.sh
+++ b/scripts/stujo_migrate_prod.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Run the StuJo → EduHub migration against PRODUCTION.
+#
+# Thin wrapper around stujo_migrate_gcp.sh: it only sets the production target
+# endpoints (all env-overridable in the shared runner) and then delegates. Run
+# it the same way — on a throwaway VM in the PRODUCTION GCP project whose
+# attached service account can read the two secrets and write the uploads
+# bucket. All ETL args (e.g. --dry-run via DRY_RUN=1, --steps) pass through.
+#
+# !!! THIS WRITES TO PRODUCTION Hasura / Keycloak / GCS. !!!
+#
+# Required env (no safe defaults — must be set explicitly):
+#   GCP_PROJECT      production GCP project id (Secret Manager + GCS bucket live here)
+#   GCS_BUCKET       production uploads bucket
+#   HAW_ORG_ID       prod Organization.id of HAW Kiel (mandate target) — look it up,
+#                    it is NOT 8 (that was the staging id)
+#   STRATO_SSH_PASS  prod StuJo server SSH password
+#
+# Optional env (sensible prod defaults, override only if the naming differs):
+#   HASURA_URL=https://hasura.opencampus.sh/v1/graphql
+#   KEYCLOAK_URL=https://keycloak.opencampus.sh
+#   KEYCLOAK_USER=login@opencampus.sh          (staging used "keycloak")
+#   KEYCLOAK_REALM=edu-hub
+#   ETL_STEPS=companies,users,jobs,credits,students
+#   DRY_RUN=1                                    (preview, no writes)
+#
+# Confirmation: interactive runs prompt for "PROD"; non-interactive runs (e.g.
+# under setsid/nohup on the VM) must pass STUJO_PROD_CONFIRM=PROD.
+#
+# Usage on the VM (recommended order):
+#   export STRATO_SSH_PASS='...'
+#   GCP_PROJECT=<prod> GCS_BUCKET=<prod-bucket> HAW_ORG_ID=<id> \
+#     DRY_RUN=1 bash stujo_migrate_prod.sh 2>&1 | tee prod-dryrun.log   # dry run
+#   GCP_PROJECT=<prod> GCS_BUCKET=<prod-bucket> HAW_ORG_ID=<id> \
+#     STUJO_PROD_CONFIRM=PROD bash stujo_migrate_prod.sh 2>&1 | tee prod-migrate.log
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ---- Required prod-specific values (fail fast if missing) -------------------
+: "${GCP_PROJECT:?set GCP_PROJECT to the PRODUCTION project id}"
+: "${GCS_BUCKET:?set GCS_BUCKET to the production uploads bucket}"
+: "${HAW_ORG_ID:?set HAW_ORG_ID to the prod HAW Kiel Organization.id (NOT 8 — look it up)}"
+: "${STRATO_SSH_PASS:?export STRATO_SSH_PASS (prod StuJo SSH password) first}"
+
+# ---- Production target endpoints (overridable) -----------------------------
+export GCP_PROJECT GCS_BUCKET HAW_ORG_ID
+export HASURA_URL="${HASURA_URL:-https://hasura.opencampus.sh/v1/graphql}"
+export KEYCLOAK_URL="${KEYCLOAK_URL:-https://keycloak.opencampus.sh}"
+export KEYCLOAK_REALM="${KEYCLOAK_REALM:-edu-hub}"
+export KEYCLOAK_USER="${KEYCLOAK_USER:-login@opencampus.sh}"
+
+# ---- Safety confirmation ---------------------------------------------------
+cat <<EOF
+-------------------------------------------------------------------------------
+  StuJo → EduHub migration — TARGET: PRODUCTION
+    project      ${GCP_PROJECT}
+    HASURA_URL   ${HASURA_URL}
+    KEYCLOAK_URL ${KEYCLOAK_URL}  (user ${KEYCLOAK_USER}, realm ${KEYCLOAK_REALM})
+    GCS_BUCKET   ${GCS_BUCKET}
+    HAW_ORG_ID   ${HAW_ORG_ID}
+    ETL steps    ${ETL_STEPS:-companies,users,jobs,credits,students}${DRY_RUN:+   [DRY RUN]}
+    ETL args     $*
+-------------------------------------------------------------------------------
+EOF
+if [ "${STUJO_PROD_CONFIRM:-}" != "PROD" ]; then
+  if [ -t 0 ]; then
+    read -r -p "Type 'PROD' to proceed: " STUJO_PROD_CONFIRM
+  else
+    echo "ERROR: refusing to run non-interactively without STUJO_PROD_CONFIRM=PROD" >&2
+    exit 1
+  fi
+fi
+[ "${STUJO_PROD_CONFIRM}" = "PROD" ] || { echo "aborted."; exit 1; }
+
+exec bash "${SCRIPT_DIR}/stujo_migrate_gcp.sh" "$@"


### PR DESCRIPTION
## What

Adds the production side of the StuJo → EduHub cutover: a prod ETL runner and a full cutover runbook (with drop-in Terraform for the domain move). Docs + a script wrapper only — no runtime/app code.

### Commits
- **`scripts/stujo_migrate_prod.sh`** — thin wrapper over `stujo_migrate_gcp.sh` that sets the production endpoints (all env-overridable) and *requires* the prod-specific values (`GCP_PROJECT`, `GCS_BUCKET`, `HAW_ORG_ID`, `KEYCLOAK_USER=login@opencampus.sh`) + a `PROD` confirmation, so it can't be aimed at the wrong environment by accident. Also makes the shared runner's target endpoints env-overridable (staging defaults unchanged).
- **`docs/STUJO_PROD_CUTOVER.md`** — end-to-end runbook:
  - Ordering: the redirects are gated/inert, so the switch is driven by **flags + DNS + data ordering, not merge timing** → *promote → prod ETL → freeze/delta → stand up stujo.net → flip flags*.
  - Data cutover (ETL against prod) steps.
  - Domain cutover checklist (Terraform vs manual) + the cert re-provisioning window warning.
  - Drop-in Terraform for the domain move: cert SANs, `stujo.net` Cloudflare records, and host-rule routing to the root `stujo` service.

## Notes
- Both scripts pass `bash -n`.
- The routing Terraform is the one piece to validate against the pinned `lb-http` module version and rehearse on staging (flagged in the doc) — it's the only step touching live routing.
- Companion to #1800 (the redirect middleware + `NEXT_PUBLIC_STUJO_URL` wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)