### PR TITLE
fix: staging smoke-test findings (post React 19 / Next 16 release)

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/CalendarContent/CalendarLegend.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CalendarContent/CalendarLegend.tsx
@@ -11,7 +11,7 @@ const CalendarLegend: FC = () => {
           className="w-3 h-3 rounded border-2 border-dashed border-label-secondary"
           aria-hidden
         />
-        <span className="text-sm text-label-secondary">{t('filter_events')}</span>
+        <span className="text-sm text-label-secondary">{t('calendar.filter_events')}</span>
       </div>
       {Object.entries(LOCATION_COLORS).map(([location, colors]) => (
         <div key={location} className="flex items-center gap-2">

--- a/frontend-nx/apps/edu-hub/helpers/dateTimeHelpers.ts
+++ b/frontend-nx/apps/edu-hub/helpers/dateTimeHelpers.ts
@@ -64,7 +64,7 @@ export const useFormatTimeString = () => {
       }
 
       // Check if the string is in HH:mm or HH:mm:ss format
-      if (typeof ts === 'string' && /^\d{2}:\d{2}(:\d{2})?$/.test(ts)) {
+      if (typeof ts === 'string' && /^\d{2}:\d{2}(:\d{2}(\.\d+)?)?$/.test(ts)) {
         // Since we're already dealing with a simple HH:mm format, we assume
         // the input is already in the correct timezone and we don't need to
         // convert it.

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -2429,7 +2429,8 @@
       "REGISTRATION_CONFIRMED_PAID": "Bezahlung bestätigt",
       "APPLICATION_RECEIVED_PAID": "Bewerbung erhalten (kostenpflichtig)",
       "USER_CREATED": "Benutzer erstellt",
-      "ORGANIZER_ADDED": "Organisator hinzugefügt"
+      "ORGANIZER_ADDED": "Organisator hinzugefügt",
+      "WAITLIST_NOTICE": "Wartelisten-Benachrichtigung"
     },
     "placeholders": {
       "subject": "E-Mail-Betreff eingeben...",
@@ -2456,7 +2457,8 @@
       "APPLICATION_RECEIVED_PAID": "Gesendet, wenn eine Bewerbung für einen kostenpflichtigen Kurs eingegangen ist",
       "SESSION_REMINDER": "Gesendet vor Beginn der Sitzungen (24h, 1h, 15min vorher)",
       "USER_CREATED": "Gesendet, wenn ein neues Benutzerkonto erstellt wird",
-      "ORGANIZER_ADDED": "Gesendet, wenn ein Benutzer als Organisator zu einem Kurs oder Event hinzugefügt wird"
+      "ORGANIZER_ADDED": "Gesendet, wenn ein Benutzer als Organisator zu einem Kurs oder Event hinzugefügt wird",
+      "WAITLIST_NOTICE": "Gesendet, wenn ein Benutzer auf die Warteliste kommt, weil der Kurs voll ist"
     },
     "delete_confirmation": "Bist du sicher, dass du die E-Mail-Vorlage '{title}' löschen möchtest?",
     "unknown_trigger": "Unbekannter Auslöser-Typ",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -2444,7 +2444,8 @@
       "REGISTRATION_CONFIRMED_PAID": "Payment Confirmed",
       "APPLICATION_RECEIVED_PAID": "Application Received (Paid)",
       "USER_CREATED": "User Created",
-      "ORGANIZER_ADDED": "Organizer Added"
+      "ORGANIZER_ADDED": "Organizer Added",
+      "WAITLIST_NOTICE": "Waitlist Notice"
     },
     "placeholders": {
       "subject": "Enter email subject...",
@@ -2471,7 +2472,8 @@
       "APPLICATION_RECEIVED_PAID": "Sent when an application for a paid course is received",
       "SESSION_REMINDER": "Sent before sessions start (24h, 1h, 15min before)",
       "USER_CREATED": "Sent when a new user account is created",
-      "ORGANIZER_ADDED": "Sent when a user is added as an organizer to a course or event"
+      "ORGANIZER_ADDED": "Sent when a user is added as an organizer to a course or event",
+      "WAITLIST_NOTICE": "Sent when a user joins the waitlist because the course is full"
     },
     "delete_confirmation": "Are you sure you want to delete the email template '{title}'?",
     "unknown_trigger": "Unknown trigger type",

--- a/frontend-nx/apps/edu-hub/pages/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/index.tsx
@@ -15,7 +15,7 @@ import HomeJobSlider from '../components/common/TileSlider/HomeJobSlider';
 import FaqSection from '../components/common/FaqSection';
 import NotificationSnackbar from '../components/common/dialogs/NotificationSnackbar';
 
-import { useAuthedQuery, useInstructorQuery } from '../hooks/authedQuery';
+import { useAuthedQuery, useRoleQuery } from '../hooks/authedQuery';
 import { useIsLoggedIn, useIsInstructor, useIsAdmin } from '../hooks/authentication';
 import { useUserId } from '../hooks/user';
 import { AuthRoles } from '../types/enums';
@@ -60,11 +60,14 @@ const Home: FC = () => {
     }
   }, [router]);
 
-  const { data: adminCoursesData, loading: adminCoursesLoading } = useInstructorQuery<CoursesByInstructor>(
+  // Query under a role the JWT actually has: admins without the instructor
+  // role would otherwise be rejected by Hasura ("role is not in allowed roles").
+  const { data: adminCoursesData, loading: adminCoursesLoading } = useRoleQuery<CoursesByInstructor>(
     COURSES_BY_INSTRUCTOR,
     {
       variables: { userId },
       skip: !isLoggedIn || !(isInstructor || isAdmin),
+      context: { role: isInstructor ? AuthRoles.instructor : AuthRoles.admin },
     }
   );
 

--- a/frontend-nx/apps/edu-hub/pages/manage/course/[courseId]/email-templates/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/course/[courseId]/email-templates/index.tsx
@@ -3,8 +3,8 @@ import { FC, useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 import { Page } from '../../../../../components/layout/Page';
 import { useIsAdmin, useIsLoggedIn } from '../../../../../hooks/authentication';
-import { useRoleQuery } from '../../../../../hooks/authedQuery';
-import { useRoleMutation } from '../../../../../hooks/authedMutation';
+import { useAdminQuery } from '../../../../../hooks/authedQuery';
+import { useAdminMutation } from '../../../../../hooks/authedMutation';
 import { useTranslations } from 'next-intl';
 import Loading from '../../../../../components/common/Loading';
 import { MANAGED_COURSE } from '../../../../../queries/course';
@@ -31,13 +31,13 @@ const CourseEmailTemplates: FC = () => {
   const isValidCourseId = courseIdNumber !== null && Number.isInteger(courseIdNumber) && courseIdNumber > 0;
   const [templatesCreated, setTemplatesCreated] = useState(false);
 
-  const { data, loading, error } = useRoleQuery<ManagedCourse>(MANAGED_COURSE, {
+  const { data, loading, error } = useAdminQuery<ManagedCourse>(MANAGED_COURSE, {
     variables: { id: courseIdNumber || 0 },
     skip: !isValidCourseId,
   });
 
   // Check if course has templates
-  const { data: templatesCountData, refetch: refetchTemplatesCount } = useRoleQuery<GetCourseTemplatesCount>(
+  const { data: templatesCountData, refetch: refetchTemplatesCount } = useAdminQuery<GetCourseTemplatesCount>(
     GET_COURSE_TEMPLATES_COUNT,
     {
       variables: { courseId: courseIdNumber || 0 },
@@ -46,9 +46,9 @@ const CourseEmailTemplates: FC = () => {
   );
 
   // Get default templates
-  const { data: defaultTemplatesData } = useRoleQuery<GetDefaultTemplates>(GET_DEFAULT_TEMPLATES);
+  const { data: defaultTemplatesData } = useAdminQuery<GetDefaultTemplates>(GET_DEFAULT_TEMPLATES);
 
-  const [insertEmailTemplate] = useRoleMutation<InsertEmailTemplate, InsertEmailTemplateVariables>(
+  const [insertEmailTemplate] = useAdminMutation<InsertEmailTemplate, InsertEmailTemplateVariables>(
     INSERT_EMAIL_TEMPLATE
   );
 


### PR DESCRIPTION
## Summary

The React 19 / Next.js 16 release candidate deployed to staging without errors. A full Playwright smoke test over all pages (public, admin/manage, course/project details, widgets, StuJo) found five pre-existing bugs — none caused by the upgrade — fixed here:

- **dateTimeHelpers**: accept `HH:mm:ss.fff` times (StuJo ETL data) — was logging `Error parsing time` on home/course pages
- **CalendarLegend**: missing `calendar.` i18n namespace — raw key `filter_events` shown in UI
- **locales**: add missing `WAITLIST_NOTICE` template-type + trigger translations (de/en)
- **manage/course/[id]/email-templates**: pin admin role on queries — page queried under default `user` role and Hasura rejected `MailTemplate`/`User.email`
- **homepage**: query `CoursesByInstructor` under a role the JWT actually has — admins without the `instructor` role got "requested role is not in allowed roles"

## Test plan
- [x] `tsc --noEmit` (edu-hub) passes
- [x] Jest: 10 suites / 69 tests pass
- [x] Staging smoke test script identifies each issue; re-run after deploy to confirm

🤖 Generated with [Claude Code](https://claude.com/claude-code)