### PR TITLE
fix(email-templates): wait for session before querying

### DIFF
--- a/frontend-nx/apps/edu-hub/pages/manage/course/[courseId]/email-templates/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/course/[courseId]/email-templates/index.tsx
@@ -31,9 +31,12 @@ const CourseEmailTemplates: FC = () => {
   const isValidCourseId = courseIdNumber !== null && Number.isInteger(courseIdNumber) && courseIdNumber > 0;
   const [templatesCreated, setTemplatesCreated] = useState(false);
 
+  // Skip until the session is ready: the Apollo auth link only attaches the
+  // Authorization/role headers once the access token is in the auth store, so
+  // firing earlier sends the queries unauthenticated and Hasura rejects them.
   const { data, loading, error } = useAdminQuery<ManagedCourse>(MANAGED_COURSE, {
     variables: { id: courseIdNumber || 0 },
-    skip: !isValidCourseId,
+    skip: !isLoggedIn || !isAdmin || !isValidCourseId,
   });
 
   // Check if course has templates
@@ -41,12 +44,14 @@ const CourseEmailTemplates: FC = () => {
     GET_COURSE_TEMPLATES_COUNT,
     {
       variables: { courseId: courseIdNumber || 0 },
-      skip: !isValidCourseId,
+      skip: !isLoggedIn || !isAdmin || !isValidCourseId,
     }
   );
 
   // Get default templates
-  const { data: defaultTemplatesData } = useAdminQuery<GetDefaultTemplates>(GET_DEFAULT_TEMPLATES);
+  const { data: defaultTemplatesData } = useAdminQuery<GetDefaultTemplates>(GET_DEFAULT_TEMPLATES, {
+    skip: !isLoggedIn || !isAdmin,
+  });
 
   const [insertEmailTemplate] = useAdminMutation<InsertEmailTemplate, InsertEmailTemplateVariables>(
     INSERT_EMAIL_TEMPLATE


### PR DESCRIPTION
## Summary

Follow-up to #1803: the course email-templates page (`/manage/course/[id]/email-templates`) fired its GraphQL queries before the Apollo auth link had an access token, so requests went out **unauthenticated** (no `Authorization`/`x-hasura-role` headers) and Hasura rejected `MailTemplate`/`User.email` — regardless of the admin role pinned in #1803. Verified via request-level probing on staging (`role=(none)` on all three failing operations).

Fix: skip the queries until the admin session is ready, matching the other manage pages.

## Test plan
- [x] `tsc --noEmit` passes
- [x] Re-run staging smoke test after deploy: page must load without GraphQL errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)