### PR TITLE
fix(infra): raise Hasura memory limit to 2048M to prevent startup OOM

### DIFF
--- a/infrastructure/application/00_variables.tf
+++ b/infrastructure/application/00_variables.tf
@@ -202,7 +202,14 @@ variable "hasura_graphql_dev_mode" {
 variable "hasura_memory_limit" {
   description = "Memory limit for Hasura cloud run service"
   type        = string
-  default     = "1024M"
+  # 2048M: the cli-migrations-v3 image runs a temporary engine to apply
+  # migrations/metadata that overlaps in memory with the real engine at boot,
+  # and the schema cache has grown (many tables + event triggers). At 1024M the
+  # startup peak exceeded the limit and the container was OOM-killed before
+  # binding port 8080, so Cloud Run's startup probe timed out and rollouts got
+  # stuck (prod, 2026-07-21). The running instance also OOM'd at rest. ~$6.6/mo
+  # extra per always-on instance.
+  default = "2048M"
 }
 
 # Frontend


### PR DESCRIPTION
## Problem

The production `hasura` Cloud Run service (`eduhub-production`, `europe-west1`) had a **stuck rollout**: revisions 00185→00189 all failed to go live with `Default STARTUP TCP probe failed … on port 8080 … DEADLINE_EXCEEDED`, so traffic stayed pinned to old revision 00184.

Container logs showed the real cause on every failed revision:

```
Out-of-memory event detected in container
```

## Root cause

The `hasura/graphql-engine:v2.19.0.cli-migrations-v3` image starts a **temporary** engine to run `migrate apply` + `metadata apply` at boot, which overlaps in memory with the **real** engine it then starts. Combined with a grown schema cache (1386 migrations, many tables + event triggers), the startup peak exceeded the **1024M** limit → OOM-kill before port 8080 opens → startup probe times out → revision rejected.

This is not a config regression — memory was 1024M on both good and bad revisions. Notably, the running revision 00184 also OOM'd **at rest** (no pending migrations) on 2026-07-22, so production was near the ceiling even without migration activity.

Staging shares the same 1024M default and OOM'd intermittently too; it only "looked fine" because its tiny dataset + frequent merges kept the per-boot peak lower.

## Change

Raise `hasura_memory_limit` default `1024M → 2048M` (1 vCPU unchanged; well within Cloud Run's 4 GiB/vCPU limit). ~$6.6/month extra per always-on instance.

## Deployment note

Production was already **hotfixed live** to unstick it: `gcloud run services update hasura --memory 2Gi` → revision `hasura-00190-xkn`, now healthy and serving 100% traffic (verified `https://hasura.opencampus.sh/healthz` → 200). This PR persists the change so a future `terraform apply` doesn't revert to 1024M. The live service is `2Gi` while this sets `2048M` (~5% less, harmless); the next apply reconciles.

Also benefits staging, which shares this default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)