### PR TITLE
feat(menu): group account menu into sections and move Projects to Settings

### DIFF
--- a/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
+++ b/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
@@ -18,6 +18,14 @@ interface IProps {
   setVisible: (visible: boolean) => void;
 }
 
+// Shared class for the nested navigation links. The negative margins + padding make the link fill
+// the whole MenuItem so the clickable area matches the row. On touch devices (coarse pointer) we
+// enforce a >=44px (min-h-11) target and vertically center the label; fine-pointer devices keep the
+// tighter rows so the full admin menu still fits on smaller laptop screens.
+const MENU_LINK_CLASS =
+  'block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug touch-manipulation ' +
+  'pointer-coarse:flex pointer-coarse:items-center pointer-coarse:min-h-11';
+
 // Replace with styled
 const StyledMenu = styled(MaterialMenu)(() => ({
   '& .MuiPaper-root': {
@@ -121,13 +129,13 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
       <ListSubheader disableSticky>{t('menu.section_personal')}</ListSubheader>
 
       <MenuItem onClick={closeMenu} selected={isActiveRoute('/profile')}>
-        <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/profile">
+        <Link className={MENU_LINK_CLASS} href="/profile">
           {t('menu.profile')}
         </Link>
       </MenuItem>
 
       <MenuItem onClick={closeMenu} selected={isActiveRoute('/my-certificates')}>
-        <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/my-certificates">
+        <Link className={MENU_LINK_CLASS} href="/my-certificates">
           {t('menu.my_certificates')}
         </Link>
       </MenuItem>
@@ -137,7 +145,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {canManageCoursesMenu && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/courses')}>
-          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/courses">
+          <Link className={MENU_LINK_CLASS} href="/manage/courses">
             {t('menu.courses')}
           </Link>
         </MenuItem>
@@ -145,7 +153,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {canManageEventsMenu && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/events')}>
-          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/events">
+          <Link className={MENU_LINK_CLASS} href="/manage/events">
             {t('menu.events')}
           </Link>
         </MenuItem>
@@ -153,7 +161,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {canManageDegreesMenu && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/degrees')}>
-          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/degrees">
+          <Link className={MENU_LINK_CLASS} href="/manage/degrees">
             {t('menu.degrees')}
           </Link>
         </MenuItem>
@@ -161,7 +169,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/users')}>
-          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/users">
+          <Link className={MENU_LINK_CLASS} href="/manage/users">
             {t('menu.user')}
           </Link>
         </MenuItem>
@@ -169,7 +177,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/experts')}>
-          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/experts">
+          <Link className={MENU_LINK_CLASS} href="/manage/experts">
             {t('menu.experts')}
           </Link>
         </MenuItem>
@@ -177,7 +185,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/calendar')}>
-          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/calendar">
+          <Link className={MENU_LINK_CLASS} href="/manage/calendar">
             {t('menu.calendar')}
           </Link>
         </MenuItem>
@@ -185,7 +193,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/statistics')}>
-          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/statistics">
+          <Link className={MENU_LINK_CLASS} href="/statistics">
             {t('menu.statistics')}
           </Link>
         </MenuItem>
@@ -196,7 +204,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
           onClick={closeMenu}
           selected={isActiveRoute('/manage/settings') || router.pathname.startsWith('/manage/settings/')}
         >
-          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/settings">
+          <Link className={MENU_LINK_CLASS} href="/manage/settings">
             {t('menu.settings')}
           </Link>
         </MenuItem>
@@ -208,7 +216,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
       {isInstructorOrAdmin && (
         <MenuItem onClick={closeMenu}>
           <Link
-            className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug"
+            className={MENU_LINK_CLASS}
             href="https://opencampus.gitbook.io/kursleitungshandbuch/"
             target="_blank"
             rel="noopener noreferrer"
@@ -219,7 +227,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
       )}
 
       <MenuItem onClick={closeMenu}>
-        <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="https://opencampus.gitbook.io/faq/" target="_blank">
+        <Link className={MENU_LINK_CLASS} href="https://opencampus.gitbook.io/faq/" target="_blank">
           {t('menu.faq')}
         </Link>
       </MenuItem>

--- a/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
+++ b/frontend-nx/apps/edu-hub/components/layout/Menu.tsx
@@ -22,42 +22,45 @@ interface IProps {
 const StyledMenu = styled(MaterialMenu)(() => ({
   '& .MuiPaper-root': {
     minWidth: '225px',
-    padding: '1rem 2rem',
-    backgroundColor: 'var(--eduhub-fill-primary, #ffffff) !important',
-    color: 'var(--eduhub-label-primary, #222222) !important',
+    padding: '0.5rem 2rem',
+    backgroundColor: 'var(--eduhub-fill-primary) !important',
+    color: 'var(--eduhub-label-primary) !important',
     borderRadius: '8px',
     boxShadow: '0 4px 6px rgba(0, 0, 0, 0.1)',
   },
   '& .MuiMenuItem-root': {
-    color: 'var(--eduhub-label-primary, #222222) !important',
-    backgroundColor: 'var(--eduhub-fill-primary, #ffffff) !important',
-    padding: '0.75rem 1rem',
+    color: 'var(--eduhub-label-primary) !important',
+    backgroundColor: 'var(--eduhub-fill-primary) !important',
+    padding: '0.375rem 1rem',
     '&:hover': {
-      backgroundColor: '#E5E5E5 !important', // Slightly darker than selected for better contrast
+      backgroundColor: 'var(--eduhub-fill-disabled) !important', // Slightly darker than selected for better contrast
     },
     '&.Mui-selected': {
-      backgroundColor: 'var(--eduhub-bg-secondary, #F2F2F2) !important',
-      borderLeft: '3px solid var(--eduhub-warning)',
-      paddingLeft: 'calc(1rem - 3px)',
+      backgroundColor: 'var(--eduhub-bg-secondary) !important',
+      // Inset accent bar for the active route — drawn as a box-shadow so it never shifts
+      // the layout or renders as a ragged partial border the way a `border-left` would.
+      boxShadow: 'inset 3px 0 0 var(--eduhub-warning)',
       '&:hover': {
-        backgroundColor: '#E5E5E5 !important', // Slightly darker than selected
+        backgroundColor: 'var(--eduhub-fill-disabled) !important', // Slightly darker than selected
       },
     },
   },
   '& .MuiListSubheader-root': {
     backgroundColor: 'transparent',
-    color: 'var(--eduhub-label-secondary, #666666)',
+    color: 'var(--eduhub-label-secondary)',
     fontFamily: 'inherit',
     fontSize: '0.6875rem', // 11px
     fontWeight: 600,
-    lineHeight: 2,
+    lineHeight: 1.3,
     letterSpacing: '0.06em',
     textTransform: 'uppercase',
-    padding: '0.5rem 1rem 0.25rem',
+    // No horizontal padding so the label's left edge lines up with the section
+    // dividers (which span the full menu width), sitting left of the item labels.
+    padding: '0.5rem 0 0.125rem',
   },
   '& .MuiDivider-root': {
-    borderColor: '#E5E5E5',
-    margin: '0.5rem 0',
+    borderColor: 'var(--eduhub-border-primary)',
+    margin: '0.25rem 0',
   },
 }));
 
@@ -118,13 +121,13 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
       <ListSubheader disableSticky>{t('menu.section_personal')}</ListSubheader>
 
       <MenuItem onClick={closeMenu} selected={isActiveRoute('/profile')}>
-        <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/profile">
+        <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/profile">
           {t('menu.profile')}
         </Link>
       </MenuItem>
 
       <MenuItem onClick={closeMenu} selected={isActiveRoute('/my-certificates')}>
-        <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/my-certificates">
+        <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/my-certificates">
           {t('menu.my_certificates')}
         </Link>
       </MenuItem>
@@ -134,7 +137,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {canManageCoursesMenu && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/courses')}>
-          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/courses">
+          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/courses">
             {t('menu.courses')}
           </Link>
         </MenuItem>
@@ -142,7 +145,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {canManageEventsMenu && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/events')}>
-          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/events">
+          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/events">
             {t('menu.events')}
           </Link>
         </MenuItem>
@@ -150,23 +153,15 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {canManageDegreesMenu && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/degrees')}>
-          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/degrees">
+          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/degrees">
             {t('menu.degrees')}
           </Link>
         </MenuItem>
       )}
 
       {isAdmin && (
-        <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/projects')}>
-          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/projects">
-            {t('menu.projects')}
-          </Link>
-        </MenuItem>
-      )}
-
-      {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/users')}>
-          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/users">
+          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/users">
             {t('menu.user')}
           </Link>
         </MenuItem>
@@ -174,7 +169,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/experts')}>
-          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/experts">
+          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/experts">
             {t('menu.experts')}
           </Link>
         </MenuItem>
@@ -182,7 +177,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/manage/calendar')}>
-          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/calendar">
+          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/calendar">
             {t('menu.calendar')}
           </Link>
         </MenuItem>
@@ -190,7 +185,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
 
       {isAdmin && (
         <MenuItem onClick={closeMenu} selected={isActiveRoute('/statistics')}>
-          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/statistics">
+          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/statistics">
             {t('menu.statistics')}
           </Link>
         </MenuItem>
@@ -201,7 +196,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
           onClick={closeMenu}
           selected={isActiveRoute('/manage/settings') || router.pathname.startsWith('/manage/settings/')}
         >
-          <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="/manage/settings">
+          <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="/manage/settings">
             {t('menu.settings')}
           </Link>
         </MenuItem>
@@ -213,7 +208,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
       {isInstructorOrAdmin && (
         <MenuItem onClick={closeMenu}>
           <Link
-            className="block -my-3 -mx-4 py-3 px-4 text-lg"
+            className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug"
             href="https://opencampus.gitbook.io/kursleitungshandbuch/"
             target="_blank"
             rel="noopener noreferrer"
@@ -224,7 +219,7 @@ export const Menu: FC<IProps> = ({ anchorElement, isVisible, setVisible }) => {
       )}
 
       <MenuItem onClick={closeMenu}>
-        <Link className="block -my-3 -mx-4 py-3 px-4 text-lg" href="https://opencampus.gitbook.io/faq/" target="_blank">
+        <Link className="block -my-1.5 -mx-4 py-1.5 px-4 text-lg leading-snug" href="https://opencampus.gitbook.io/faq/" target="_blank">
           {t('menu.faq')}
         </Link>
       </MenuItem>

--- a/frontend-nx/apps/edu-hub/components/pages/ManageProjectsContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageProjectsContent/index.tsx
@@ -68,7 +68,12 @@ const PROJECT_LIST_SCOPE_WHERE = {
   ],
 };
 
-const ManageProjectsContent: FC = () => {
+type ManageProjectsContentProps = {
+  /** When true, rendered inside SettingsLayout (no page header / max-width wrapper). */
+  inSettingsLayout?: boolean;
+};
+
+const ManageProjectsContent: FC<ManageProjectsContentProps> = ({ inSettingsLayout = false }) => {
   const t = useTranslations('manageProjects');
   const tCommon = useTranslations('common');
 
@@ -318,8 +323,8 @@ const ManageProjectsContent: FC = () => {
   );
 
   return (
-    <div className="max-w-screen-xl mx-auto">
-      <CommonPageHeader headline={t('headline')} />
+    <div className={inSettingsLayout ? '' : 'max-w-screen-xl mx-auto'}>
+      {!inSettingsLayout && <CommonPageHeader headline={t('headline')} />}
 
       <div className="flex flex-col sm:flex-row gap-4 mb-4">
         <DropDownSelector

--- a/frontend-nx/apps/edu-hub/components/pages/ManageSettings/config.ts
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageSettings/config.ts
@@ -5,6 +5,7 @@ import {
   MdOutlineWorkOutline,
   MdOutlineDescription,
   MdOutlineEmail,
+  MdOutlineFolderOpen,
   MdOutlineEventNote,
   MdOutlineGroups,
   MdOutlineBallot,
@@ -36,6 +37,7 @@ export type SettingsNavItemId =
   | 'programs'
   | 'attendance-certificates'
   | 'project-types'
+  | 'projects'
   | 'documentation-instructions'
   | 'onboarding-texts'
   | 'course-groups'
@@ -125,6 +127,14 @@ export const SETTINGS_NAV_ITEMS: Record<SettingsNavItemId, SettingsNavItemDef> =
     status: 'live',
     groupId: 'programs',
   },
+  projects: {
+    id: 'projects',
+    icon: MdOutlineFolderOpen,
+    href: '/manage/settings/projects',
+    requiredCapability: 'admin',
+    status: 'live',
+    groupId: 'programs',
+  },
   'documentation-instructions': {
     id: 'documentation-instructions',
     icon: MdOutlineDescription,
@@ -199,6 +209,7 @@ export const SETTINGS_NAV_GROUPS: SettingsNavGroupDef[] = [
       'programs',
       'attendance-certificates',
       'project-types',
+      'projects',
       'documentation-instructions',
       'onboarding-texts',
       'course-groups',

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -46,10 +46,7 @@
       "courses": "Kurse",
       "events": "Veranstaltungen",
       "degrees": "Degrees",
-      "projects": "Projekte",
       "programs": "Programme",
-      "organizations": "Organisationen",
-      "location_addresses": "Veranstaltungsadressen",
       "settings": "Einstellungen",
       "calendar": "Kalender",
       "statistics": "Statistiken",
@@ -2591,6 +2588,10 @@
         "project-types": {
           "label": "Projekttypen",
           "description": "Standard-Leistungszertifikate und Dokumentationsanleitungen pro Projekttyp"
+        },
+        "projects": {
+          "label": "Projekte",
+          "description": "Projekte veröffentlichen, verbergen und verschlagworten"
         },
         "documentation-instructions": {
           "label": "Dokumentationsanleitungen",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -46,10 +46,7 @@
       "courses": "Courses",
       "events": "Events",
       "degrees": "Degrees",
-      "projects": "Projects",
       "programs": "Programs",
-      "organizations": "Organizations",
-      "location_addresses": "Location Addresses",
       "settings": "Settings",
       "calendar": "Calendar",
       "statistics": "Statistics",
@@ -2606,6 +2603,10 @@
         "project-types": {
           "label": "Project types",
           "description": "Default achievement certificate templates and documentation instructions per project type"
+        },
+        "projects": {
+          "label": "Projects",
+          "description": "Publish, unpublish and tag projects"
         },
         "documentation-instructions": {
           "label": "Documentation instructions",

--- a/frontend-nx/apps/edu-hub/pages/manage/projects/index.tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/projects/index.tsx
@@ -2,31 +2,13 @@
 import path from 'path';
 path.resolve('./next.config.js');
 
-import Head from 'next/head';
-import { FC } from 'react';
-import { Page } from '../../../components/layout/Page';
-import { OnlyAdmin } from '../../../components/common/OnlyLoggedIn';
+import { GetServerSideProps } from 'next';
 
-import ManageProjectsContent from '../../../components/pages/ManageProjectsContent';
+/** @deprecated Use /manage/settings/projects — kept for bookmarks and external links. */
+export const getServerSideProps: GetServerSideProps = async () => ({
+  redirect: { destination: '/manage/settings/projects', permanent: false },
+});
 
-const ManageProjects: FC = () => {
-  return (
-    <>
-      <Head>
-        <title>EduHub | opencampus.sh</title>
-        <link rel="icon" href="/favicon.png" />
-      </Head>
-      <div className="max-w-screen-xl mx-auto">
-        <Page>
-          <div className="min-h-[77vh]">
-            <OnlyAdmin showFeedback={true}>
-              <ManageProjectsContent />
-            </OnlyAdmin>
-          </div>
-        </Page>
-      </div>
-    </>
-  );
-};
-
-export default ManageProjects;
+export default function ManageProjectsRedirect() {
+  return null;
+}

--- a/frontend-nx/apps/edu-hub/pages/manage/settings/projects.tsx
+++ b/frontend-nx/apps/edu-hub/pages/manage/settings/projects.tsx
@@ -1,0 +1,12 @@
+import { FC } from 'react';
+
+import ManageProjectsContent from '../../../components/pages/ManageProjectsContent';
+import SettingsSectionPage from '../../../components/pages/ManageSettings/SettingsSectionPage';
+
+const ProjectsSettingsPage: FC = () => (
+  <SettingsSectionPage itemId="projects">
+    <ManageProjectsContent inSettingsLayout />
+  </SettingsSectionPage>
+);
+
+export default ProjectsSettingsPage;


### PR DESCRIPTION
## Summary

Implements **Option 1** of the account-menu redesign (grouped dropdown) and moves the rarely-used **Projekte** admin screen into Settings.

### Menu grouping & polish (`Menu.tsx`)
- Group the account dropdown under **Persönlich / Verwaltung / Hilfe** section headers with dividers. The Verwaltung header only shows when the user actually has management entries (plain instructors skip it).
- Subheaders align with the divider start — slightly left of the item labels.
- Tighter row spacing so the full admin menu fits smaller laptop screens.
- Replaced the active-item `border-left` (which rendered as a ragged partial edge and read as a stray red border) with a clean **inset box-shadow accent**.
- All colors now come from semantic `--eduhub-*` tokens — no hardcoded hex.

### Move Projects into Settings
Projekte is rarely used and mainly for admin publish/unpublish + tagging, so it's a better fit under Settings than the operational Verwaltung list:
- New settings sub-page at `/manage/settings/projects` (Programme group), following the Organizations / Location-addresses pattern.
- Old `/manage/projects` route now redirects (keeps bookmarks working).
- `ManageProjectsContent` gained an `inSettingsLayout` prop (drops the page header / max-width wrapper when embedded).
- Access is unchanged: still admin-only.

### Translations
- Added `menu.section_*` and `manageSettings.nav.items.projects` labels (EN/DE).
- Removed now-unused `menu.*` keys (`projects`, `organizations`, `location_addresses`).

## Verification
- ESLint clean; `tsc --noEmit` reports no errors in the changed files.
- `config.test.ts` (settings nav registry + EN/DE label parity) passes.
- Both locale JSON files validate.

> Note: two other menu keys (`menu.programs`, `menu.admin_users`) are also currently unused but were left in place, as they were added by the in-progress settings-sidebar / org-admin work rather than this redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Projects section in Settings to publish, unpublish, and tag projects.
  * Added Projects to the settings navigation, with updated English and German labels and descriptions.
* **Improvements**
  * Updated the navigation menu styling (spacing, dividers, hover/selected visuals, and active-route emphasis).
  * Moved project management into the Settings layout and updated the Projects page routing (existing project links now redirect to the new Settings location).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->