### PR TITLE
feat(org-admin): settings defaults, default programs & program-type decoupling

### DIFF
--- a/backend/metadata/databases/default/tables/public_Course.yaml
+++ b/backend/metadata/databases/default/tables/public_Course.yaml
@@ -409,6 +409,15 @@ update_permissions:
                             _eq: X-Hasura-User-Id
                         - canManageDegrees:
                             _eq: true
+          # A settings admin manages every program type for their organization (no type constraint).
+          - Program:
+              Organization:
+                OrganizationAdmins:
+                  _and:
+                    - userId:
+                        _eq: X-Hasura-User-Id
+                    - canManageSettings:
+                        _eq: true
       check:
         _or:
           - Program:
@@ -444,6 +453,15 @@ update_permissions:
                             _eq: X-Hasura-User-Id
                         - canManageDegrees:
                             _eq: true
+          # A settings admin manages every program type for their organization (no type constraint).
+          - Program:
+              Organization:
+                OrganizationAdmins:
+                  _and:
+                    - userId:
+                        _eq: X-Hasura-User-Id
+                    - canManageSettings:
+                        _eq: true
 insert_permissions:
   - role: org_admin_access
     permission:
@@ -516,6 +534,15 @@ insert_permissions:
                             _eq: X-Hasura-User-Id
                         - canManageDegrees:
                             _eq: true
+          # A settings admin manages every program type for their organization (no type constraint).
+          - Program:
+              Organization:
+                OrganizationAdmins:
+                  _and:
+                    - userId:
+                        _eq: X-Hasura-User-Id
+                    - canManageSettings:
+                        _eq: true
 delete_permissions:
   - role: org_admin_access
     permission:
@@ -554,3 +581,12 @@ delete_permissions:
                             _eq: X-Hasura-User-Id
                         - canManageDegrees:
                             _eq: true
+          # A settings admin manages every program type for their organization (no type constraint).
+          - Program:
+              Organization:
+                OrganizationAdmins:
+                  _and:
+                    - userId:
+                        _eq: X-Hasura-User-Id
+                    - canManageSettings:
+                        _eq: true

--- a/backend/metadata/databases/default/tables/public_CourseEnrollment.yaml
+++ b/backend/metadata/databases/default/tables/public_CourseEnrollment.yaml
@@ -57,6 +57,65 @@ insert_permissions:
         - userId
         - location
         - termsAcceptedAt
+  # Org admins may enroll users into courses whose program they manage (per-type capability or
+  # canManageSettings). The check resolves the target course's program/organization.
+  - role: org_admin_access
+    permission:
+      check:
+        _or:
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: EVENTS
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageEvents:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: COURSES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageCourses:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: DEGREES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageDegrees:
+                              _eq: true
+          - Course:
+              Program:
+                Organization:
+                  OrganizationAdmins:
+                    _and:
+                      - userId:
+                          _eq: X-Hasura-User-Id
+                      - canManageSettings:
+                          _eq: true
+      columns:
+        - courseId
+        - userId
+        - status
+        - billingOrganizationId
+        - motivationLetter
+        - location
+        - termsAcceptedAt
 select_permissions:
   - role: instructor_access
     permission:
@@ -109,17 +168,26 @@ select_permissions:
         - userId
         - location
       filter: {}
-  # Org admins need enrollment counts on /manage/courses (AdminCourseList). Scoped to enrollments
-  # for courses whose program belongs to an organization they administer, and only when their
-  # OrganizationAdmin grant includes the capability matching that program type (same rules as
-  # Course org_admin_access update/delete).
+  # Org admins may read enrollments for courses whose program belongs to an organization they
+  # administer, gated by the capability matching that program type or by canManageSettings. The
+  # column set mirrors instructor_access so the management UI can display/edit the same fields.
   - role: org_admin_access
     permission:
       columns:
         - id
         - courseId
+        - userId
         - status
+        - motivationLetter
         - motivationRating
+        - achievementCertificateURL
+        - attendanceCertificateURL
+        - created_at
+        - updated_at
+        - billingOrganizationId
+        - invitationExpirationDate
+        - location
+        - termsAcceptedAt
       filter:
         _or:
           - Course:
@@ -158,6 +226,15 @@ select_permissions:
                               _eq: X-Hasura-User-Id
                           - canManageDegrees:
                               _eq: true
+          - Course:
+              Program:
+                Organization:
+                  OrganizationAdmins:
+                    _and:
+                      - userId:
+                          _eq: X-Hasura-User-Id
+                      - canManageSettings:
+                          _eq: true
       allow_aggregations: true
 update_permissions:
   - role: instructor_access
@@ -209,6 +286,112 @@ update_permissions:
           - userId:
               _eq: X-Hasura-User-Id
       check: {}
+  # Org admins may update enrollments for courses whose program they manage. There is no delete
+  # permission by design: "removing" an enrollment is a status change (e.g. to CANCELLED), which
+  # avoids the destructive ProjectEnrollment / CourseEnrollmentAddon cascades.
+  - role: org_admin_access
+    permission:
+      columns:
+        - status
+        - motivationRating
+        - billingOrganizationId
+        - invitationExpirationDate
+        - location
+        - termsAcceptedAt
+      filter:
+        _or:
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: EVENTS
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageEvents:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: COURSES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageCourses:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: DEGREES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageDegrees:
+                              _eq: true
+          - Course:
+              Program:
+                Organization:
+                  OrganizationAdmins:
+                    _and:
+                      - userId:
+                          _eq: X-Hasura-User-Id
+                      - canManageSettings:
+                          _eq: true
+      check:
+        _or:
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: EVENTS
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageEvents:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: COURSES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageCourses:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: DEGREES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageDegrees:
+                              _eq: true
+          - Course:
+              Program:
+                Organization:
+                  OrganizationAdmins:
+                    _and:
+                      - userId:
+                          _eq: X-Hasura-User-Id
+                      - canManageSettings:
+                          _eq: true
 event_triggers:
   - name: add_confirmed_user_to_mm
     definition:

--- a/backend/metadata/databases/default/tables/public_MailTemplate.yaml
+++ b/backend/metadata/databases/default/tables/public_MailTemplate.yaml
@@ -8,6 +8,67 @@ object_relationships:
   - name: MailTemplateType
     using:
       foreign_key_constraint_on: type
+insert_permissions:
+  # Org admins may create course-specific templates for courses whose program they manage (per-type
+  # capability or canManageSettings). System-default templates (courseId null) stay super-admin-only:
+  # every branch below requires a Course -> Program, so a null-courseId row can never pass the check.
+  - role: org_admin_access
+    permission:
+      check:
+        _or:
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: EVENTS
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageEvents:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: COURSES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageCourses:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: DEGREES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageDegrees:
+                              _eq: true
+          - Course:
+              Program:
+                Organization:
+                  OrganizationAdmins:
+                    _and:
+                      - userId:
+                          _eq: X-Hasura-User-Id
+                      - canManageSettings:
+                          _eq: true
+      columns:
+        - type
+        - courseId
+        - subject
+        - content
+        - from
+        - cc
+        - bcc
 select_permissions:
   - role: instructor_access
     permission:
@@ -86,3 +147,160 @@ select_permissions:
                           - canManageDegrees:
                               _eq: true
       allow_aggregations: true
+update_permissions:
+  # Org admins may edit course-specific templates for courses whose program they manage. Global
+  # (courseId null) templates are excluded for the same reason as insert.
+  - role: org_admin_access
+    permission:
+      columns:
+        - type
+        - courseId
+        - subject
+        - content
+        - from
+        - cc
+        - bcc
+      filter:
+        _or:
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: EVENTS
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageEvents:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: COURSES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageCourses:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: DEGREES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageDegrees:
+                              _eq: true
+          - Course:
+              Program:
+                Organization:
+                  OrganizationAdmins:
+                    _and:
+                      - userId:
+                          _eq: X-Hasura-User-Id
+                      - canManageSettings:
+                          _eq: true
+      check:
+        _or:
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: EVENTS
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageEvents:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: COURSES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageCourses:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: DEGREES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageDegrees:
+                              _eq: true
+          - Course:
+              Program:
+                Organization:
+                  OrganizationAdmins:
+                    _and:
+                      - userId:
+                          _eq: X-Hasura-User-Id
+                      - canManageSettings:
+                          _eq: true
+delete_permissions:
+  - role: org_admin_access
+    permission:
+      filter:
+        _or:
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: EVENTS
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageEvents:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: COURSES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageCourses:
+                              _eq: true
+          - Course:
+              Program:
+                _and:
+                  - type:
+                      _eq: DEGREES
+                  - Organization:
+                      OrganizationAdmins:
+                        _and:
+                          - userId:
+                              _eq: X-Hasura-User-Id
+                          - canManageDegrees:
+                              _eq: true
+          - Course:
+              Program:
+                Organization:
+                  OrganizationAdmins:
+                    _and:
+                      - userId:
+                          _eq: X-Hasura-User-Id
+                      - canManageSettings:
+                          _eq: true

--- a/backend/metadata/databases/default/tables/public_Program.yaml
+++ b/backend/metadata/databases/default/tables/public_Program.yaml
@@ -171,6 +171,14 @@ update_permissions:
                           _eq: X-Hasura-User-Id
                       - canManageDegrees:
                           _eq: true
+          # A settings admin manages every program type for their organization (no type constraint).
+          - Organization:
+              OrganizationAdmins:
+                _and:
+                  - userId:
+                      _eq: X-Hasura-User-Id
+                  - canManageSettings:
+                      _eq: true
       check:
         _or:
           - _and:
@@ -203,6 +211,14 @@ update_permissions:
                           _eq: X-Hasura-User-Id
                       - canManageDegrees:
                           _eq: true
+          # A settings admin manages every program type for their organization (no type constraint).
+          - Organization:
+              OrganizationAdmins:
+                _and:
+                  - userId:
+                      _eq: X-Hasura-User-Id
+                  - canManageSettings:
+                      _eq: true
 insert_permissions:
   # A new program may only be created in an organization the admin manages, and only of a type
   # they are allowed to manage (the check reuses the same per-type scope as update).
@@ -264,6 +280,14 @@ insert_permissions:
                           _eq: X-Hasura-User-Id
                       - canManageDegrees:
                           _eq: true
+          # A settings admin manages every program type for their organization (no type constraint).
+          - Organization:
+              OrganizationAdmins:
+                _and:
+                  - userId:
+                      _eq: X-Hasura-User-Id
+                  - canManageSettings:
+                      _eq: true
 delete_permissions:
   - role: org_admin_access
     permission:
@@ -299,3 +323,11 @@ delete_permissions:
                           _eq: X-Hasura-User-Id
                       - canManageDegrees:
                           _eq: true
+          # A settings admin manages every program type for their organization (no type constraint).
+          - Organization:
+              OrganizationAdmins:
+                _and:
+                  - userId:
+                      _eq: X-Hasura-User-Id
+                  - canManageSettings:
+                      _eq: true

--- a/backend/migrations/default/1784879499085_organization_admin_settings_and_default_programs/down.sql
+++ b/backend/migrations/default/1784879499085_organization_admin_settings_and_default_programs/down.sql
@@ -1,0 +1,11 @@
+DROP TRIGGER IF EXISTS "organization_admin_keep_last_settings_admin_delete" ON "public"."OrganizationAdmin";
+DROP TRIGGER IF EXISTS "organization_admin_keep_last_settings_admin_update" ON "public"."OrganizationAdmin";
+DROP TRIGGER IF EXISTS "organization_admin_seed_default_programs" ON "public"."OrganizationAdmin";
+DROP TRIGGER IF EXISTS "organization_admin_force_first_settings" ON "public"."OrganizationAdmin";
+
+DROP FUNCTION IF EXISTS "public"."organization_admin_keep_last_settings_admin"();
+DROP FUNCTION IF EXISTS "public"."organization_admin_seed_default_programs"();
+DROP FUNCTION IF EXISTS "public"."organization_admin_force_first_settings"();
+
+-- Note: default Program rows already seeded by trigger C are intentionally left in place
+-- (this migration reverses schema/triggers, not seeded data).

--- a/backend/migrations/default/1784879499085_organization_admin_settings_and_default_programs/up.sql
+++ b/backend/migrations/default/1784879499085_organization_admin_settings_and_default_programs/up.sql
@@ -82,6 +82,11 @@ BEGIN
     RETURN COALESCE(NEW, OLD);
   END IF;
 
+  -- Serialize against concurrent demote/delete (and the first-admin insert) for this organization,
+  -- so the "another settings admin exists" check below cannot be defeated by an uncommitted sibling
+  -- transaction demoting/deleting a different one of the org's last settings admins (TOCTOU).
+  PERFORM pg_advisory_xact_lock(hashtext('OrganizationAdmin'), OLD."organizationId");
+
   IF TG_OP = 'UPDATE' THEN
     IF OLD."canManageSettings" = true AND NEW."canManageSettings" = false THEN
       org_id := OLD."organizationId";

--- a/backend/migrations/default/1784879499085_organization_admin_settings_and_default_programs/up.sql
+++ b/backend/migrations/default/1784879499085_organization_admin_settings_and_default_programs/up.sql
@@ -1,0 +1,137 @@
+-- Org-admin bootstrapping rules for the OrganizationAdmin table:
+--   A. The FIRST admin of an organization always gets canManageSettings = true, so every
+--      organization has at least one user able to manage its admin team and settings.
+--   B. An organization can never be left with zero settings admins by a non-admin caller
+--      (super-admins / migrations bypass the guard so they can always clean up).
+--   C. The first admin of an organization triggers seeding of one default Program per type
+--      (COURSES / EVENTS / DEGREES), so a fresh organization has something to manage.
+
+-- A. Force canManageSettings on the first admin of an organization.
+CREATE OR REPLACE FUNCTION "public"."organization_admin_force_first_settings"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Serialize concurrent inserts for the same organization so the "first admin" checks in
+  -- this function and in the AFTER INSERT seed are reliable (prevents duplicate seeding).
+  PERFORM pg_advisory_xact_lock(hashtext('OrganizationAdmin'), NEW."organizationId");
+
+  IF NOT EXISTS (
+    SELECT 1 FROM "public"."OrganizationAdmin"
+    WHERE "organizationId" = NEW."organizationId"
+  ) THEN
+    NEW."canManageSettings" := true;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- C. Seed default programs when the just-inserted row is the organization's first admin.
+CREATE OR REPLACE FUNCTION "public"."organization_admin_seed_default_programs"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- AFTER INSERT: the new row is already present, so the first admin means exactly one row.
+  IF (
+    SELECT count(*) FROM "public"."OrganizationAdmin"
+    WHERE "organizationId" = NEW."organizationId"
+  ) = 1 THEN
+    -- Idempotent: skip any type the organization already has a program for. `type` is the real
+    -- discriminator; `title` is a friendly, editable label and `shortTitle` is a free-text label.
+    INSERT INTO "public"."Program" (
+      "type", "title", "shortTitle", "organizationId",
+      "visibility", "defaultMaxMissedSessions",
+      "lectureStart", "lectureEnd", "applicationStart",
+      "defaultApplicationEnd", "achievementRecordUploadDeadline"
+    )
+    SELECT seed."type", seed."title", seed."shortTitle", NEW."organizationId",
+           false, 2,
+           CURRENT_DATE, CURRENT_DATE, CURRENT_DATE, CURRENT_DATE, CURRENT_DATE
+    FROM (VALUES
+      ('COURSES', 'Kurse',   'COURSES'),
+      ('EVENTS',  'Events',  'EVENTS'),
+      ('DEGREES', 'Degrees', 'DEGREES')
+    ) AS seed("type", "title", "shortTitle")
+    WHERE NOT EXISTS (
+      SELECT 1 FROM "public"."Program" p
+      WHERE p."organizationId" = NEW."organizationId"
+        AND p."type" = seed."type"
+    );
+  END IF;
+
+  RETURN NULL; -- AFTER trigger; return value is ignored.
+END;
+$$;
+
+-- B. Keep at least one settings admin per organization (guards UPDATE canManageSettings true->false
+--    and DELETE of a settings admin). Super-admins and direct DB/migration callers are exempt.
+CREATE OR REPLACE FUNCTION "public"."organization_admin_keep_last_settings_admin"()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  caller_role text;
+  org_id integer;
+BEGIN
+  -- Only the Hasura admin (super-admin) sets no/`admin` role here; org_admin_access and other
+  -- non-admin roles are guarded. A NULL setting means a direct DB / migration call -> exempt.
+  caller_role := current_setting('hasura.user', true)::json ->> 'x-hasura-role';
+  IF caller_role IS NULL OR caller_role = 'admin' THEN
+    RETURN COALESCE(NEW, OLD);
+  END IF;
+
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD."canManageSettings" = true AND NEW."canManageSettings" = false THEN
+      org_id := OLD."organizationId";
+      IF NOT EXISTS (
+        SELECT 1 FROM "public"."OrganizationAdmin"
+        WHERE "organizationId" = org_id
+          AND "canManageSettings" = true
+          AND "id" <> OLD."id"
+      ) THEN
+        RAISE EXCEPTION 'Cannot remove the last settings admin of organization %', org_id
+          USING ERRCODE = 'check_violation', HINT = 'last_settings_admin';
+      END IF;
+    END IF;
+    RETURN NEW;
+  ELSIF TG_OP = 'DELETE' THEN
+    IF OLD."canManageSettings" = true THEN
+      org_id := OLD."organizationId";
+      IF NOT EXISTS (
+        SELECT 1 FROM "public"."OrganizationAdmin"
+        WHERE "organizationId" = org_id
+          AND "canManageSettings" = true
+          AND "id" <> OLD."id"
+      ) THEN
+        RAISE EXCEPTION 'Cannot remove the last settings admin of organization %', org_id
+          USING ERRCODE = 'check_violation', HINT = 'last_settings_admin';
+      END IF;
+    END IF;
+    RETURN OLD;
+  END IF;
+
+  RETURN COALESCE(NEW, OLD);
+END;
+$$;
+
+CREATE TRIGGER "organization_admin_force_first_settings"
+BEFORE INSERT ON "public"."OrganizationAdmin"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."organization_admin_force_first_settings"();
+
+CREATE TRIGGER "organization_admin_seed_default_programs"
+AFTER INSERT ON "public"."OrganizationAdmin"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."organization_admin_seed_default_programs"();
+
+CREATE TRIGGER "organization_admin_keep_last_settings_admin_update"
+BEFORE UPDATE ON "public"."OrganizationAdmin"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."organization_admin_keep_last_settings_admin"();
+
+CREATE TRIGGER "organization_admin_keep_last_settings_admin_delete"
+BEFORE DELETE ON "public"."OrganizationAdmin"
+FOR EACH ROW
+EXECUTE PROCEDURE "public"."organization_admin_keep_last_settings_admin"();

--- a/frontend-nx/apps/edu-hub/components/pages/CalendarContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CalendarContent/index.tsx
@@ -112,10 +112,10 @@ const CalendarContent: FC = () => {
       return { id: { _eq: -1 } }; // no courses when neither selected
     }
     if (showCourses && !showEvents) {
-      return { Program: { shortTitle: { _neq: 'EVENTS' } } };
+      return { Program: { type: { _neq: 'EVENTS' } } };
     }
     if (!showCourses && showEvents) {
-      return { Program: { shortTitle: { _eq: 'EVENTS' } } };
+      return { Program: { type: { _eq: 'EVENTS' } } };
     }
     return {};
   }, [showCourses, showEvents]);
@@ -152,9 +152,9 @@ const CalendarContent: FC = () => {
     if (!showCourses && !showEvents) {
       conditions.push({ courseId: { _eq: -1 } }); // show nothing
     } else if (showCourses && !showEvents) {
-      conditions.push({ Course: { Program: { shortTitle: { _neq: 'EVENTS' } } } });
+      conditions.push({ Course: { Program: { type: { _neq: 'EVENTS' } } } });
     } else if (!showCourses && showEvents) {
-      conditions.push({ Course: { Program: { shortTitle: { _eq: 'EVENTS' } } } });
+      conditions.push({ Course: { Program: { type: { _eq: 'EVENTS' } } } });
     }
     if (conditions.length === 0) return {};
     if (conditions.length === 1) return conditions[0];

--- a/frontend-nx/apps/edu-hub/components/pages/CalendarContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CalendarContent/index.tsx
@@ -212,8 +212,8 @@ const CalendarContent: FC = () => {
       const location = resolveLocation(session);
       const colors = getLocationColor(location);
       const courseTitle = session.Course?.title || '';
-      const programShortTitle = session.Course?.Program?.shortTitle || '';
-      const isEvent = programShortTitle === 'EVENTS';
+      // Classify by Program.type (shortTitle is a free-text label); keep shortTitle for display only.
+      const isEvent = session.Course?.Program?.type === 'EVENTS';
       const address = resolveAddress(session);
 
       const titleLine = courseTitle + (session.title ? ` – ${session.title}` : '');

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/DegreeCourses.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/DegreeCourses.tsx
@@ -68,9 +68,9 @@ export const CompletedDegreeCourses: FC<{ degreeCourseId: number }> = ({ degreeC
                 <NextLink href={`/course/${degreeEnrollment?.Course?.id}`} passHref>
                   <MuiLink className="text-label-secondary">
                     {degreeEnrollment?.Course?.title} -{' '}
-                    {degreeEnrollment?.Course?.Program?.shortTitle !== 'EVENTS'
+                    {degreeEnrollment?.Course?.Program?.type !== 'EVENTS'
                       ? ` ${t(degreeEnrollment?.Course?.Program?.title)} (${ectsTranslations[degreeEnrollment?.Course?.ects] || degreeEnrollment?.Course?.ects} ECTS)`
-                      : `${t(degreeEnrollment?.Course?.Program?.shortTitle)}`}
+                      : `${t(degreeEnrollment?.Course?.Program?.type)}`}
                   </MuiLink>
                 </NextLink>
               </li>

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/index.tsx
@@ -136,8 +136,8 @@ const CourseContent: FC<{ id: number }> = ({ id }) => {
   }
 
   // Check if course is a degree course
-  const isDegreeCourse = course.Program?.shortTitle === 'DEGREES';
-  const isEventCourse = course.Program?.shortTitle === 'EVENTS';
+  const isDegreeCourse = course.Program?.type === 'DEGREES';
+  const isEventCourse = course.Program?.type === 'EVENTS';
 
   // Check if registration requires payment
   const registrationConfig = course.registrationType 

--- a/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
@@ -149,7 +149,7 @@ const ExpandableUserRow: FC<{
             updateValueMutation={capability.mutation}
             role={manageRole}
             identifierVariables={{ itemId: row.id }}
-            refetchQueries={capability.refetchQueries ?? ['GetAdminUsers']}
+            refetchQueries={capability.refetchQueries ?? ['OrganizationAdminList']}
           />
         ))}
       </div>

--- a/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageAdminUsersContent/index.tsx
@@ -1,6 +1,7 @@
 import { FC, ReactNode, useMemo, useCallback, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { ColumnDef } from '@tanstack/react-table';
+import { DocumentNode } from 'graphql';
 import { MdStar } from 'react-icons/md';
 
 import TableGrid from '../../common/TableGrid';
@@ -15,6 +16,7 @@ import {
   ORGANIZATION_ADMIN_LIST,
   DELETE_ORGANIZATION_ADMIN,
   MANAGEABLE_ORGANIZATIONS,
+  SETTINGS_ADMIN_GRANTS,
   UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_EVENTS,
   UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_COURSES,
   UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_DEGREES,
@@ -33,16 +35,24 @@ import {
   ManageableOrganizations,
   ManageableOrganizationsVariables,
 } from '../../../queries/__generated__/ManageableOrganizations';
+import { SettingsAdminGrants } from '../../../queries/__generated__/SettingsAdminGrants';
 import AddOrganizationAdminDialog, { AdminOrganizationOption } from './AddOrganizationAdminDialog';
 
 const ExpandableUserRow: FC<{
   row: OrganizationAdminList_OrganizationAdmin;
   isSuperAdmin: boolean;
+  // True when this grant is the only settings admin of its organization: the settings capability
+  // must not be turned off here (the DB guard would reject it), so the checkbox is disabled —
+  // unless the viewer is a super-admin, who bypasses the guard at the DB level.
+  isSoleSettingsAdmin: boolean;
   onAdminStatusChange: () => void;
-}> = ({ row, isSuperAdmin, onAdminStatusChange }) => {
+}> = ({ row, isSuperAdmin, isSoleSettingsAdmin, onAdminStatusChange }) => {
   const t = useTranslations('manageAdminUsers');
   const isAdmin = useIsAdmin();
   const manageRole = useManageRole();
+
+  // Non-super-admins cannot clear the last settings admin of an org; super-admins bypass the guard.
+  const settingsLocked = isSoleSettingsAdmin && !isAdmin;
 
   const [setAdminStatus] = useAdminMutation(UPDATE_USER_ADMIN_STATUS);
 
@@ -70,7 +80,17 @@ const ExpandableUserRow: FC<{
     [onAdminStatusChange, row.User?.id, setAdminStatus]
   );
 
-  const capabilities = useMemo(
+  const capabilities = useMemo<
+    {
+      key: string;
+      label: string;
+      checked: boolean;
+      mutation: DocumentNode;
+      disabled?: boolean;
+      helpText?: string;
+      refetchQueries?: string[];
+    }[]
+  >(
     () => [
       {
         key: 'events',
@@ -101,9 +121,15 @@ const ExpandableUserRow: FC<{
         label: t('can_manage_users_and_settings'),
         checked: row.canManageSettings,
         mutation: UPDATE_ORGANIZATION_ADMIN_CAN_MANAGE_SETTINGS,
+        // Sole settings admin: block turning it off (except for super-admins, who bypass the DB
+        // guard). Refetch the list + counts on toggle so the disabled state stays in sync after
+        // granting settings to someone else first.
+        disabled: settingsLocked,
+        helpText: settingsLocked ? t('sole_settings_admin_hint') : undefined,
+        refetchQueries: ['OrganizationAdminList', 'SettingsAdminGrants'],
       },
     ],
-    [row, t]
+    [row, t, settingsLocked]
   );
 
   return (
@@ -118,10 +144,12 @@ const ExpandableUserRow: FC<{
             variant="eduhub"
             label={capability.label}
             checked={capability.checked}
+            disabled={capability.disabled}
+            helpText={capability.helpText}
             updateValueMutation={capability.mutation}
             role={manageRole}
             identifierVariables={{ itemId: row.id }}
-            refetchQueries={['GetAdminUsers']}
+            refetchQueries={capability.refetchQueries ?? ['GetAdminUsers']}
           />
         ))}
       </div>
@@ -199,6 +227,28 @@ const ManageAdminUsersContent: FC<ManageAdminUsersContentProps> = ({ inSettingsL
       };
     },
   });
+
+  // Per-organization count of settings admins, so the UI can pre-disable removing/deleting the
+  // *last* one for an org (the DB guard enforces the same rule). Role-scoped like the list: org
+  // admins see grants of their orgs, super-admins see all. Refetched after add/toggle/delete.
+  const { data: settingsAdminData, refetch: refetchSettingsAdmins } =
+    useManageQuery<SettingsAdminGrants>(SETTINGS_ADMIN_GRANTS);
+
+  const settingsAdminCountByOrg = useMemo(() => {
+    const counts = new Map<number, number>();
+    (settingsAdminData?.OrganizationAdmin ?? []).forEach((grant) => {
+      counts.set(grant.organizationId, (counts.get(grant.organizationId) ?? 0) + 1);
+    });
+    return counts;
+  }, [settingsAdminData]);
+
+  const isSoleSettingsAdmin = useCallback(
+    (row: OrganizationAdminList_OrganizationAdmin) => {
+      const orgId = row.Organization?.id;
+      return !!row.canManageSettings && orgId != null && (settingsAdminCountByOrg.get(orgId) ?? 0) <= 1;
+    },
+    [settingsAdminCountByOrg]
+  );
 
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
 
@@ -336,15 +386,19 @@ const ManageAdminUsersContent: FC<ManageAdminUsersContentProps> = ({ inSettingsL
               onSearchFilterChange={setSearchFilter}
               deleteMutation={DELETE_ORGANIZATION_ADMIN}
               deleteIdType="number"
+              // Block deleting the last settings admin of an org (the DB guard would reject it too),
+              // except for super-admins, who bypass the guard at the DB level.
+              canDeleteRow={(row) => isAdmin || !isSoleSettingsAdmin(row)}
               role={manageRole}
               error={error}
               loading={loading}
-              refetchQueries={['OrganizationAdminList', 'AdminUsers']}
+              refetchQueries={['OrganizationAdminList', 'AdminUsers', 'SettingsAdminGrants']}
               generateDeletionConfirmationQuestion={generateDeletionConfirmation}
               expandableRowComponent={({ row }) => (
                 <ExpandableUserRow
                   row={row}
                   isSuperAdmin={adminUserIds.includes(row.User?.id)}
+                  isSoleSettingsAdmin={isSoleSettingsAdmin(row)}
                   onAdminStatusChange={handleAdminStatusChange}
                 />
               )}
@@ -352,7 +406,12 @@ const ManageAdminUsersContent: FC<ManageAdminUsersContentProps> = ({ inSettingsL
             <AddOrganizationAdminDialog
               open={isAddDialogOpen}
               onClose={() => setIsAddDialogOpen(false)}
-              onSuccess={() => refetch()}
+              onSuccess={() => {
+                // Refetch the list (so a first admin's DB-forced canManageSettings shows) and the
+                // settings-admin counts (so sole-admin disabling stays correct).
+                refetch();
+                refetchSettingsAdmins();
+              }}
               organizationOptions={organizationOptions}
             />
         </div>

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/DegreeParticipationsTab/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/DegreeParticipationsTab/index.tsx
@@ -241,12 +241,12 @@ export const DegreeParticipationsTab: FC<DegreeParticipationsTabIProps> = ({ cou
     // Attended courses (not passed AND (has attendance certificate OR is an EVENT course))
     const attendedEnrollments = courseEnrollments.filter(
       (ce: CeType) =>
-        !ce.achievementCertificateURL && (ce.attendanceCertificateURL || ce.Course.Program.shortTitle === 'EVENTS')
+        !ce.achievementCertificateURL && (ce.attendanceCertificateURL || ce.Course.Program.type === 'EVENTS')
     );
 
     // Not completed courses (not passed AND not attended by new definition)
     const notCompletedEnrollments = courseEnrollments.filter(
-      (ce: CeType) => !ce.achievementCertificateURL && !ce.attendanceCertificateURL && ce.Course.Program.shortTitle !== 'EVENTS'
+      (ce: CeType) => !ce.achievementCertificateURL && !ce.attendanceCertificateURL && ce.Course.Program.type !== 'EVENTS'
     );
 
     const mapParticipation = (ce: CeType): DegreeParticipationListItem => ({

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/index.tsx
@@ -211,7 +211,7 @@ export const ManageCourseContent: FC<Props> = ({ courseId }) => {
               {t('description')}
             </div>
 
-            {course.Program.shortTitle === 'DEGREES' ? null : (
+            {course.Program.type === 'DEGREES' ? null : (
               <div className={`p-4 m-2 ${determineTabClasses(1, openTabIndex)}`} onClick={openTab1}>
                 {t('sessions')}
               </div>
@@ -223,13 +223,13 @@ export const ManageCourseContent: FC<Props> = ({ courseId }) => {
               </div>
             )}
 
-            {course.externalRegistrationLink || course.Program.shortTitle === 'DEGREES' ? null : (
+            {course.externalRegistrationLink || course.Program.type === 'DEGREES' ? null : (
               <div className={`p-4 m-2 ${determineTabClasses(3, openTabIndex)}`} onClick={openTab3}>
                 {t('participations_and_achievements')}
               </div>
             )}
 
-            {course.Program.shortTitle === 'DEGREES' ? (
+            {course.Program.type === 'DEGREES' ? (
               <div className={`p-4 m-2 ${determineTabClasses(4, openTabIndex)}`} onClick={openTab4}>
                 {t('degree_participations')}
               </div>

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/index.tsx
@@ -96,8 +96,8 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
   const sortedPrograms = useMemo(() => {
     return [...programs].sort((a, b) => {
       // Assign specific indices for 'EVENTS' and 'DEGREES'
-      const indexA = a.shortTitle === 'EVENTS' ? -2 : a.shortTitle === 'DEGREES' ? -1 : programs.indexOf(a);
-      const indexB = b.shortTitle === 'EVENTS' ? -2 : b.shortTitle === 'DEGREES' ? -1 : programs.indexOf(b);
+      const indexA = a.type === 'EVENTS' ? -2 : a.type === 'DEGREES' ? -1 : programs.indexOf(a);
+      const indexB = b.type === 'EVENTS' ? -2 : b.type === 'DEGREES' ? -1 : programs.indexOf(b);
       // Sort based on these indices
       return indexA - indexB;
     });
@@ -108,7 +108,7 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
       return undefined;
     }
     const preferredRegularProgram = sortedPrograms.find(
-      (program) => program.shortTitle !== 'EVENTS' && program.shortTitle !== 'DEGREES'
+      (program) => program.type !== 'EVENTS' && program.type !== 'DEGREES'
     );
     return (preferredRegularProgram ?? sortedPrograms[0]).id;
   }, [sortedPrograms]);
@@ -132,14 +132,14 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
     const programs: Programs_Program[] = [];
 
     // First, add EVENTS and DEGREES if they exist (maintain their priority)
-    const eventsProgram = sortedPrograms.find((p) => p.shortTitle === 'EVENTS');
-    const degreesProgram = sortedPrograms.find((p) => p.shortTitle === 'DEGREES');
+    const eventsProgram = sortedPrograms.find((p) => p.type === 'EVENTS');
+    const degreesProgram = sortedPrograms.find((p) => p.type === 'DEGREES');
 
     if (eventsProgram) programs.push(eventsProgram);
     if (degreesProgram) programs.push(degreesProgram);
 
     // Then, get other programs (excluding EVENTS and DEGREES)
-    const otherPrograms = sortedPrograms.filter((p) => p.shortTitle !== 'EVENTS' && p.shortTitle !== 'DEGREES');
+    const otherPrograms = sortedPrograms.filter((p) => p.type !== 'EVENTS' && p.type !== 'DEGREES');
 
     // Take the most recent other programs (they should already be sorted by recency)
     const recentOtherPrograms = otherPrograms.slice(0, maxOtherPrograms);

--- a/frontend-nx/apps/edu-hub/helpers/errorHandling.ts
+++ b/frontend-nx/apps/edu-hub/helpers/errorHandling.ts
@@ -69,6 +69,13 @@ export const handleForeignKeyError = (error: ApolloError, t: (key: string, optio
     }
   }
   
+  // Custom trigger guard: an organization must always keep at least one settings admin. The DB
+  // raises "Cannot remove the last settings admin of organization <id>" (see the OrganizationAdmin
+  // trigger migration). Map it to a friendly message rather than the generic fallback.
+  if (errorMessage.includes('last settings admin')) {
+    return t('error_handling.last_settings_admin');
+  }
+
   // Check for specific database constraint error messages
   if (errorMessage.includes('Cannot delete') && errorMessage.includes('because it is referenced by')) {
     // Handle specific constraint error messages like:

--- a/frontend-nx/apps/edu-hub/hooks/manageScope.ts
+++ b/frontend-nx/apps/edu-hub/hooks/manageScope.ts
@@ -57,6 +57,16 @@ const orgAdminProgramCapabilityOr = (userId: string): Program_bool_exp['_or'] =>
       },
     ],
   },
+  // A settings admin manages every program type for their organization, so this branch has no
+  // `type` constraint — it matches any program whose org has the user's grant with canManageSettings.
+  // Mirrors the type-agnostic canManageSettings branch in the Hasura org_admin_access write rules.
+  {
+    Organization: {
+      OrganizationAdmins: {
+        _and: [{ userId: { _eq: userId } }, { canManageSettings: { _eq: true } }],
+      },
+    },
+  },
 ];
 
 // Program_bool_exp scoping for the program management list.

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -257,6 +257,7 @@
       "delete_restricted_by_relationship": "{parent} können nicht gelöscht werden, wenn sie mit {child} verknüpft sind. Bitte lösche diese zuerst.",
       "delete_restricted_by_relationships": "{table} können nicht gelöscht werden, wenn sie mit anderen Einträgen verknüpft sind. Bitte lösche zuerst die anderen Einträge.",
       "generic_error": "Ein Fehler ist aufgetreten. Bitte versuche es erneut.",
+      "last_settings_admin": "Diese Organisation muss mindestens einen Nutzer mit Rechten zur Nutzer- und Einstellungsverwaltung behalten. Übertrage diese Rechte zuerst einem anderen Admin.",
       "certificate_deletion_failed": "Fehler beim Löschen der Leistungsnachweise. Bitte versuche es erneut.",
       "entities": {
         "course": "Kurse",
@@ -1925,6 +1926,7 @@
   },
   "manageAdminUsers": {
     "headline": "Admin-Benutzer",
+    "sole_settings_admin_hint": "Dies ist der einzige Nutzer mit Einstellungsrechten für diese Organisation. Übertrage die Einstellungsrechte zuerst einem anderen Admin, bevor du sie hier entfernst.",
     "first_name": "Vorname",
     "last_name": "Nachname",
     "email": "E-Mail",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -257,6 +257,7 @@
       "delete_restricted_by_relationship": "{parent} cannot be deleted when they are still associated with {child}. Please remove all {child} first.",
       "delete_restricted_by_relationships": "{table} cannot be deleted when they are associated with other records. Please remove those records first.",
       "generic_error": "An error occurred. Please try again later.",
+      "last_settings_admin": "This organization must keep at least one user with user & settings management rights. Grant it to another admin first.",
       "certificate_deletion_failed": "Failed to delete achievement certificates. Please try again.",
       "entities": {
         "course": "Courses",
@@ -1940,6 +1941,7 @@
   },
   "manageAdminUsers": {
     "headline": "Admin Users",
+    "sole_settings_admin_hint": "This is the only user with settings rights for this organization. Grant settings to another admin before removing it here.",
     "first_name": "First Name",
     "last_name": "Last Name",
     "email": "Email",

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CalendarSessions.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CalendarSessions.ts
@@ -25,6 +25,7 @@ export interface CalendarSessions_Session_Course_CourseLocations {
 export interface CalendarSessions_Session_Course_Program {
   __typename: "Program";
   id: number;
+  type: string;
   /**
    * The title of the program
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CompletedDegreeEnrollments.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CompletedDegreeEnrollments.ts
@@ -9,6 +9,7 @@
 
 export interface CompletedDegreeEnrollments_CourseEnrollment_Course_Program {
   __typename: "Program";
+  id: number;
   type: string;
   /**
    * The 6 letter short title for the program.

--- a/frontend-nx/apps/edu-hub/queries/__generated__/CompletedDegreeEnrollments.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/CompletedDegreeEnrollments.ts
@@ -9,6 +9,7 @@
 
 export interface CompletedDegreeEnrollments_CourseEnrollment_Course_Program {
   __typename: "Program";
+  type: string;
   /**
    * The 6 letter short title for the program.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/DegreeCourseProgramFields.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/DegreeCourseProgramFields.ts
@@ -1,0 +1,22 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL fragment: DegreeCourseProgramFields
+// ====================================================
+
+export interface DegreeCourseProgramFields {
+  __typename: "Program";
+  id: number;
+  type: string;
+  /**
+   * The 6 letter short title for the program.
+   */
+  shortTitle: string | null;
+  /**
+   * The title of the program
+   */
+  title: string;
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/DegreeParticipantsWithDegreeEnrollments.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/DegreeParticipantsWithDegreeEnrollments.ts
@@ -18,6 +18,7 @@ export interface DegreeParticipantsWithDegreeEnrollments_Course_by_pk_CourseEnro
 export interface DegreeParticipantsWithDegreeEnrollments_Course_by_pk_CourseEnrollments_User_CourseEnrollments_Course_Program {
   __typename: "Program";
   id: number;
+  type: string;
   /**
    * The 6 letter short title for the program.
    */

--- a/frontend-nx/apps/edu-hub/queries/__generated__/SettingsAdminGrants.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/SettingsAdminGrants.ts
@@ -1,0 +1,21 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: SettingsAdminGrants
+// ====================================================
+
+export interface SettingsAdminGrants_OrganizationAdmin {
+  __typename: "OrganizationAdmin";
+  id: number;
+  organizationId: number;
+}
+
+export interface SettingsAdminGrants {
+  /**
+   * fetch data from the table: "OrganizationAdmin"
+   */
+  OrganizationAdmin: SettingsAdminGrants_OrganizationAdmin[];
+}

--- a/frontend-nx/apps/edu-hub/queries/calendarSessions.ts
+++ b/frontend-nx/apps/edu-hub/queries/calendarSessions.ts
@@ -28,6 +28,7 @@ export const CALENDAR_SESSIONS = gql`
         }
         Program {
           id
+          type
           title
           shortTitle
         }

--- a/frontend-nx/apps/edu-hub/queries/courseDegree.ts
+++ b/frontend-nx/apps/edu-hub/queries/courseDegree.ts
@@ -1,5 +1,16 @@
 import { gql } from '@apollo/client';
 
+// Shared Program selection for the degree enrollment views, so `type` (used for classification) and
+// the display fields stay consistent across both queries.
+const DEGREE_COURSE_PROGRAM_FIELDS = gql`
+  fragment DegreeCourseProgramFields on Program {
+    id
+    type
+    shortTitle
+    title
+  }
+`;
+
 export const DEGREE_COURSES = gql`
   query DegreeCourses {
     Course(where: {Program: {type: {_eq: "DEGREES"}}}) {
@@ -34,13 +45,12 @@ export const COMPLETED_DEGREE_ENROLLMENTS = gql`
         title
         ects
         Program {
-          type
-          shortTitle
-          title
+          ...DegreeCourseProgramFields
         }
       }
     }
   }
+  ${DEGREE_COURSE_PROGRAM_FIELDS}
 `;
 
 export const DEGREE_PARTICIPANTS_WITH_DEGREE_ENROLLMENTS = gql`
@@ -82,10 +92,7 @@ export const DEGREE_PARTICIPANTS_WITH_DEGREE_ENROLLMENTS = gql`
               title
               ects
               Program {
-                id
-                type
-                shortTitle
-                title
+                ...DegreeCourseProgramFields
               }
             }
           }
@@ -98,6 +105,7 @@ export const DEGREE_PARTICIPANTS_WITH_DEGREE_ENROLLMENTS = gql`
       }
     }
   }
+  ${DEGREE_COURSE_PROGRAM_FIELDS}
 `;
 
 export const INSERT_COURSE_DEGREE_TAG = gql`

--- a/frontend-nx/apps/edu-hub/queries/courseDegree.ts
+++ b/frontend-nx/apps/edu-hub/queries/courseDegree.ts
@@ -2,7 +2,7 @@ import { gql } from '@apollo/client';
 
 export const DEGREE_COURSES = gql`
   query DegreeCourses {
-    Course(where: {Program: {shortTitle: {_eq: "DEGREES"}}}) {
+    Course(where: {Program: {type: {_eq: "DEGREES"}}}) {
       id
       title
     }
@@ -23,7 +23,7 @@ export const COMPLETED_DEGREE_ENROLLMENTS = gql`
             userId: { _eq: $userId },
             Course: {
               CourseDegrees: { degreeCourseId: { _eq: $degreeCourseId } },
-              Program: { shortTitle: { _eq: "EVENTS" } }
+              Program: { type: { _eq: "EVENTS" } }
             }
           }
         ]
@@ -34,6 +34,7 @@ export const COMPLETED_DEGREE_ENROLLMENTS = gql`
         title
         ects
         Program {
+          type
           shortTitle
           title
         }
@@ -82,6 +83,7 @@ export const DEGREE_PARTICIPANTS_WITH_DEGREE_ENROLLMENTS = gql`
               ects
               Program {
                 id
+                type
                 shortTitle
                 title
               }

--- a/frontend-nx/apps/edu-hub/queries/organizationAdmin.ts
+++ b/frontend-nx/apps/edu-hub/queries/organizationAdmin.ts
@@ -42,6 +42,18 @@ export const ORGANIZATION_ADMIN_LIST = gql`
   }
 `;
 
+// All settings-admin grants the caller may see (their own orgs). Used to decide, per organization,
+// whether a row is the *sole* settings admin — so the UI can pre-disable turning that flag off or
+// deleting the grant, matching the DB guard that keeps at least one settings admin per org.
+export const SETTINGS_ADMIN_GRANTS = gql`
+  query SettingsAdminGrants {
+    OrganizationAdmin(where: { canManageSettings: { _eq: true } }) {
+      id
+      organizationId
+    }
+  }
+`;
+
 export const DELETE_ORGANIZATION_ADMIN = gql`
   mutation DeleteOrganizationAdmin($id: Int!) {
     delete_OrganizationAdmin_by_pk(id: $id) {


### PR DESCRIPTION
## Summary

Bootstraps organizations for self-service admin management and broadens what org admins can do, plus decouples program-type detection from `shortTitle`.

### Backend (commit 1)
- **Triggers on `OrganizationAdmin`:**
  - First admin of an organization is auto-granted `canManageSettings`.
  - An org must keep ≥1 settings admin — clearing/deleting the last one is blocked for `org_admin_access` (super-admins / migrations are exempt via the Hasura role in `hasura.user`).
  - The first admin seeds default `COURSES`/`EVENTS`/`DEGREES` programs (idempotent; new orgs only, no backfill).
- **Hasura permissions:** `canManageSettings` grants write access to all program types on `Program` and `Course`. New `org_admin_access` insert/update/delete on `MailTemplate` (scoped to the caller's courses; global `courseId`-null templates stay super-admin-only) and insert/update on `CourseEnrollment` (no hard delete — "removal" is a `status` → `CANCELLED` update; select widened to mirror `instructor_access`).

### Frontend (commit 2)
- `manageScope`: settings-only admins see all their org's program/course lists.
- `ManageAdminUsers`: the sole settings admin of an org can't have that flag cleared or the grant deleted (super-admins exempt); the DB guard error maps to a friendly message.
- **Decouple program type from `shortTitle`:** all detection now branches on `Program.type` (21 sites / 7 files) so `shortTitle` is a freely-editable label. Added `type` to two degree queries and regenerated types.
- DE (informal *Du*) / EN strings added.

## Testing
- **Trigger behaviour** verified in a rolled-back SQL transaction (auto-settings, seed, no duplicate seed, guard on update+delete, super-admin bypass).
- **Live smoke test through the GraphQL API** with role impersonation — 15/15 checks: first-admin bootstrap, settings-only admin reading/writing Program/Course/MailTemplate/CourseEnrollment, denial of global mail templates, soft-cancel, guard enforcement + super-admin bypass, non-admin write denied. Test data cleaned up afterward.
- `yarn type-check` and `eslint` clean.

## Notes
- New orgs only — existing organizations are untouched (a backfill can be a separate migration later).
- Enrollment writes still fire the existing status-email / Mattermost event triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings administrators can manage courses, programs, enrollments, and course email templates across their organization.
  * New safeguards ensure each organization retains at least one settings administrator.
  * Admin management now warns and prevents removal or permission changes that would leave no settings administrator.

* **Bug Fixes**
  * Program classification and filtering now consistently distinguish events, courses, and degrees.
  * Improved messaging explains why the last settings administrator cannot be removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->