### PR TITLE
fix(infra): re-add stujo.opencampus.sh to managed SSL cert (+ Hasura 2048M)

### DIFF
--- a/infrastructure/application/00_variables.tf
+++ b/infrastructure/application/00_variables.tf
@@ -202,7 +202,14 @@ variable "hasura_graphql_dev_mode" {
 variable "hasura_memory_limit" {
   description = "Memory limit for Hasura cloud run service"
   type        = string
-  default     = "1024M"
+  # 2048M: the cli-migrations-v3 image runs a temporary engine to apply
+  # migrations/metadata that overlaps in memory with the real engine at boot,
+  # and the schema cache has grown (many tables + event triggers). At 1024M the
+  # startup peak exceeded the limit and the container was OOM-killed before
+  # binding port 8080, so Cloud Run's startup probe timed out and rollouts got
+  # stuck (prod, 2026-07-21). The running instance also OOM'd at rest. ~$6.6/mo
+  # extra per always-on instance.
+  default = "2048M"
 }
 
 # Frontend

--- a/infrastructure/application/02_network.tf
+++ b/infrastructure/application/02_network.tf
@@ -86,16 +86,8 @@ module "lb-http" {
   # which the affected hosts serve no valid HTTPS. Apply domain changes in a
   # low-traffic window and confirm the new cert is ACTIVE and the new records
   # resolve before treating the new hosts as live.
-  #
-  # TEMPORARY (2026-07-21 incident): local.stujo_domain is excluded from the
-  # cert. stujo.opencampus.sh currently resolves to a manually configured
-  # Cloudflare proxied setup (302 redirect to stujo.net) that Terraform does
-  # not manage, so its validation fails and blocks the ENTIRE cert — taking
-  # down HTTPS for all hosts on the load balancer. Re-add local.stujo_domain
-  # once the manual Cloudflare record/redirect rule is removed and
-  # stujo.opencampus.sh resolves to this LB's IP again.
   ssl                             = "true"
-  managed_ssl_certificate_domains = concat(["${local.keycloak_service_name}.opencampus.sh", "${local.hasura_service_name}.opencampus.sh", "${local.eduhub_service_name}.opencampus.sh", "${local.eduhub_api_service_name}.opencampus.sh"], [for portal in local.stujo_portals : portal.domain])
+  managed_ssl_certificate_domains = concat(["${local.keycloak_service_name}.opencampus.sh", "${local.hasura_service_name}.opencampus.sh", "${local.eduhub_service_name}.opencampus.sh", "${local.eduhub_api_service_name}.opencampus.sh", local.stujo_domain], [for portal in local.stujo_portals : portal.domain])
   https_redirect                  = "true"
   random_certificate_suffix       = "true"
 


### PR DESCRIPTION
## What

Scoped production hotfix, branched off `production`, containing two infra fixes already reviewed/merged on `develop`:

1. **`02_network.tf`** — re-add `local.stujo_domain` to `managed_ssl_certificate_domains` and remove the TEMPORARY 2026-07-21 exclusion.
2. **`00_variables.tf`** — raise `hasura_memory_limit` `1024M → 2048M` (startup-OOM fix). *Drop this commit if you want cert-only.*

Both files are now byte-identical to `origin/develop`.

## Why not the full develop→production promotion

`production` carries a `Revert "restore stujo host on managed SSL certificate"`, so a staging→production merge would **conflict on the exact cert line** we need to change — high risk the fix silently doesn't land. The full promotion also drags in an unrelated DB migration + a semantic version bump. This scoped hotfix makes the pipeline plan essentially just the cert reprovision.

## Preconditions already satisfied

- `stujo.opencampus.sh` now resolves **DNS-only → LB IP `34.160.235.229`** (verified on `8.8.8.8` and `1.1.1.1`); the old `302 → stujo.net` is gone. The redirect came from the proxied `*.opencampus.sh` wildcard's origin — not a per-host DNS record, Page Rule, Redirect Rule, Bulk Redirect, or Worker (all checked).
- `cloudflare_record.stujo` was created via a targeted apply and already exists in the prod TF state, matching `production`-branch config — so the pipeline plan is **not** a record add, just the cert change.

## Expected pipeline plan on merge

- `~ google_compute_managed_ssl_certificate` — **reprovision** (new multi-SAN cert including `stujo.opencampus.sh`).
- `~ hasura` Cloud Run — memory `1024M → 2048M` (new revision), if the Hasura commit is kept.
- No `cloudflare_record.stujo` change.

## ⚠️ Merge in a low-traffic window

Changing the managed-cert domain list forces a reprovision with a window (can be tens of minutes) where HTTPS for **all** LB hosts (edu, api-edu, hasura, keycloak, portals) may be interrupted. `stujo` DNS now resolves to the LB, so validation should pass. After apply, confirm the cert is **ACTIVE**, then:

    dig +noall +answer stujo.opencampus.sh A     # 34.160.235.229
    curl -sSI https://stujo.opencampus.sh          # 200 from Google Frontend, no 302 → stujo.net

## Note

Direct-to-`production` hotfix. Backport to `develop`/`staging` isn't needed for the cert change (already there via `b19b3ff5`), but the post-release tag/branch sync should still be run to close the current `staging`↔`production` divergence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)