### PR TITLE
fix(infra): use binary units for Hasura memory limit

### DIFF
--- a/infrastructure/application/00_variables.tf
+++ b/infrastructure/application/00_variables.tf
@@ -202,14 +202,24 @@ variable "hasura_graphql_dev_mode" {
 variable "hasura_memory_limit" {
   description = "Memory limit for Hasura cloud run service"
   type        = string
-  # 2048M: the cli-migrations-v3 image runs a temporary engine to apply
+  # 2Gi: the cli-migrations-v3 image runs a temporary engine to apply
   # migrations/metadata that overlaps in memory with the real engine at boot,
   # and the schema cache has grown (many tables + event triggers). At 1024M the
   # startup peak exceeded the limit and the container was OOM-killed before
   # binding port 8080, so Cloud Run's startup probe timed out and rollouts got
   # stuck (prod, 2026-07-21). The running instance also OOM'd at rest. ~$6.6/mo
   # extra per always-on instance.
-  default = "2048M"
+  #
+  # Use binary units ("2Gi", like Keycloak in 04_keycloak.tf). The Cloud Run v1
+  # Admin API that google_cloud_run_service talks to rejects "2048M" with
+  # HTTP 400 "For 1.0 CPU, memory must be between 128Mi and 4Gi inclusive"
+  # (staging apply, 2026-07-24), even though gcloud/the v2 API accepts it.
+  #
+  # This default is the production value. Staging overrides it to "1Gi" via its
+  # Terraform Cloud workspace variable: its dataset is a fraction of prod's, so
+  # the boot peak stays well under the limit and it saves ~$6/mo on the
+  # always-on instance. Consequence: staging cannot reproduce a prod boot OOM.
+  default = "2Gi"
 }
 
 # Frontend


### PR DESCRIPTION
## Problem

The staging infrastructure deploy failed at `Terraform Apply` ([run 30134236552](https://github.com/eduhub-org/eduhub/actions/runs/30134236552)):

```
Error updating Service ".../services/hasura-staging": googleapi: Error 400:
spec.template.spec.containers[0].resources.limits.memory: Invalid value specified
for container memory. For 1.0 CPU, memory must be between 128Mi and 4Gi inclusive.
```

`2048M` (~1.9Gi) *is* inside that range, so the message is misleading. The actual cause is the unit form: the **Cloud Run v1 Admin API** that `google_cloud_run_service` talks to rejects the decimal-unit value. `gcloud` and the v2 API accept it — which is why the live prod hotfix on 2026-07-23 worked and this only surfaced on the first Terraform apply carrying the new default from `f2ba7d0f`.

Evidence from the same failed run, same project, same API:

- `keycloak-staging` uses `memory = "2Gi"` (`04_keycloak.tf:56`) and its update **succeeded** seconds before Hasura's failed.
- `hasura-staging` is still at `1024M` — the apply died before writing anything.
- Prod's service spec shows `2048M` set by client `gcloud`, not by Terraform.

This had already blocked an earlier staging run ([30128734692](https://github.com/eduhub-org/eduhub/actions/runs/30128734692)) at the same step.

## Change

- Default `hasura_memory_limit`: `2048M` → `2Gi`. No change in effective size, just the unit form the v1 API accepts.
- Document that staging overrides this to `1Gi` through its Terraform Cloud workspace variable, and that such a variable wins over this default.

## Required outside this PR

The staging TFC workspace variable `hasura_memory_limit` is currently `1024`, which would still 400 (no unit ⇒ 1024 *bytes*, below the 128Mi floor). It must be set to `1Gi` for the staging deploy to pass. The prod workspace should have no override, or `2Gi`.

## Known follow-up (not addressed here)

Prod revision `hasura-00191-n24` never became ready: `HealthCheckContainerError`, startup probe timed out after 4m. Not an OOM — the engine did boot, just ~30s past the probe window. Traffic stays on the healthy `hasura-00190-xkn` (same Hasura content SHA), so prod is not behind on migrations. But this PR makes `2048M` → `2Gi` a real diff on prod, so the next prod apply creates a revision that may hit the same 4-minute wall. The durable fix is raising the startup probe's `failureThreshold` or decoupling migrations from container boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the default memory allocation for Hasura services to improve stability and help prevent out-of-memory errors during deployments.
* **Documentation**
  * Clarified memory-unit handling and documented the differences between production defaults and staging overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->