### PR TITLE
fix(i18n): use Events/Degrees labels instead of Course text

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/index.tsx
@@ -92,6 +92,17 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
     }
   }, [programType, tCoursePage]);
 
+  const addButtonText = useMemo(() => {
+    switch (programType) {
+      case ProgramType.EVENTS:
+        return t('add_event_button');
+      case ProgramType.DEGREES:
+        return t('add_degree_button');
+      default:
+        return t('add_course_button');
+    }
+  }, [programType, t]);
+
   // Calculate default program
   const sortedPrograms = useMemo(() => {
     return [...programs].sort((a, b) => {
@@ -820,7 +831,7 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
           bulkActions={bulkActions}
           onBulkAction={handleBulkAction}
           onAddButtonClick={handleAddCourse}
-          addButtonText={t('add_course_button')}
+          addButtonText={addButtonText}
           expandableRowComponent={(props) => (
             <ExpandableCourseRow
               course={props.row}

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -44,7 +44,7 @@
       "admin_users": "Admin-Benutzer",
       "experts": "Experten",
       "courses": "Kurse",
-      "events": "Veranstaltungen",
+      "events": "Events",
       "degrees": "Degrees",
       "programs": "Programme",
       "settings": "Einstellungen",
@@ -709,7 +709,7 @@
     "toCourseDescription": "zur Kursbeschreibung",
     "coursesPageTitle": "Courses: opencampus.sh Edu Hub",
     "coursesHeadline": "Kurse",
-    "eventsHeadline": "Veranstaltungen",
+    "eventsHeadline": "Events",
     "degreesHeadline": "Degrees",
     "courseSearchPlaceholder": "Search in title",
     "addCourseText": "Add Course",
@@ -1167,6 +1167,8 @@
       "placeholder": "Die Grundlagen des Themas verstehen\nSchlüsselkonzepte in praktischen Szenarien anwenden\nKomplexe Probleme und Lösungen analysieren\nInnovative Ansätze entwickeln"
     },
     "add_course_button": "Kurs hinzufügen",
+    "add_event_button": "Event hinzufügen",
+    "add_degree_button": "Degree hinzufügen",
     "delete_button": {
       "delete_course_confirmation": "Bist du sicher, dass du den Kurs '{title}' löschen möchtest?",
       "untitled_course": "Unbenannter Kurs"

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1185,6 +1185,8 @@
       "placeholder": "Understand the fundamentals of the topic\nApply key concepts in practical scenarios\nAnalyze complex problems and solutions\nCreate innovative approaches"
     },
     "add_course_button": "Add Course",
+    "add_event_button": "Add Event",
+    "add_degree_button": "Add Degree",
     "delete_button": {
       "delete_course_confirmation": "Are you sure you want to delete the course '{title}'?",
       "untitled_course": "Untitled Course"


### PR DESCRIPTION
The German menu label read "Veranstaltungen" instead of "Events", and the Events management page headline had the same issue. The add-row button on the Events and Degrees management tables always showed "Add Course" regardless of the active programType.

Update the German menu and headline strings, add addButtonText logic in ManageCoursesContent that switches on programType, and add add_event_button/add_degree_button translation keys in de.json and en.json.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added program-specific labels for adding events, degrees, and other course types.
  * Added localized “Add Event” and “Add Degree” actions in English and German.

* **Localization**
  * Updated German navigation and page headings to use “Events” consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->