### PR TITLE
feat(projects): let instructors manage their own documentation instructions

### DIFF
--- a/backend/metadata/actions.yaml
+++ b/backend/metadata/actions.yaml
@@ -363,12 +363,27 @@ actions:
           value_from_env: HASURA_CLOUD_FUNCTION_SECRET
         - name: bucket
           value_from_env: HASURA_BUCKET
+        # Dedicated handler instead of the generic saveFile: the target object path
+        # is derived from projectDocumentationInstructionId, so a caller who is not
+        # the owner could otherwise overwrite another instruction's PDF.
         - name: name
-          value: saveFile
+          value: saveProjectDocumentationInstruction
         - name: file-path
           value: project-docs-instructions/public/instruction-${projectDocumentationInstructionId}/${filename}
         - name: is-public
           value: "true"
+        # Was previously implicit (saveFile's 20 MB default); pinned so widening the
+        # caller set does not depend on a handler default.
+        - name: max-file-size-bytes
+          value: "20971520"
+        # Enables validateFileUpload -> isPdf (%PDF- magic bytes + trailing %%EOF) in
+        # saveFile/fileValidation.js. Without this header saveFile skips validation
+        # entirely, so a renamed non-PDF would reach storage.
+        - name: allowed-file-extensions
+          value: .pdf
+    permissions:
+      - role: instructor_access
+    comment: Stores an instruction PDF. The handler verifies that a non-admin caller owns the target non-default instruction before delegating to saveFile.
   - name: setProjectDocumentationInstructionDefault
     definition:
       kind: synchronous
@@ -390,7 +405,8 @@ actions:
           value: deleteProjectDocumentationInstruction
     permissions:
       - role: admin
-    comment: Reassigns projects using the instruction to the type default, then deletes the non-default instruction.
+      - role: instructor_access
+    comment: Reassigns projects using the instruction to the type default, then deletes the non-default instruction. Instructors may only delete instructions they created (verified in the handler).
   - name: saveProjectImage
     definition:
       kind: synchronous

--- a/backend/metadata/databases/default/tables/public_ProjectDocumentationInstruction.yaml
+++ b/backend/metadata/databases/default/tables/public_ProjectDocumentationInstruction.yaml
@@ -2,6 +2,9 @@ table:
   name: ProjectDocumentationInstruction
   schema: public
 object_relationships:
+  - name: CreatedByUser
+    using:
+      foreign_key_constraint_on: createdByUserId
   - name: ProjectType
     using:
       foreign_key_constraint_on: projectTypeValue
@@ -14,6 +17,12 @@ array_relationships:
           name: Project
           schema: public
 select_permissions:
+  # Restricted to the platform catalogue, for two reasons. It keeps
+  # instructor-created titles off public pages (no anonymous query reads this table
+  # today, so nothing is lost), and - crucially - `instructor` INHERITS `anonymous`
+  # (inherited_roles.yaml). An unrestricted filter here would union over the
+  # instructor_access filter below and hand every instructor every other
+  # instructor's private instruction.
   - role: anonymous
     permission:
       columns:
@@ -24,7 +33,9 @@ select_permissions:
         - isDefault
         - created_at
         - updated_at
-      filter: {}
+      filter:
+        createdByUserId:
+          _is_null: true
   - role: user_access
     permission:
       columns:
@@ -36,6 +47,10 @@ select_permissions:
         - created_at
         - updated_at
       filter: {}
+  # Instructors see the platform catalogue plus their own uploads. Students and
+  # anonymous keep an unfiltered select (above) so a team can always open whichever
+  # instruction its project points at, whoever created it, and neither role is
+  # granted createdByUserId.
   - role: instructor_access
     permission:
       columns:
@@ -44,6 +59,90 @@ select_permissions:
         - url
         - projectTypeValue
         - isDefault
+        - createdByUserId
         - created_at
         - updated_at
-      filter: {}
+      filter:
+        _or:
+          # Platform / admin-maintained catalogue: today's behaviour for every
+          # pre-existing row, including admin-created non-default ones.
+          - createdByUserId:
+              _is_null: true
+          # Own uploads.
+          - createdByUserId:
+              _eq: X-Hasura-User-Id
+          # A type's default must never be invisible: handleSetProjectType resolves
+          # the new type's default from this list, and setProjectDocumentation-
+          # InstructionDefault could have promoted an instructor-owned row.
+          - isDefault:
+              _eq: true
+          # Keep an instruction a colleague attached to a shared project visible.
+          # Otherwise the mutation-driven dropdown in ProjectsManagementGrid renders
+          # a value that is not among its options and the co-instructor silently
+          # reassigns it. Mirrors the instructor_access filter on public_Project.
+          - Projects:
+              _or:
+                - ProjectCourses:
+                    Course:
+                      CourseInstructors:
+                        User:
+                          id:
+                            _eq: X-Hasura-User-Id
+                - ProjectMentors:
+                    User:
+                      id:
+                        _eq: X-Hasura-User-Id
+insert_permissions:
+  # createdByUserId is a preset, so Hasura removes it from this role's insert input
+  # type: an instructor can neither forge ownership nor create a platform-wide
+  # (NULL) row. isDefault is absent, so a new row is always non-default. url is
+  # absent too: it may only ever come from the filePath the
+  # saveProjectDocumentationInstruction action returns.
+  - role: instructor_access
+    permission:
+      set:
+        createdByUserId: x-hasura-user-id
+      check: {}
+      columns:
+        - title
+        - projectTypeValue
+update_permissions:
+  # Rename and replace-PDF, restricted to the caller's own non-default rows.
+  # projectTypeValue is deliberately not updatable: Project_instruction_matches_type
+  # _trg fires only on Project writes, so retyping an instruction would leave every
+  # referencing project permanently inconsistent. isDefault and createdByUserId are
+  # absent, and the check repeats the filter so that stays true if the column list is
+  # ever widened.
+  - role: instructor_access
+    permission:
+      columns:
+        - title
+        - url
+      filter:
+        _and:
+          - createdByUserId:
+              _eq: X-Hasura-User-Id
+          - isDefault:
+              _eq: false
+      check:
+        _and:
+          - createdByUserId:
+              _eq: X-Hasura-User-Id
+          - isDefault:
+              _eq: false
+delete_permissions:
+  # Rollback path only. Creating is three non-atomic steps (insert -> upload -> set
+  # url); when the upload fails the draft row has to go. Restricted to url IS NULL so
+  # a real deletion can never bypass deleteProjectDocumentationInstruction:
+  # Project.documentationInstructionId is ON DELETE RESTRICT and referencing projects
+  # must be reassigned to the type default first.
+  - role: instructor_access
+    permission:
+      filter:
+        _and:
+          - createdByUserId:
+              _eq: X-Hasura-User-Id
+          - isDefault:
+              _eq: false
+          - url:
+              _is_null: true

--- a/backend/migrations/default/1787176620813_alter_table_public_ProjectDocumentationInstruction_add_column_createdByUserId/down.sql
+++ b/backend/migrations/default/1787176620813_alter_table_public_ProjectDocumentationInstruction_add_column_createdByUserId/down.sql
@@ -1,4 +1,7 @@
 ALTER TABLE "public"."ProjectDocumentationInstruction"
+  DROP CONSTRAINT IF EXISTS "ProjectDocumentationInstruction_default_is_platform_check";
+
+ALTER TABLE "public"."ProjectDocumentationInstruction"
   DROP CONSTRAINT IF EXISTS "ProjectDocumentationInstruction_owned_url_prefix_check";
 
 DROP INDEX IF EXISTS "public"."ProjectDocumentationInstruction_owner_title_key";

--- a/backend/migrations/default/1787176620813_alter_table_public_ProjectDocumentationInstruction_add_column_createdByUserId/down.sql
+++ b/backend/migrations/default/1787176620813_alter_table_public_ProjectDocumentationInstruction_add_column_createdByUserId/down.sql
@@ -1,0 +1,18 @@
+ALTER TABLE "public"."ProjectDocumentationInstruction"
+  DROP CONSTRAINT IF EXISTS "ProjectDocumentationInstruction_owned_url_prefix_check";
+
+DROP INDEX IF EXISTS "public"."ProjectDocumentationInstruction_owner_title_key";
+DROP INDEX IF EXISTS "public"."ProjectDocumentationInstruction_platform_title_key";
+
+-- Fails loudly if instructor uploads introduced titles that collide globally; the
+-- developer then decides whether to rename or delete them before rolling back.
+ALTER TABLE "public"."ProjectDocumentationInstruction"
+  ADD CONSTRAINT "ProjectDocumentationInstruction_title_key" UNIQUE ("title");
+
+DROP INDEX IF EXISTS "public"."ProjectDocumentationInstruction_createdByUserId_idx";
+
+ALTER TABLE "public"."ProjectDocumentationInstruction"
+  DROP CONSTRAINT IF EXISTS "ProjectDocumentationInstruction_createdByUserId_fkey";
+
+ALTER TABLE "public"."ProjectDocumentationInstruction"
+  DROP COLUMN IF EXISTS "createdByUserId";

--- a/backend/migrations/default/1787176620813_alter_table_public_ProjectDocumentationInstruction_add_column_createdByUserId/up.sql
+++ b/backend/migrations/default/1787176620813_alter_table_public_ProjectDocumentationInstruction_add_column_createdByUserId/up.sql
@@ -1,0 +1,52 @@
+-- Instructors may upload their own documentation instructions. Ownership lives in
+-- createdByUserId; NULL keeps the historical meaning "platform / admin-maintained",
+-- so every existing row (including admin-created non-default ones) stays visible to
+-- every instructor and today's behaviour is preserved without a backfill.
+
+ALTER TABLE "public"."ProjectDocumentationInstruction"
+  ADD COLUMN "createdByUserId" uuid NULL;
+
+COMMENT ON COLUMN "public"."ProjectDocumentationInstruction"."createdByUserId" IS
+  E'Instructor who uploaded this instruction. NULL = platform/admin-maintained: visible to every instructor, writable only by admins. A non-NULL value scopes the row to that user via Hasura select/update permissions and is stamped server-side by an insert preset, never by the client.';
+
+-- ON DELETE RESTRICT, not SET NULL: user removal in this codebase is anonymisation
+-- (functions/callNodeFunction/anonymizeUser keeps the User row with status DELETED),
+-- so RESTRICT never blocks the real deletion path, while SET NULL would silently
+-- promote a departed instructor's private instruction to a platform-wide one.
+-- Mirrors Project_proposedByUserId_fkey.
+ALTER TABLE "public"."ProjectDocumentationInstruction"
+  ADD CONSTRAINT "ProjectDocumentationInstruction_createdByUserId_fkey"
+  FOREIGN KEY ("createdByUserId") REFERENCES "public"."User" ("id")
+  ON UPDATE RESTRICT ON DELETE RESTRICT;
+
+CREATE INDEX "ProjectDocumentationInstruction_createdByUserId_idx"
+  ON "public"."ProjectDocumentationInstruction" ("createdByUserId");
+
+-- Title uniqueness was global. Instructors now pick titles, so a global unique
+-- constraint would (a) reject a title whose owner the caller cannot even see and
+-- (b) leak the existence of other instructors' titles. Keep global uniqueness for
+-- the platform catalogue and scope instructor titles to their owner.
+ALTER TABLE "public"."ProjectDocumentationInstruction"
+  DROP CONSTRAINT "ProjectDocumentationInstruction_title_key";
+
+CREATE UNIQUE INDEX "ProjectDocumentationInstruction_platform_title_key"
+  ON "public"."ProjectDocumentationInstruction" ("title")
+  WHERE "createdByUserId" IS NULL;
+
+CREATE UNIQUE INDEX "ProjectDocumentationInstruction_owner_title_key"
+  ON "public"."ProjectDocumentationInstruction" ("createdByUserId", "title")
+  WHERE "createdByUserId" IS NOT NULL;
+
+-- Instructors need UPDATE on "url" for the 3-step create (insert -> upload -> set
+-- url) and for PDF replacement, which would otherwise let them point an
+-- instruction at any public object in the bucket. Constrain owned rows to the
+-- prefix the saveProjectDocumentationInstruction action writes. Platform rows are
+-- untouched: they hold either GCS keys or the seeded
+-- '/project-documentation-instructions/...' static paths.
+ALTER TABLE "public"."ProjectDocumentationInstruction"
+  ADD CONSTRAINT "ProjectDocumentationInstruction_owned_url_prefix_check"
+  CHECK (
+    "createdByUserId" IS NULL
+    OR "url" IS NULL
+    OR "url" LIKE 'project-docs-instructions/public/%'
+  );

--- a/backend/migrations/default/1787176620813_alter_table_public_ProjectDocumentationInstruction_add_column_createdByUserId/up.sql
+++ b/backend/migrations/default/1787176620813_alter_table_public_ProjectDocumentationInstruction_add_column_createdByUserId/up.sql
@@ -50,3 +50,16 @@ ALTER TABLE "public"."ProjectDocumentationInstruction"
     OR "url" IS NULL
     OR "url" LIKE 'project-docs-instructions/public/%'
   );
+
+-- A type default belongs to the platform catalogue and stays visible to every
+-- instructor, so it must never be personally owned. setProjectDocumentation-
+-- InstructionDefault already refuses to promote an owned row; this makes the
+-- invariant structural, so a privileged mutation or a data repair cannot create a
+-- default that only its owner can see (and that its owner could not manage either,
+-- because the update/delete permissions exclude isDefault rows).
+ALTER TABLE "public"."ProjectDocumentationInstruction"
+  ADD CONSTRAINT "ProjectDocumentationInstruction_default_is_platform_check"
+  CHECK (
+    "isDefault" IS NOT TRUE
+    OR "createdByUserId" IS NULL
+  );

--- a/docs/PROJECTS_TESTING_GUIDE.md
+++ b/docs/PROJECTS_TESTING_GUIDE.md
@@ -558,7 +558,7 @@ Participations → Projects (expand the row), and again in **Add project** and
     deletes must go through the action).
 17. **`saveProjectDocumentationInstruction` against a row `instr-b` does not
     own**, using that row's exact filename → `..._UNAUTHORIZED`, and the object
-    in the bucket is byte-identical afterwards. This is the overwrite the
+    in the bucket is byte-identical afterward. This is the overwrite the
     dedicated handler exists to prevent.
 18. `deleteProjectDocumentationInstruction` on `instr-a`'s row →
     `..._FORBIDDEN`; on any default row → `..._IS_DEFAULT`.

--- a/docs/PROJECTS_TESTING_GUIDE.md
+++ b/docs/PROJECTS_TESTING_GUIDE.md
@@ -59,6 +59,10 @@ every `ProjectType` already has a default instruction. If not, upload a
 small PDF and mark it default for the missing types. Add **one extra**
 non-default instruction for `PROJECT_WITH_DOCUMENTATION_ONLY` to test the picker.
 
+All instructions seeded this way are **platform** instructions
+(`createdByUserId IS NULL`). For §8.1, also upload one instruction as `instr-a`
+from inside a course so at least one personal instruction exists.
+
 ---
 
 ## 3. Regression sweep — shared components
@@ -494,6 +498,73 @@ In App settings → Project documentation instructions:
 5. The icon-only delete button has a screen-reader-readable label. In
    Chrome DevTools → Accessibility, confirm the **Accessible name**
    reads "Delete documentation" (or your translation).
+6. Instructor uploads (see §8.1) are listed here too. **Set as default** on such
+   a row is refused with `..._NOT_PLATFORM` — a personal instruction must never
+   become a type default.
+7. Uploading a non-PDF renamed to `.pdf` is now rejected on content
+   (`INVALID_FORMAT`), not just on extension.
+
+---
+
+## 8.1 Own documentation instructions (instructor)
+
+Roles: `instr-a` and `instr-b` are instructors on **different** courses;
+`user-1` is an ACCEPTED author on one of `instr-a`'s ONGOING projects.
+
+**Happy path — as `instr-a`**, on an ONGOING project in Manage Course →
+Participations → Projects (expand the row), and again in **Add project** and
+**Confirm team**:
+
+1. Click the upload button next to the instruction dropdown. Enter a title,
+   choose a PDF, submit.
+2. The dialog closes, the new instruction is **selected** in the dropdown, and it
+   appears among the options. No console warnings about an out-of-range value.
+3. Reopen the dialog: the instruction is listed under *your instructions* with a
+   title field, an open button, **PDF ersetzen**, and a delete button.
+4. Rename it (the field saves on blur) and replace its PDF. Both persist after a
+   reload. There is deliberately **no** "remove PDF" control: clearing the URL
+   would hide an instruction that projects still reference.
+5. Delete it. A project still using it falls back to the type default and the
+   number of reassigned projects is reported.
+
+**Guards:**
+
+6. On a PROPOSED project without a type, the button is disabled and its tooltip
+   explains why.
+7. After the team submits, the button and the dropdown are both disabled.
+8. For a project type with no instruction at all, the section still renders so
+   the first instruction can be created.
+
+**Isolation matrix:**
+
+9. As `instr-b`: `instr-a`'s instruction is **not** in any dropdown and not in
+   the dialog list. Platform instructions are still all visible.
+10. Add `instr-b` as a CourseInstructor on `instr-a`'s course: `instr-b` now sees
+    that instruction for the project that uses it (so the dropdown is never out
+    of range) but still cannot rename or delete it.
+11. As `user-1`: the instruction PDF still downloads from **My Project**. Confirm
+    in the network panel that the response contains no `createdByUserId`.
+
+**Negative GraphQL** (Hasura console as `instr-b`, `x-hasura-role: instructor`):
+
+12. `update_ProjectDocumentationInstruction_by_pk` on `instr-a`'s row → affects
+    zero rows.
+13. `insert_..._one` with `createdByUserId` or `isDefault` → the field does not
+    exist in the input type.
+14. `_set: { projectTypeValue }` → field not in the set input type.
+15. `_set: { url: "programs/program-1/private/x.pdf" }` on an own row → check
+    constraint violation (`..._owned_url_prefix_check`).
+16. `delete_..._by_pk` on any row that has a URL → affects zero rows (real
+    deletes must go through the action).
+17. **`saveProjectDocumentationInstruction` against a row `instr-b` does not
+    own**, using that row's exact filename → `..._UNAUTHORIZED`, and the object
+    in the bucket is byte-identical afterwards. This is the overwrite the
+    dedicated handler exists to prevent.
+18. `deleteProjectDocumentationInstruction` on `instr-a`'s row →
+    `..._FORBIDDEN`; on any default row → `..._IS_DEFAULT`.
+19. Upload a file named `../../../evil.pdf` → stored as
+    `project-docs-instructions/public/instruction-<id>/evil.pdf`; confirm on the
+    dev container filesystem that nothing was written outside that folder.
 
 ---
 

--- a/docs/PROJECTS_USER_MANUAL.md
+++ b/docs/PROJECTS_USER_MANUAL.md
@@ -95,6 +95,7 @@ Key transitions in detail:
 | Manage join requests | ✓ (any ACCEPTED author) | ✓ | ✓ | ✓ |
 | Confirm team (PROPOSED → ONGOING) | — | ✓ | ✓ | ✓ |
 | Change project type / documentation instruction | — | ✓ (PROPOSED/ONGOING) | ✓ (PROPOSED/ONGOING) | ✓ |
+| Upload / rename / replace / delete a documentation instruction | — | ✓ (own uploads only) | ✓ (own uploads only) | ✓ (whole catalogue) |
 | Submit (ONGOING → SUBMITTED) | ✓ | — | — | ✓ |
 | Send back / approve / reject | — | ✓ | ✓ | ✓ |
 | Rate & comment | — | ✓ | ✓ | ✓ |
@@ -433,12 +434,28 @@ write-up).
 
 - Lives in the `ProjectDocumentationInstruction` table.
 - Each instruction has a **title**, a **PDF URL**, an associated
-  **project type**, and an **isDefault** flag.
+  **project type**, an **isDefault** flag, and a **createdByUserId**.
 - A database constraint guarantees that **exactly one** instruction per
   type is marked default. Promotions are atomic.
 - Default URLs follow a stable static path
   (`/project-documentation-instructions/<type>.pdf`). Custom uploads
   live in the GCS bucket and are served via a signed URL.
+
+**Ownership (`createdByUserId`)** decides who sees and manages a row:
+
+- **NULL — platform instruction.** Maintained by admins, visible to every
+  instructor. All instructions that existed before instructor uploads were
+  introduced are platform instructions.
+- **Set — a personal instruction.** Visible to its creator, to co-instructors
+  and mentors of a project that uses it, and to the students of those projects
+  (so a team can always open the instruction their project points at). Other
+  instructors do not see it. Only the creator (and admins) can rename it,
+  replace its PDF, or delete it.
+
+Only platform instructions can become a type default; promoting a personal
+instruction is refused, because a default has to stay visible to everyone.
+Titles must be unique per owner, and globally unique among platform
+instructions.
 
 ### 7.2 Where instructions appear
 
@@ -450,6 +467,10 @@ write-up).
   SUBMITTED.
 - **In the manage grid** — instructors can change a project's
   instruction after confirmation if requirements change.
+- **Next to every instruction dropdown** — an upload button opens *Your
+  documentation instructions* (see §7.3a). It is disabled while no project type
+  is selected, and in the manage grid it locks together with the dropdown once
+  the project has been submitted.
 
 ### 7.3 Managing the catalogue (admin only)
 
@@ -461,8 +482,36 @@ Open **App settings → Project documentation instructions**. Admins can:
 - **Edit** the title, replace the PDF, or change the URL.
 - **Set as default** — promotes the row to the type's default; the
   previous default is demoted in the same transaction.
-- **Delete** — only available for non-default rows that are not
-  currently referenced by any project.
+- **Delete** — available for non-default rows. Projects still using the
+  instruction are first reassigned to the type default, so a referenced row can
+  be deleted; the number of reassigned projects is reported back.
+
+Instructor uploads also appear here, so admins keep an overview of the whole
+catalogue. **Set as default** is refused for them (§7.1).
+
+### 7.3a Your own instructions (instructors)
+
+Instructors do not need an admin to get a course-specific write-up guide. Next
+to any documentation-instruction dropdown, the upload button opens **Your
+documentation instructions** for the project's type. In that dialog an
+instructor can:
+
+- **Upload** a new instruction: a title plus one PDF (at most 20 MB). It is
+  created as a non-default, personal instruction for the current project type
+  and is selected for the project immediately.
+- **Rename** it, **replace its PDF**, or **delete** it — for their own uploads
+  only. Deleting reassigns any project still using it to the type default.
+
+Notes:
+
+- An instruction always belongs to exactly one project type, so the button stays
+  disabled until a type is selected. Changing a project's type therefore also
+  resets its instruction.
+- PDFs are validated by content, not just by file extension.
+- Uploads are only offered while the project type itself is still editable, i.e.
+  until the team submits.
+- A super-admin using the same dialog creates a **platform** instruction, not a
+  personal one — admins manage the catalogue in app settings.
 
 ### 7.4 The author write-up (Documentation field)
 

--- a/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
+++ b/frontend-nx/apps/edu-hub/__generated__/globalTypes.ts
@@ -2099,14 +2099,16 @@ export enum ProjectCourse_update_column {
  */
 export enum ProjectDocumentationInstruction_constraint {
   ProjectDocumentationInstruction_one_default_per_type = "ProjectDocumentationInstruction_one_default_per_type",
+  ProjectDocumentationInstruction_owner_title_key = "ProjectDocumentationInstruction_owner_title_key",
   ProjectDocumentationInstruction_pkey = "ProjectDocumentationInstruction_pkey",
-  ProjectDocumentationInstruction_title_key = "ProjectDocumentationInstruction_title_key",
+  ProjectDocumentationInstruction_platform_title_key = "ProjectDocumentationInstruction_platform_title_key",
 }
 
 /**
  * select columns of table "ProjectDocumentationInstruction"
  */
 export enum ProjectDocumentationInstruction_select_column {
+  createdByUserId = "createdByUserId",
   created_at = "created_at",
   id = "id",
   isDefault = "isDefault",
@@ -2135,6 +2137,7 @@ export enum ProjectDocumentationInstruction_select_column_ProjectDocumentationIn
  * update columns of table "ProjectDocumentationInstruction"
  */
 export enum ProjectDocumentationInstruction_update_column {
+  createdByUserId = "createdByUserId",
   created_at = "created_at",
   id = "id",
   isDefault = "isDefault",
@@ -10569,12 +10572,14 @@ export interface ProjectDocumentationInstruction_avg_order_by {
  * Boolean expression to filter rows from the table "ProjectDocumentationInstruction". All fields are combined with a logical 'AND'.
  */
 export interface ProjectDocumentationInstruction_bool_exp {
+  CreatedByUser?: User_bool_exp | null;
   ProjectType?: ProjectType_bool_exp | null;
   Projects?: Project_bool_exp | null;
   Projects_aggregate?: Project_aggregate_bool_exp | null;
   _and?: ProjectDocumentationInstruction_bool_exp[] | null;
   _not?: ProjectDocumentationInstruction_bool_exp | null;
   _or?: ProjectDocumentationInstruction_bool_exp[] | null;
+  createdByUserId?: uuid_comparison_exp | null;
   created_at?: timestamptz_comparison_exp | null;
   id?: Int_comparison_exp | null;
   isDefault?: Boolean_comparison_exp | null;
@@ -10589,8 +10594,10 @@ export interface ProjectDocumentationInstruction_bool_exp {
  * input type for inserting data into table "ProjectDocumentationInstruction"
  */
 export interface ProjectDocumentationInstruction_insert_input {
+  CreatedByUser?: User_obj_rel_insert_input | null;
   ProjectType?: ProjectType_obj_rel_insert_input | null;
   Projects?: Project_arr_rel_insert_input | null;
+  createdByUserId?: any | null;
   created_at?: any | null;
   id?: number | null;
   isDefault?: boolean | null;
@@ -10605,6 +10612,7 @@ export interface ProjectDocumentationInstruction_insert_input {
  * order by max() on columns of table "ProjectDocumentationInstruction"
  */
 export interface ProjectDocumentationInstruction_max_order_by {
+  createdByUserId?: order_by | null;
   created_at?: order_by | null;
   id?: order_by | null;
   legacyAchievementDocumentationTemplateId?: order_by | null;
@@ -10618,6 +10626,7 @@ export interface ProjectDocumentationInstruction_max_order_by {
  * order by min() on columns of table "ProjectDocumentationInstruction"
  */
 export interface ProjectDocumentationInstruction_min_order_by {
+  createdByUserId?: order_by | null;
   created_at?: order_by | null;
   id?: order_by | null;
   legacyAchievementDocumentationTemplateId?: order_by | null;
@@ -10648,8 +10657,10 @@ export interface ProjectDocumentationInstruction_on_conflict {
  * Ordering options when selecting data from "ProjectDocumentationInstruction".
  */
 export interface ProjectDocumentationInstruction_order_by {
+  CreatedByUser?: User_order_by | null;
   ProjectType?: ProjectType_order_by | null;
   Projects_aggregate?: Project_aggregate_order_by | null;
+  createdByUserId?: order_by | null;
   created_at?: order_by | null;
   id?: order_by | null;
   isDefault?: order_by | null;

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/InstructionUploadButton.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/InstructionUploadButton.tsx
@@ -1,0 +1,57 @@
+import { FC } from 'react';
+import { Tooltip } from '@mui/material';
+import { MdUploadFile } from 'react-icons/md';
+
+interface InstructionUploadButtonProps {
+  onClick: () => void;
+  disabled?: boolean;
+  /**
+   * Accessible name and tooltip. Callers pass the reason when `disabled` is set
+   * (e.g. no project type selected yet), so the button explains itself.
+   */
+  label: string;
+  className?: string;
+}
+
+/**
+ * Opens the dialog for managing the instructor's own documentation instructions.
+ * Sits next to `InstructionDownloadButton` and deliberately copies its shape so
+ * the pair reads as one control group.
+ */
+const InstructionUploadButton: FC<InstructionUploadButtonProps> = ({
+  onClick,
+  disabled = false,
+  label,
+  className = '',
+}) => {
+  const baseClass = `inline-flex h-11 w-11 shrink-0 items-center justify-center rounded border border-border-primary text-label-secondary touch-manipulation ${className}`;
+
+  if (disabled) {
+    return (
+      <button
+        type="button"
+        aria-label={label}
+        title={label}
+        disabled
+        className={`${baseClass} cursor-not-allowed opacity-40`}
+      >
+        <MdUploadFile />
+      </button>
+    );
+  }
+
+  return (
+    <Tooltip title={label} placement="top">
+      <button
+        type="button"
+        aria-label={label}
+        onClick={onClick}
+        className={`${baseClass} hover:bg-bg-secondary`}
+      >
+        <MdUploadFile />
+      </button>
+    </Tooltip>
+  );
+};
+
+export default InstructionUploadButton;

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/AddProjectDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/AddProjectDialog.tsx
@@ -9,6 +9,8 @@ import { Button } from '../../../../common/Button';
 import DropDownSelector from '../../../../inputs/DropDownSelector';
 import ProjectFormatSelector from '../../../CourseContent/Projects/ProjectFormatSelector';
 import InstructionDownloadButton from '../../../CourseContent/Projects/InstructionDownloadButton';
+import InstructionUploadButton from '../../../CourseContent/Projects/InstructionUploadButton';
+import DocumentationInstructionUploadDialog from './DocumentationInstructionUploadDialog';
 import { resolveInitialProjectType } from '../../../CourseContent/Projects/projectTypeRequirements';
 import { filterProjectDocumentationInstructionsWithPdf } from '../../../CourseContent/Projects/projectDocumentationInstruction';
 import { INSTRUCTOR_INSERT_PROJECT } from '../../../../../queries/projectInstructor';
@@ -63,6 +65,7 @@ const AddProjectDialog: FC<AddProjectDialogProps> = ({
   );
   const [authors, setAuthors] = useState<UserSelectionWithFilter_User[]>([]);
   const [selectAuthorOpen, setSelectAuthorOpen] = useState(false);
+  const [instructionDialogOpen, setInstructionDialogOpen] = useState(false);
 
   const projectTypesQuery = useRoleQuery<ProjectTypes>(PROJECT_TYPES);
   const documentationInstructionsQuery = useRoleQuery<ProjectDocumentationInstructions>(
@@ -454,6 +457,15 @@ const AddProjectDialog: FC<AddProjectDialogProps> = ({
                 url={selectedInstructionUrl}
                 disabled={loading}
               />
+              <InstructionUploadButton
+                onClick={() => setInstructionDialogOpen(true)}
+                disabled={loading || !type}
+                label={
+                  type
+                    ? t('projects.instruction_upload.open')
+                    : t('projects.instruction_upload.disabled_no_type')
+                }
+              />
             </div>
             <p className="mt-2 text-xs text-label-secondary whitespace-pre-line">
               {instructionHelpText}
@@ -472,6 +484,18 @@ const AddProjectDialog: FC<AddProjectDialogProps> = ({
         title={t('projects.select_author_title')}
         onClose={handleAuthorSelected}
       />
+
+      {type ? (
+        <DocumentationInstructionUploadDialog
+          open={instructionDialogOpen}
+          onClose={() => setInstructionDialogOpen(false)}
+          projectTypeValue={type}
+          selectedInstructionId={instructionId ? Number(instructionId) : null}
+          onCreated={(newId) => setInstructionId(String(newId))}
+          onSelectedDeleted={() => setInstructionId('')}
+          onError={onError}
+        />
+      ) : null}
     </>
   );
 };

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/ConfirmProjectDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/ConfirmProjectDialog.tsx
@@ -1,4 +1,4 @@
-import { FC, useCallback, useEffect, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslations } from 'next-intl';
 import { useRoleMutation } from '../../../../../hooks/authedMutation';
 import { DialogShell } from '../../../../common/dialogs/DialogShell';
@@ -6,6 +6,8 @@ import { Button } from '../../../../common/Button';
 import DropDownSelector from '../../../../inputs/DropDownSelector';
 import ProjectFormatSelector from '../../../CourseContent/Projects/ProjectFormatSelector';
 import InstructionDownloadButton from '../../../CourseContent/Projects/InstructionDownloadButton';
+import InstructionUploadButton from '../../../CourseContent/Projects/InstructionUploadButton';
+import DocumentationInstructionUploadDialog from './DocumentationInstructionUploadDialog';
 import {
   DEFAULT_CLASSIC_REQUIREMENT_FLAGS,
   isClassicCatalogType,
@@ -50,6 +52,7 @@ const ConfirmProjectDialog: FC<ConfirmProjectDialogProps> = ({
 
   const [type, setType] = useState<string>('');
   const [instructionId, setInstructionId] = useState<string>('');
+  const [instructionDialogOpen, setInstructionDialogOpen] = useState(false);
   const [submitProject, { loading }] = useRoleMutation(UPDATE_PROJECT_CONFIRM_TEAM, {
     refetchQueries,
   });
@@ -86,8 +89,22 @@ const ConfirmProjectDialog: FC<ConfirmProjectDialogProps> = ({
     [projectTypes]
   );
 
+  // Seeding must run once per opened project. Its dependencies include
+  // selectableInstructions / findDefaultInstructionIdForType, whose identity changes
+  // whenever the ProjectDocumentationInstructions query refetches - and creating an
+  // instruction from this dialog does exactly that. Without this guard the effect
+  // re-runs and overwrites the instruction the instructor just created with the
+  // type's default.
+  const seededForProjectRef = useRef<number | null>(null);
+
   useEffect(() => {
+    if (!open) {
+      seededForProjectRef.current = null;
+      return;
+    }
     if (!project) return;
+    if (seededForProjectRef.current === project.id) return;
+    seededForProjectRef.current = project.id;
     const carried = projectTypes.find(
       (pt) => pt.value === (project.type ?? programDefaultProjectType)
     );
@@ -184,92 +201,115 @@ const ConfirmProjectDialog: FC<ConfirmProjectDialogProps> = ({
   };
 
   return (
-    <DialogShell
-      open={open}
-      onClose={onClose}
-      title={t('projects.confirm_project_dialog.title')}
-      ariaLabelledBy="confirm-project-dialog"
-      maxWidth="md"
-      actions={
-        <div className="flex justify-end gap-2">
-          <Button onClick={onClose} disabled={loading}>
-            {tCommon('cancel')}
-          </Button>
-          <Button
-            filled
-            onClick={handleConfirm}
-            disabled={loading || !type || !instructionId || !hasAcceptedAuthor}
-          >
-            {t('projects.confirm_project_dialog.confirm_button')}
-          </Button>
-        </div>
-      }
-    >
-      {project ? (
-        <div className="space-y-5">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wide text-label-secondary mb-2">
-              {t('projects.confirm_project_dialog.project_title_label')}
-            </p>
-            <p className="text-sm font-semibold text-label-primary break-words">
-              {project.title}
-            </p>
+    <>
+      <DialogShell
+        open={open}
+        onClose={onClose}
+        title={t('projects.confirm_project_dialog.title')}
+        ariaLabelledBy="confirm-project-dialog"
+        maxWidth="md"
+        actions={
+          <div className="flex justify-end gap-2">
+            <Button onClick={onClose} disabled={loading}>
+              {tCommon('cancel')}
+            </Button>
+            <Button
+              filled
+              onClick={handleConfirm}
+              disabled={loading || !type || !instructionId || !hasAcceptedAuthor}
+            >
+              {t('projects.confirm_project_dialog.confirm_button')}
+            </Button>
           </div>
-          <div className="border-t border-border-primary pt-5">
-            <p className="text-xs font-semibold uppercase tracking-wide text-label-secondary mb-2">
-              {t('projects.confirm_project_dialog.authors_label')}
-            </p>
-            {hasAcceptedAuthor ? (
-              <p className="text-sm">{acceptedAuthorNames.join(', ')}</p>
-            ) : (
-              <p className="text-sm text-error">
-                {t('projects.confirm_project_dialog.no_authors_blocking')}
+        }
+      >
+        {project ? (
+          <div className="space-y-5">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-label-secondary mb-2">
+                {t('projects.confirm_project_dialog.project_title_label')}
               </p>
-            )}
-          </div>
+              <p className="text-sm font-semibold text-label-primary break-words">
+                {project.title}
+              </p>
+            </div>
+            <div className="border-t border-border-primary pt-5">
+              <p className="text-xs font-semibold uppercase tracking-wide text-label-secondary mb-2">
+                {t('projects.confirm_project_dialog.authors_label')}
+              </p>
+              {hasAcceptedAuthor ? (
+                <p className="text-sm">{acceptedAuthorNames.join(', ')}</p>
+              ) : (
+                <p className="text-sm text-error">
+                  {t('projects.confirm_project_dialog.no_authors_blocking')}
+                </p>
+              )}
+            </div>
 
-          <div className="border-t border-border-primary pt-5">
-            <ProjectFormatSelector
-              projectTypes={projectTypes}
-              value={type}
-              onChange={handleTypeChange}
-              showFormatChoice={false}
-              disabled={loading}
-            />
-          </div>
-
-          <div className="border-t border-border-primary pt-5 [&_.col-span-10]:!mt-0">
-            <p className="text-xs font-semibold uppercase tracking-wide text-label-secondary mb-2">
-              {t('projects.add_dialog.instruction_label')}
-            </p>
-            <div className="flex items-center gap-2">
-              <div className="flex-1">
-                <DropDownSelector
-                  variant="material"
-                  placeholder={t('projects.add_dialog.instruction_placeholder')}
-                  value={instructionId}
-                  options={instructionDropdownOptions}
-                  isMandatory
-                  disabled={loading}
-                  onValueUpdated={(v: string) => {
-                    setInstructionId(v);
-                  }}
-                  identifierVariables={{}}
-                  refetchQueries={[]}
-                />
-              </div>
-              <InstructionDownloadButton
-                url={selectedInstructionUrl}
+            <div className="border-t border-border-primary pt-5">
+              <ProjectFormatSelector
+                projectTypes={projectTypes}
+                value={type}
+                onChange={handleTypeChange}
+                showFormatChoice={false}
                 disabled={loading}
               />
             </div>
-            <p className="mt-2 text-xs text-label-secondary whitespace-pre-line">
-              {instructionHelpText}
-            </p>
+
+            <div className="border-t border-border-primary pt-5 [&_.col-span-10]:!mt-0">
+              <p className="text-xs font-semibold uppercase tracking-wide text-label-secondary mb-2">
+                {t('projects.add_dialog.instruction_label')}
+              </p>
+              <div className="flex items-center gap-2">
+                <div className="flex-1">
+                  <DropDownSelector
+                    variant="material"
+                    placeholder={t('projects.add_dialog.instruction_placeholder')}
+                    value={instructionId}
+                    options={instructionDropdownOptions}
+                    isMandatory
+                    disabled={loading}
+                    onValueUpdated={(v: string) => {
+                      setInstructionId(v);
+                    }}
+                    identifierVariables={{}}
+                    refetchQueries={[]}
+                  />
+                </div>
+                <InstructionDownloadButton
+                  url={selectedInstructionUrl}
+                  disabled={loading}
+                />
+                <InstructionUploadButton
+                  onClick={() => setInstructionDialogOpen(true)}
+                  disabled={loading || !type}
+                  label={
+                    type
+                      ? t('projects.instruction_upload.open')
+                      : t('projects.instruction_upload.disabled_no_type')
+                  }
+                />
+              </div>
+              <p className="mt-2 text-xs text-label-secondary whitespace-pre-line">
+                {instructionHelpText}
+              </p>
+            </div>
           </div>
-        </div>
+        ) : null}
+      </DialogShell>
+
+      {type ? (
+        <DocumentationInstructionUploadDialog
+          open={instructionDialogOpen}
+          onClose={() => setInstructionDialogOpen(false)}
+          projectTypeValue={type}
+          selectedInstructionId={instructionId ? Number(instructionId) : null}
+          onCreated={(newId) => setInstructionId(String(newId))}
+          onSelectedDeleted={() => setInstructionId('')}
+          onError={onError}
+        />
       ) : null}
-    </DialogShell>
+    </>
   );
 };
 

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/DocumentationInstructionUploadDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/DocumentationInstructionUploadDialog.tsx
@@ -1,0 +1,501 @@
+import { FC, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { ApolloError } from '@apollo/client';
+import { MdDelete } from 'react-icons/md';
+import { DialogShell } from '../../../../common/dialogs/DialogShell';
+import { QuestionConfirmationDialog } from '../../../../common/dialogs/QuestionConfirmationDialog';
+import { Button } from '../../../../common/Button';
+import InputField from '../../../../inputs/InputField';
+import InstructionDownloadButton from '../../../CourseContent/Projects/InstructionDownloadButton';
+import { useRoleMutation } from '../../../../../hooks/authedMutation';
+import { useRoleQuery } from '../../../../../hooks/authedQuery';
+import { useFileUploader } from '../../../../../hooks/fileUpload';
+import { useUserId } from '../../../../../hooks/user';
+import {
+  DELETE_PROJECT_DOCUMENTATION_INSTRUCTION,
+  DELETE_PROJECT_DOCUMENTATION_INSTRUCTION_ACTION,
+  INSERT_PROJECT_DOCUMENTATION_INSTRUCTION,
+  MY_PROJECT_DOCUMENTATION_INSTRUCTIONS,
+  SAVE_PROJECT_DOCUMENTATION_INSTRUCTION,
+  UPDATE_PROJECT_DOCUMENTATION_INSTRUCTION_TITLE,
+  UPDATE_PROJECT_DOCUMENTATION_INSTRUCTION_URL,
+} from '../../../../../queries/projectDocumentationInstruction';
+import {
+  MyProjectDocumentationInstructions,
+  MyProjectDocumentationInstructionsVariables,
+  MyProjectDocumentationInstructions_ProjectDocumentationInstruction,
+} from '../../../../../queries/__generated__/MyProjectDocumentationInstructions';
+
+/** PDFs only: the action enforces the same via allowed-file-extensions + magic bytes. */
+const INSTRUCTION_ACCEPT = 'application/pdf,.pdf';
+const TITLE_MAX_LENGTH = 200;
+
+type OwnInstruction =
+  MyProjectDocumentationInstructions_ProjectDocumentationInstruction;
+
+interface DocumentationInstructionUploadDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Instructions belong to exactly one project type; never opened without one. */
+  projectTypeValue: string;
+  /**
+   * Fires once the row exists, its PDF is stored and the shared instruction query
+   * has been refetched — so the id is already among every dropdown's options.
+   */
+  onCreated: (instructionId: number) => void;
+  /** Instruction currently selected at the call site, if any. */
+  selectedInstructionId?: number | null;
+  /** Fires when `selectedInstructionId` was deleted, so callers can re-select. */
+  onSelectedDeleted?: () => void;
+  onError: (message: string) => void;
+  /** Call-site refetches to run on top of this dialog's own. */
+  refetchQueries?: string[];
+}
+
+/**
+ * Lets an instructor manage the documentation instructions they created for one
+ * project type: upload a new PDF, rename, replace the PDF, or delete.
+ *
+ * Ownership is enforced server-side, not here — the Hasura insert preset stamps
+ * `createdByUserId`, the update/delete permissions filter on it, and the
+ * saveProjectDocumentationInstruction handler re-checks it before storing a file.
+ * Platform (admin-maintained) instructions are therefore never listed or editable.
+ */
+const DocumentationInstructionUploadDialog: FC<
+  DocumentationInstructionUploadDialogProps
+> = ({
+  open,
+  onClose,
+  projectTypeValue,
+  onCreated,
+  selectedInstructionId,
+  onSelectedDeleted,
+  onError,
+  refetchQueries = [],
+}) => {
+  const t = useTranslations('manageCourse');
+  const tCommon = useTranslations('common');
+  const userId = useUserId();
+
+  const [title, setTitle] = useState('');
+  const [pdfFile, setPdfFile] = useState<File | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<OwnInstruction | null>(null);
+
+  const pdfInputId = useId();
+  const pdfInputRef = useRef<HTMLInputElement | null>(null);
+
+  // Refetch the shared dropdown query too, otherwise a newly created instruction
+  // is not yet an option at the call site when onCreated selects it.
+  const refetch = useMemo(
+    () => [
+      'ProjectDocumentationInstructions',
+      'MyProjectDocumentationInstructions',
+      ...refetchQueries,
+    ],
+    [refetchQueries]
+  );
+
+  const ownInstructionsQuery = useRoleQuery<
+    MyProjectDocumentationInstructions,
+    MyProjectDocumentationInstructionsVariables
+  >(MY_PROJECT_DOCUMENTATION_INSTRUCTIONS, {
+    variables: {
+      filter: {
+        projectTypeValue: { _eq: projectTypeValue },
+        createdByUserId: { _eq: userId },
+      },
+    },
+    skip: !open || !projectTypeValue || !userId,
+    fetchPolicy: 'cache-and-network',
+  });
+
+  const [insertInstruction] = useRoleMutation(
+    INSERT_PROJECT_DOCUMENTATION_INSTRUCTION
+  );
+  const [saveInstructionFile] = useRoleMutation(
+    SAVE_PROJECT_DOCUMENTATION_INSTRUCTION
+  );
+  const [updateInstructionUrl] = useRoleMutation(
+    UPDATE_PROJECT_DOCUMENTATION_INSTRUCTION_URL
+  );
+  // Rollback for a half-finished create. The narrow Hasura delete permission only
+  // covers own draft rows (url IS NULL), which is exactly this case.
+  const [deleteDraftInstruction] = useRoleMutation(
+    DELETE_PROJECT_DOCUMENTATION_INSTRUCTION
+  );
+  // Real deletions go through the action so referencing projects are reassigned to
+  // the type default first (Project.documentationInstructionId is ON DELETE RESTRICT).
+  const [deleteInstruction] = useRoleMutation(
+    DELETE_PROJECT_DOCUMENTATION_INSTRUCTION_ACTION,
+    { refetchQueries: refetch }
+  );
+  const { getFileBase64, isLoading: pdfEncoding } = useFileUploader();
+
+  const ownInstructions = ownInstructionsQuery.data?.ProjectDocumentationInstruction ?? [];
+
+  const resetForm = useCallback(() => {
+    setTitle('');
+    setPdfFile(null);
+    if (pdfInputRef.current) pdfInputRef.current.value = '';
+  }, []);
+
+  useEffect(() => {
+    if (!open) resetForm();
+  }, [open, resetForm]);
+
+  const handleClose = useCallback(() => {
+    // Closing mid-create would leave the user unsure whether the row was written.
+    if (busy) return;
+    onClose();
+  }, [busy, onClose]);
+
+  const canSubmit =
+    Boolean(title.trim()) && pdfFile !== null && !busy && !pdfEncoding;
+
+  /**
+   * Stores `file` as the PDF of an existing instruction and persists the returned
+   * path. Shared by the create flow and by replacing the PDF of a listed
+   * instruction. Returns true on success; the caller decides how to recover.
+   */
+  const uploadPdfFor = useCallback(
+    async (instructionId: number, file: File): Promise<boolean> => {
+      const base64File = await getFileBase64(file);
+      if (!base64File) {
+        onError(t('projects.instruction_upload.error.pdf_upload_failed'));
+        return false;
+      }
+
+      const uploadResult = await saveInstructionFile({
+        variables: {
+          base64File,
+          fileName: file.name,
+          projectDocumentationInstructionId: instructionId,
+        },
+      });
+      const uploadPayload = uploadResult.data?.saveProjectDocumentationInstruction;
+      if (!uploadPayload?.success || !uploadPayload.filePath) {
+        onError(
+          uploadPayload?.error ??
+            t('projects.instruction_upload.error.pdf_upload_failed')
+        );
+        return false;
+      }
+
+      // awaitRefetchQueries matters: the call sites only accept an instruction that
+      // is already among their (PDF-bearing) options, so the refetch has to land
+      // before onCreated selects it.
+      await updateInstructionUrl({
+        variables: { itemId: instructionId, url: uploadPayload.filePath },
+        refetchQueries: refetch,
+        awaitRefetchQueries: true,
+      });
+      return true;
+    },
+    [getFileBase64, saveInstructionFile, updateInstructionUrl, refetch, onError, t]
+  );
+
+  const handleReplacePdf = useCallback(
+    async (instructionId: number, file: File | null) => {
+      if (!file) return;
+      setBusy(true);
+      try {
+        await uploadPdfFor(instructionId, file);
+      } catch (err) {
+        onError(
+          err instanceof Error
+            ? err.message
+            : t('projects.instruction_upload.error.pdf_upload_failed')
+        );
+      } finally {
+        setBusy(false);
+      }
+    },
+    [uploadPdfFor, onError, t]
+  );
+
+  /**
+   * Three non-atomic steps: insert the row, store the PDF under a path derived
+   * from its id, then persist the returned path. Every failure branch removes the
+   * draft row again so a retry does not collide with its own leftovers.
+   */
+  const handleSubmit = useCallback(async () => {
+    const titleTrimmed = title.trim();
+    if (!titleTrimmed || !pdfFile) return;
+
+    setBusy(true);
+    let createdId: number | null = null;
+
+    const rollback = async () => {
+      if (createdId == null) return;
+      try {
+        await deleteDraftInstruction({ variables: { id: createdId } });
+      } catch {
+        // Best-effort: a url-less draft is hidden from every picker and the owner
+        // can still delete it from the list below.
+      }
+    };
+
+    try {
+      const insertResult = await insertInstruction({
+        variables: { title: titleTrimmed, projectTypeValue },
+      });
+      createdId =
+        insertResult.data?.insert_ProjectDocumentationInstruction_one?.id ?? null;
+      if (createdId == null) {
+        onError(t('projects.instruction_upload.error.create_failed'));
+        return;
+      }
+
+      const stored = await uploadPdfFor(createdId, pdfFile);
+      if (!stored) {
+        await rollback();
+        return;
+      }
+
+      onCreated(createdId);
+      resetForm();
+      onClose();
+    } catch (err) {
+      await rollback();
+      if (err instanceof ApolloError && err.message.includes('duplicate key value')) {
+        onError(t('projects.instruction_upload.error.duplicate_title'));
+      } else if (err instanceof ApolloError) {
+        onError(err.message);
+      } else {
+        onError(t('projects.instruction_upload.error.pdf_upload_failed'));
+      }
+    } finally {
+      setBusy(false);
+    }
+  }, [
+    title,
+    pdfFile,
+    projectTypeValue,
+    insertInstruction,
+    deleteDraftInstruction,
+    uploadPdfFor,
+    onCreated,
+    onClose,
+    onError,
+    resetForm,
+    t,
+  ]);
+
+  const handleConfirmDelete = useCallback(async () => {
+    if (!deleteTarget) return;
+    const target = deleteTarget;
+    setDeleteTarget(null);
+    try {
+      const result = await deleteInstruction({
+        variables: { instructionId: target.id },
+      });
+      const payload = result.data?.deleteProjectDocumentationInstruction;
+      if (!payload?.success) {
+        onError(
+          payload?.error ?? t('projects.instruction_upload.error.delete_failed')
+        );
+        return;
+      }
+      if (selectedInstructionId === target.id) onSelectedDeleted?.();
+    } catch (err) {
+      onError(
+        err instanceof Error
+          ? err.message
+          : t('projects.instruction_upload.error.delete_failed')
+      );
+    }
+  }, [
+    deleteTarget,
+    deleteInstruction,
+    onError,
+    onSelectedDeleted,
+    selectedInstructionId,
+    t,
+  ]);
+
+  return (
+    <>
+      <DialogShell
+        open={open}
+        onClose={handleClose}
+        title={t('projects.instruction_upload.dialog_title')}
+        ariaLabelledBy="documentation-instruction-upload-dialog"
+        maxWidth="sm"
+        actions={
+          <div className="flex justify-end gap-2">
+            <Button onClick={handleClose} disabled={busy}>
+              {tCommon('cancel')}
+            </Button>
+            <Button filled onClick={handleSubmit} disabled={!canSubmit}>
+              {t('projects.instruction_upload.submit')}
+            </Button>
+          </div>
+        }
+      >
+        <div className="space-y-5">
+          <div className="space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-label-secondary">
+              {t('projects.instruction_upload.create_heading')}
+            </p>
+            <p className="text-xs text-label-secondary">
+              {t('projects.instruction_upload.create_help')}
+            </p>
+
+            <label className="block">
+              <span className="block text-sm font-medium mb-1">
+                {t('projects.instruction_upload.title_label')} *
+              </span>
+              <input
+                type="text"
+                className="w-full border border-border-primary rounded px-3 py-2"
+                value={title}
+                onChange={(e) => setTitle(e.target.value)}
+                placeholder={t('projects.instruction_upload.title_placeholder')}
+                maxLength={TITLE_MAX_LENGTH}
+                disabled={busy}
+                autoFocus
+              />
+            </label>
+
+            <div>
+              <span className="block text-sm font-medium mb-1">
+                {t('projects.instruction_upload.pdf_label')} *
+              </span>
+              <p className="text-xs text-label-secondary mb-2">
+                {t('projects.instruction_upload.pdf_required')}
+              </p>
+              <input
+                ref={pdfInputRef}
+                id={pdfInputId}
+                type="file"
+                accept={INSTRUCTION_ACCEPT}
+                className="sr-only"
+                disabled={busy || pdfEncoding}
+                onChange={(e) => setPdfFile(e.target.files?.[0] ?? null)}
+              />
+              <label
+                htmlFor={pdfInputId}
+                className={`inline-block cursor-pointer rounded border border-border-primary px-3 py-2 text-sm ${
+                  busy || pdfEncoding
+                    ? 'opacity-50 pointer-events-none'
+                    : 'hover:bg-bg-secondary'
+                }`}
+              >
+                {t('projects.instruction_upload.pdf_choose')}
+              </label>
+              {pdfFile ? (
+                <p className="mt-2 text-sm text-label-primary">
+                  {t('projects.instruction_upload.pdf_selected', {
+                    fileName: pdfFile.name,
+                  })}
+                </p>
+              ) : null}
+            </div>
+          </div>
+
+          <div className="border-t border-border-primary pt-4 space-y-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-label-secondary">
+              {t('projects.instruction_upload.own_list_heading')}
+            </p>
+            <p className="text-xs text-label-secondary">
+              {t('projects.instruction_upload.own_list_help')}
+            </p>
+
+            {ownInstructions.length === 0 ? (
+              <p className="text-sm text-label-secondary">
+                {t('projects.instruction_upload.own_list_empty')}
+              </p>
+            ) : (
+              <ul className="space-y-4">
+                {ownInstructions.map((instruction) => (
+                  <li
+                    key={instruction.id}
+                    className="rounded border border-border-primary p-3 space-y-2"
+                  >
+                    <div className="flex items-start gap-2">
+                      <div className="flex-1 min-w-0 [&_.col-span-10]:!mt-0">
+                        <InputField
+                          variant="material"
+                          type="input"
+                          itemId={instruction.id}
+                          value={instruction.title}
+                          updateValueMutation={
+                            UPDATE_PROJECT_DOCUMENTATION_INSTRUCTION_TITLE
+                          }
+                          refetchQueries={refetch}
+                          maxLength={TITLE_MAX_LENGTH}
+                          className="!mb-0"
+                        />
+                      </div>
+                      <InstructionDownloadButton url={instruction.url} />
+                      <button
+                        type="button"
+                        aria-label={t('projects.instruction_upload.delete_tooltip')}
+                        title={t('projects.instruction_upload.delete_tooltip')}
+                        onClick={() => setDeleteTarget(instruction)}
+                        className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded border border-border-primary text-label-secondary hover:bg-bg-secondary touch-manipulation"
+                      >
+                        <MdDelete />
+                      </button>
+                    </div>
+                    {/*
+                      A plain replace control rather than FileUploadField: that
+                      component always renders a remove button which, without a
+                      removeMutation, falls back to the update mutation and writes
+                      url = NULL - hiding an instruction that projects still
+                      reference. Replacing keeps the row and every project pointing
+                      at it.
+                    */}
+                    <div className="flex items-center gap-2">
+                      <input
+                        id={`${pdfInputId}-replace-${instruction.id}`}
+                        type="file"
+                        accept={INSTRUCTION_ACCEPT}
+                        className="sr-only"
+                        disabled={busy || pdfEncoding}
+                        onChange={(e) => {
+                          const file = e.target.files?.[0] ?? null;
+                          e.target.value = '';
+                          void handleReplacePdf(instruction.id, file);
+                        }}
+                      />
+                      <label
+                        htmlFor={`${pdfInputId}-replace-${instruction.id}`}
+                        className={`inline-block cursor-pointer rounded border border-border-primary px-3 py-1.5 text-xs ${
+                          busy || pdfEncoding
+                            ? 'opacity-50 pointer-events-none'
+                            : 'hover:bg-bg-secondary'
+                        }`}
+                      >
+                        {t('projects.instruction_upload.replace_label')}
+                      </label>
+                      {instruction.url ? null : (
+                        <span className="text-xs text-warning">
+                          {t('projects.instruction_upload.missing_pdf')}
+                        </span>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      </DialogShell>
+
+      <QuestionConfirmationDialog
+        open={Boolean(deleteTarget)}
+        title={t('projects.instruction_upload.delete_dialog.title')}
+        question={t('projects.instruction_upload.delete_dialog.question', {
+          title: deleteTarget?.title ?? '',
+        })}
+        confirmationText={t('projects.instruction_upload.delete_dialog.confirm')}
+        onClose={() => setDeleteTarget(null)}
+        onConfirm={handleConfirmDelete}
+      />
+    </>
+  );
+};
+
+export default DocumentationInstructionUploadDialog;

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/DocumentationInstructionUploadDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/DocumentationInstructionUploadDialog.tsx
@@ -29,6 +29,11 @@ import {
 /** PDFs only: the action enforces the same via allowed-file-extensions + magic bytes. */
 const INSTRUCTION_ACCEPT = 'application/pdf,.pdf';
 const TITLE_MAX_LENGTH = 200;
+/**
+ * How many of the caller's own instructions are fetched at once. The list is meant
+ * to be read as a whole, so "load more" widens this window instead of paging.
+ */
+const OWN_LIST_PAGE_SIZE = 25;
 
 type OwnInstruction =
   MyProjectDocumentationInstructions_ProjectDocumentationInstruction;
@@ -81,6 +86,7 @@ const DocumentationInstructionUploadDialog: FC<
   const [pdfFile, setPdfFile] = useState<File | null>(null);
   const [busy, setBusy] = useState(false);
   const [deleteTarget, setDeleteTarget] = useState<OwnInstruction | null>(null);
+  const [ownListLimit, setOwnListLimit] = useState(OWN_LIST_PAGE_SIZE);
 
   const pdfInputId = useId();
   const pdfInputRef = useRef<HTMLInputElement | null>(null);
@@ -105,6 +111,8 @@ const DocumentationInstructionUploadDialog: FC<
         projectTypeValue: { _eq: projectTypeValue },
         createdByUserId: { _eq: userId },
       },
+      // One extra row so a further page can be detected without a count query.
+      limit: ownListLimit + 1,
     },
     skip: !open || !projectTypeValue || !userId,
     fetchPolicy: 'cache-and-network',
@@ -132,11 +140,21 @@ const DocumentationInstructionUploadDialog: FC<
   );
   const { getFileBase64, isLoading: pdfEncoding } = useFileUploader();
 
-  const ownInstructions = ownInstructionsQuery.data?.ProjectDocumentationInstruction ?? [];
+  const fetchedOwnInstructions =
+    ownInstructionsQuery.data?.ProjectDocumentationInstruction ?? [];
+  const hasMoreOwnInstructions = fetchedOwnInstructions.length > ownListLimit;
+  const ownInstructions = hasMoreOwnInstructions
+    ? fetchedOwnInstructions.slice(0, ownListLimit)
+    : fetchedOwnInstructions;
+  // `cache-and-network` yields an empty list on the first pass, so the empty state
+  // must not be shown until the query has actually resolved once.
+  const ownListLoading =
+    ownInstructionsQuery.loading && ownInstructionsQuery.data === undefined;
 
   const resetForm = useCallback(() => {
     setTitle('');
     setPdfFile(null);
+    setOwnListLimit(OWN_LIST_PAGE_SIZE);
     if (pdfInputRef.current) pdfInputRef.current.value = '';
   }, []);
 
@@ -402,7 +420,9 @@ const DocumentationInstructionUploadDialog: FC<
               {t('projects.instruction_upload.own_list_help')}
             </p>
 
-            {ownInstructions.length === 0 ? (
+            {ownListLoading ? (
+              <p className="text-sm text-label-secondary">{tCommon('loading')}</p>
+            ) : ownInstructions.length === 0 ? (
               <p className="text-sm text-label-secondary">
                 {t('projects.instruction_upload.own_list_empty')}
               </p>
@@ -480,6 +500,14 @@ const DocumentationInstructionUploadDialog: FC<
                 ))}
               </ul>
             )}
+
+            {hasMoreOwnInstructions ? (
+              <Button
+                onClick={() => setOwnListLimit((n) => n + OWN_LIST_PAGE_SIZE)}
+              >
+                {t('projects.instruction_upload.load_more')}
+              </Button>
+            ) : null}
           </div>
         </div>
       </DialogShell>

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/ProjectsManagementGrid.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/ProjectsManagementGrid.tsx
@@ -18,6 +18,8 @@ import CheckboxSelector from '../../../../inputs/CheckboxSelector';
 import FileUploadField from '../../../../inputs/FileUploadField';
 import ProjectFormatSelector from '../../../CourseContent/Projects/ProjectFormatSelector';
 import InstructionDownloadButton from '../../../CourseContent/Projects/InstructionDownloadButton';
+import InstructionUploadButton from '../../../CourseContent/Projects/InstructionUploadButton';
+import DocumentationInstructionUploadDialog from './DocumentationInstructionUploadDialog';
 import {
   PROJECT_REQUIREMENT_KEYS,
   REQUIREMENT_I18N_KEY,
@@ -101,6 +103,9 @@ const ProjectsManagementGrid: FC<ProjectsManagementGridProps> = ({
   const [confirmProject, setConfirmProject] = useState<ProjectRow | null>(null);
   const [reviewProject, setReviewProject] = useState<ProjectRow | null>(null);
   const [addDialogOpen, setAddDialogOpen] = useState(false);
+  const [instructionDialogRow, setInstructionDialogRow] = useState<ProjectRow | null>(
+    null
+  );
   const [selectAuthorTarget, setSelectAuthorTarget] = useState<ProjectRow | null>(null);
   const [selectMentorTarget, setSelectMentorTarget] = useState<ProjectRow | null>(null);
   const [removeAuthorContext, setRemoveAuthorContext] = useState<{
@@ -142,6 +147,12 @@ const ProjectsManagementGrid: FC<ProjectsManagementGridProps> = ({
   const [updateProjectType] = useRoleMutation(UPDATE_PROJECT_TYPE, {
     refetchQueries: REFETCH_QUERIES,
   });
+  // Selecting the instruction created in the dialog: this dropdown is
+  // mutation-driven, so the choice has to be persisted rather than held in state.
+  const [updateProjectDocumentationInstruction] = useRoleMutation(
+    UPDATE_PROJECT_DOCUMENTATION_INSTRUCTION,
+    { refetchQueries: REFETCH_QUERIES }
+  );
 
   const allProjects = projectsQuery.data?.Project ?? [];
 
@@ -300,6 +311,23 @@ const ProjectsManagementGrid: FC<ProjectsManagementGridProps> = ({
       }
     },
     [updateSuggestedForPublication, tCommon]
+  );
+
+  // The dialog is opened per row, so capture the target from state rather than from
+  // a row closure that may have been re-rendered in the meantime.
+  const handleInstructionCreated = useCallback(
+    async (instructionId: number) => {
+      const targetId = instructionDialogRow?.id;
+      if (targetId == null) return;
+      try {
+        await updateProjectDocumentationInstruction({
+          variables: { itemId: targetId, value: instructionId },
+        });
+      } catch (err) {
+        setErrorMessage(err instanceof Error ? err.message : tCommon('error'));
+      }
+    },
+    [instructionDialogRow?.id, updateProjectDocumentationInstruction, tCommon]
   );
 
   const handleSetProjectType = useCallback(
@@ -705,29 +733,47 @@ const ProjectsManagementGrid: FC<ProjectsManagementGridProps> = ({
           (inst) => inst.id === row.documentationInstructionId
         )?.url ?? null;
 
+      // An instructor may upload the first instruction for a type that has none, so
+      // the section also renders when the option list is still empty.
+      const canUploadOwnInstruction = canEditProjectType && Boolean(row.type);
       const documentationInstructionSection =
-        rowInstructionOptions.length > 0 ? (
+        rowInstructionOptions.length > 0 || canUploadOwnInstruction ? (
           <div>
             <p className="text-xs font-semibold uppercase tracking-wide text-label-secondary mb-2">
               {t('projects.add_dialog.instruction_label')}
             </p>
             <div className="flex items-center gap-2 [&_.col-span-10]:!mt-0">
-              <div className="flex-1">
-                <DropDownSelector
-                  variant="material"
-                  value={
-                    row.documentationInstructionId
-                      ? String(row.documentationInstructionId)
-                      : ''
-                  }
-                  options={rowInstructionOptions}
-                  updateValueMutation={UPDATE_PROJECT_DOCUMENTATION_INSTRUCTION}
-                  identifierVariables={{ itemId: row.id }}
-                  refetchQueries={REFETCH_QUERIES}
-                  disabled={!canEditProjectType}
-                />
-              </div>
+              {rowInstructionOptions.length > 0 ? (
+                <div className="flex-1">
+                  <DropDownSelector
+                    variant="material"
+                    value={
+                      row.documentationInstructionId
+                        ? String(row.documentationInstructionId)
+                        : ''
+                    }
+                    options={rowInstructionOptions}
+                    updateValueMutation={UPDATE_PROJECT_DOCUMENTATION_INSTRUCTION}
+                    identifierVariables={{ itemId: row.id }}
+                    refetchQueries={REFETCH_QUERIES}
+                    disabled={!canEditProjectType}
+                  />
+                </div>
+              ) : (
+                <p className="flex-1 text-sm text-label-secondary">
+                  {t('projects.instruction_upload.own_list_empty')}
+                </p>
+              )}
               <InstructionDownloadButton url={selectedInstructionUrl} />
+              <InstructionUploadButton
+                onClick={() => setInstructionDialogRow(row)}
+                disabled={!canUploadOwnInstruction}
+                label={
+                  row.type
+                    ? t('projects.instruction_upload.open')
+                    : t('projects.instruction_upload.disabled_no_type')
+                }
+              />
             </div>
             <p className="mt-2 text-xs text-label-secondary whitespace-pre-line">
               {t('projects.add_dialog.instruction_info')}
@@ -1016,6 +1062,19 @@ const ProjectsManagementGrid: FC<ProjectsManagementGridProps> = ({
           blockedAuthorIds={blockedAuthorIds}
           refetchQueries={REFETCH_QUERIES}
           onError={setErrorMessage}
+        />
+      ) : null}
+
+      {instructionDialogRow?.type ? (
+        <DocumentationInstructionUploadDialog
+          open
+          onClose={() => setInstructionDialogRow(null)}
+          projectTypeValue={instructionDialogRow.type}
+          selectedInstructionId={instructionDialogRow.documentationInstructionId}
+          onCreated={handleInstructionCreated}
+          onSelectedDeleted={() => projectsQuery.refetch()}
+          onError={setErrorMessage}
+          refetchQueries={REFETCH_QUERIES}
         />
       ) : null}
 

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1449,6 +1449,37 @@
         "error_author_already_in_project": "{name} ist in diesem Kurs bereits einem aktiven Projekt zugeordnet und kann keinem weiteren hinzugefügt werden.",
         "error_author_conflict_generic": "Mindestens eine:r der ausgewählten Autor:innen ist in diesem Kurs bereits einem aktiven Projekt zugeordnet und kann keinem weiteren hinzugefügt werden."
       },
+      "instruction_upload": {
+        "open": "Eigene Dokumentationsanleitung hochladen oder verwalten",
+        "disabled_no_type": "Wähle zuerst einen Projekttyp – eine Dokumentationsanleitung gehört immer zu einem Typ.",
+        "dialog_title": "Eigene Dokumentationsanleitungen",
+        "create_heading": "Neue Anleitung hochladen",
+        "create_help": "Die Anleitung gilt für den aktuellen Projekttyp. Nur Du und die Teams, deren Projekt sie nutzt, sehen sie – andere Kursleitungen nicht.",
+        "title_label": "Titel",
+        "title_placeholder": "z. B. Doku-Leitfaden Kurs XY (WS26)",
+        "pdf_label": "PDF",
+        "pdf_required": "Erforderlich: eine PDF-Datei, maximal 20 MB.",
+        "pdf_choose": "PDF auswählen",
+        "pdf_selected": "Ausgewählt: {fileName}",
+        "submit": "Hochladen und auswählen",
+        "own_list_heading": "Deine Anleitungen für diesen Projekttyp",
+        "own_list_help": "Titel ändern, PDF ersetzen oder Anleitung löschen. Anleitungen von opencampus.sh kannst Du hier nicht bearbeiten.",
+        "own_list_empty": "Du hast für diesen Projekttyp noch keine eigene Anleitung hochgeladen.",
+        "replace_label": "PDF ersetzen",
+        "missing_pdf": "Kein PDF hinterlegt – diese Anleitung wird noch nicht angeboten.",
+        "delete_tooltip": "Anleitung löschen",
+        "delete_dialog": {
+          "title": "Anleitung löschen",
+          "question": "Soll die Anleitung „{title}“ gelöscht werden? Projekte, die sie nutzen, werden auf die Standard-Anleitung des Projekttyps umgestellt.",
+          "confirm": "Löschen"
+        },
+        "error": {
+          "create_failed": "Die Anleitung konnte nicht angelegt werden.",
+          "pdf_upload_failed": "Das PDF konnte nicht hochgeladen werden. Die Anleitung wurde nicht angelegt.",
+          "duplicate_title": "Du hast bereits eine Anleitung mit diesem Titel. Wähle einen anderen Titel.",
+          "delete_failed": "Die Anleitung konnte nicht gelöscht werden."
+        }
+      },
       "requirements": {
         "section_label": "Erforderliche Abgaben",
         "section_help": "Wähle aus, was Teilnehmende für dieses Projekt einreichen müssen. Die gewählte Kombination bestimmt den Projekttyp.",

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1465,6 +1465,7 @@
         "own_list_heading": "Deine Anleitungen für diesen Projekttyp",
         "own_list_help": "Titel ändern, PDF ersetzen oder Anleitung löschen. Anleitungen von opencampus.sh kannst Du hier nicht bearbeiten.",
         "own_list_empty": "Du hast für diesen Projekttyp noch keine eigene Anleitung hochgeladen.",
+        "load_more": "Weitere anzeigen",
         "replace_label": "PDF ersetzen",
         "missing_pdf": "Kein PDF hinterlegt – diese Anleitung wird noch nicht angeboten.",
         "delete_tooltip": "Anleitung löschen",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1467,6 +1467,37 @@
         "error_author_already_in_project": "{name} already belongs to an active project in this course and can't be added to another one.",
         "error_author_conflict_generic": "One or more selected authors already belong to an active project in this course and can't be added to another one."
       },
+      "instruction_upload": {
+        "open": "Upload or manage your own documentation instructions",
+        "disabled_no_type": "Select a project type first - a documentation instruction always belongs to one type.",
+        "dialog_title": "Your documentation instructions",
+        "create_heading": "Upload a new instruction",
+        "create_help": "The instruction applies to the current project type. Only you and the teams whose project uses it can see it - other instructors cannot.",
+        "title_label": "Title",
+        "title_placeholder": "e.g. Documentation guide course XY (WS26)",
+        "pdf_label": "PDF",
+        "pdf_required": "Required: one PDF file, at most 20 MB.",
+        "pdf_choose": "Choose PDF",
+        "pdf_selected": "Selected: {fileName}",
+        "submit": "Upload and select",
+        "own_list_heading": "Your instructions for this project type",
+        "own_list_help": "Rename, replace the PDF, or delete. Instructions provided by opencampus.sh cannot be edited here.",
+        "own_list_empty": "You have not uploaded your own instruction for this project type yet.",
+        "replace_label": "Replace PDF",
+        "missing_pdf": "No PDF attached yet - this instruction is not offered anywhere.",
+        "delete_tooltip": "Delete instruction",
+        "delete_dialog": {
+          "title": "Delete instruction",
+          "question": "Delete the instruction “{title}”? Projects using it are moved to the project type's default instruction.",
+          "confirm": "Delete"
+        },
+        "error": {
+          "create_failed": "The instruction could not be created.",
+          "pdf_upload_failed": "The PDF could not be uploaded. The instruction was not created.",
+          "duplicate_title": "You already have an instruction with this title. Choose a different title.",
+          "delete_failed": "The instruction could not be deleted."
+        }
+      },
       "requirements": {
         "section_label": "Required submission deliverables",
         "section_help": "Check what students must submit for this project. The selected combination determines the project type.",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1483,6 +1483,7 @@
         "own_list_heading": "Your instructions for this project type",
         "own_list_help": "Rename, replace the PDF, or delete. Instructions provided by opencampus.sh cannot be edited here.",
         "own_list_empty": "You have not uploaded your own instruction for this project type yet.",
+        "load_more": "Show more",
         "replace_label": "Replace PDF",
         "missing_pdf": "No PDF attached yet - this instruction is not offered anywhere.",
         "delete_tooltip": "Delete instruction",

--- a/frontend-nx/apps/edu-hub/queries/__generated__/DeleteProjectDocumentationInstructionAction.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/DeleteProjectDocumentationInstructionAction.ts
@@ -17,7 +17,7 @@ export interface DeleteProjectDocumentationInstructionAction_deleteProjectDocume
 
 export interface DeleteProjectDocumentationInstructionAction {
   /**
-   * Reassigns projects using the instruction to the type default, then deletes the non-default instruction.
+   * Reassigns projects using the instruction to the type default, then deletes the non-default instruction. Instructors may only delete instructions they created (verified in the handler).
    */
   deleteProjectDocumentationInstruction: DeleteProjectDocumentationInstructionAction_deleteProjectDocumentationInstruction;
 }

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MyProjectDocumentationInstructions.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MyProjectDocumentationInstructions.ts
@@ -40,4 +40,5 @@ export interface MyProjectDocumentationInstructions {
 
 export interface MyProjectDocumentationInstructionsVariables {
   filter: ProjectDocumentationInstruction_bool_exp;
+  limit: number;
 }

--- a/frontend-nx/apps/edu-hub/queries/__generated__/MyProjectDocumentationInstructions.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/MyProjectDocumentationInstructions.ts
@@ -1,0 +1,43 @@
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { ProjectDocumentationInstruction_bool_exp } from "./../../__generated__/globalTypes";
+
+// ====================================================
+// GraphQL query operation: MyProjectDocumentationInstructions
+// ====================================================
+
+export interface MyProjectDocumentationInstructions_ProjectDocumentationInstruction {
+  __typename: "ProjectDocumentationInstruction";
+  id: number;
+  /**
+   * Admin-facing label in instruction dropdowns.
+   */
+  title: string;
+  /**
+   * Instruction PDF location: static app path (e.g. /project-documentation-instructions/…) or GCS object path after admin upload. Nullable until a file is attached.
+   */
+  url: string | null;
+  /**
+   * FK to ProjectType.value. Every instruction belongs to exactly one type; must match Project.type when linked (see Project_instruction_matches_type_trg).
+   */
+  projectTypeValue: string;
+  /**
+   * When true, this instruction is the default for its projectTypeValue (at most one per type; partial unique index). Shown first in dropdowns and applied when the project type changes.
+   */
+  isDefault: boolean;
+  updated_at: any;
+}
+
+export interface MyProjectDocumentationInstructions {
+  /**
+   * fetch data from the table: "ProjectDocumentationInstruction"
+   */
+  ProjectDocumentationInstruction: MyProjectDocumentationInstructions_ProjectDocumentationInstruction[];
+}
+
+export interface MyProjectDocumentationInstructionsVariables {
+  filter: ProjectDocumentationInstruction_bool_exp;
+}

--- a/frontend-nx/apps/edu-hub/queries/__generated__/SaveProjectDocumentationInstruction.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/SaveProjectDocumentationInstruction.ts
@@ -17,6 +17,9 @@ export interface SaveProjectDocumentationInstruction_saveProjectDocumentationIns
 }
 
 export interface SaveProjectDocumentationInstruction {
+  /**
+   * Stores an instruction PDF. The handler verifies that a non-admin caller owns the target non-default instruction before delegating to saveFile.
+   */
   saveProjectDocumentationInstruction: SaveProjectDocumentationInstruction_saveProjectDocumentationInstruction | null;
 }
 

--- a/frontend-nx/apps/edu-hub/queries/projectDocumentationInstruction.ts
+++ b/frontend-nx/apps/edu-hub/queries/projectDocumentationInstruction.ts
@@ -151,3 +151,28 @@ export const SAVE_PROJECT_DOCUMENTATION_INSTRUCTION = gql`
     }
   }
 `;
+
+/**
+ * The instructions the caller may manage themselves.
+ *
+ * The caller passes the whole bool_exp (project type plus
+ * `createdByUserId: {_eq: <me>}`); Hasura ANDs its own select filter on top, so a
+ * client-side filter can never widen visibility. Unlike
+ * PROJECT_DOCUMENTATION_INSTRUCTIONS this does NOT filter on `url`: a draft left
+ * behind by a failed upload has to stay visible here so its owner can retry or
+ * delete it.
+ */
+export const MY_PROJECT_DOCUMENTATION_INSTRUCTIONS = gql`
+  query MyProjectDocumentationInstructions(
+    $filter: ProjectDocumentationInstruction_bool_exp!
+  ) {
+    ProjectDocumentationInstruction(where: $filter, order_by: [{ title: asc }]) {
+      id
+      title
+      url
+      projectTypeValue
+      isDefault
+      updated_at
+    }
+  }
+`;

--- a/frontend-nx/apps/edu-hub/queries/projectDocumentationInstruction.ts
+++ b/frontend-nx/apps/edu-hub/queries/projectDocumentationInstruction.ts
@@ -161,12 +161,21 @@ export const SAVE_PROJECT_DOCUMENTATION_INSTRUCTION = gql`
  * PROJECT_DOCUMENTATION_INSTRUCTIONS this does NOT filter on `url`: a draft left
  * behind by a failed upload has to stay visible here so its owner can retry or
  * delete it.
+ *
+ * `limit` bounds the result set. The dialog shows one growing window and raises the
+ * limit on demand rather than paging, because the list is meant to be read as a
+ * whole; that is why there is no `offset`.
  */
 export const MY_PROJECT_DOCUMENTATION_INSTRUCTIONS = gql`
   query MyProjectDocumentationInstructions(
     $filter: ProjectDocumentationInstruction_bool_exp!
+    $limit: Int!
   ) {
-    ProjectDocumentationInstruction(where: $filter, order_by: [{ title: asc }]) {
+    ProjectDocumentationInstruction(
+      where: $filter
+      order_by: [{ title: asc }]
+      limit: $limit
+    ) {
       id
       title
       url

--- a/functions/callNodeFunction/deleteProjectDocumentationInstruction/__tests__/deleteProjectDocumentationInstruction.test.js
+++ b/functions/callNodeFunction/deleteProjectDocumentationInstruction/__tests__/deleteProjectDocumentationInstruction.test.js
@@ -1,0 +1,178 @@
+import { jest } from '@jest/globals';
+
+const mockGraphqlRequest = jest.fn();
+
+const mockLogger = {
+  info: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+};
+
+jest.unstable_mockModule('graphql-request', () => {
+  const actual = jest.requireActual('graphql-request');
+  return {
+    ...actual,
+    GraphQLClient: jest.fn().mockImplementation(() => ({
+      request: mockGraphqlRequest,
+    })),
+  };
+});
+
+const { default: deleteProjectDocumentationInstruction } = await import('../index.js');
+
+const OWNER_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_ID = '22222222-2222-2222-2222-222222222222';
+
+const buildRequest = ({ role, userId, instructionId = 42 }) => ({
+  body: {
+    session_variables: {
+      'x-hasura-role': role,
+      ...(userId ? { 'x-hasura-user-id': userId } : {}),
+    },
+    input: { instructionId },
+  },
+});
+
+/**
+ * The handler issues up to three requests: look up the row, find the type default,
+ * then reassign-and-delete. Queue the responses in that order.
+ */
+const queueSuccessfulDelete = (instruction, { reassigned = 2 } = {}) => {
+  mockGraphqlRequest
+    .mockResolvedValueOnce({
+      ProjectDocumentationInstruction_by_pk: instruction,
+    })
+    .mockResolvedValueOnce({ ProjectDocumentationInstruction: [{ id: 9 }] })
+    .mockResolvedValueOnce({
+      update_Project: { affected_rows: reassigned },
+      delete_ProjectDocumentationInstruction_by_pk: { id: instruction.id },
+    });
+};
+
+describe('deleteProjectDocumentationInstruction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.HASURA_ENDPOINT = 'http://localhost:8080/v1/graphql';
+    process.env.HASURA_ADMIN_SECRET = 'test-admin-secret';
+  });
+
+  it('lets an admin delete a platform instruction', async () => {
+    queueSuccessfulDelete({
+      id: 42,
+      projectTypeValue: 'PROJECT_WITH_LINK',
+      isDefault: false,
+      createdByUserId: null,
+    });
+
+    const result = await deleteProjectDocumentationInstruction(
+      buildRequest({ role: 'admin' }),
+      mockLogger
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.reassignedProjectCount).toBe(2);
+  });
+
+  it('lets an instructor delete their own instruction', async () => {
+    queueSuccessfulDelete({
+      id: 42,
+      projectTypeValue: 'PROJECT_WITH_LINK',
+      isDefault: false,
+      createdByUserId: OWNER_ID,
+    });
+
+    const result = await deleteProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor', userId: OWNER_ID }),
+      mockLogger
+    );
+
+    expect(result.success).toBe(true);
+  });
+
+  it("refuses another instructor's instruction", async () => {
+    mockGraphqlRequest.mockResolvedValueOnce({
+      ProjectDocumentationInstruction_by_pk: {
+        id: 42,
+        projectTypeValue: 'PROJECT_WITH_LINK',
+        isDefault: false,
+        createdByUserId: OTHER_ID,
+      },
+    });
+
+    const result = await deleteProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor', userId: OWNER_ID }),
+      mockLogger
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.messageKey).toBe(
+      'DELETE_PROJECT_DOCUMENTATION_INSTRUCTION_FORBIDDEN'
+    );
+    // Only the lookup ran: nothing was reassigned or deleted.
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('refuses a platform instruction for an instructor', async () => {
+    mockGraphqlRequest.mockResolvedValueOnce({
+      ProjectDocumentationInstruction_by_pk: {
+        id: 7,
+        projectTypeValue: 'PROJECT_WITH_LINK',
+        isDefault: false,
+        createdByUserId: null,
+      },
+    });
+
+    const result = await deleteProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor', userId: OWNER_ID, instructionId: 7 }),
+      mockLogger
+    );
+
+    expect(result.messageKey).toBe(
+      'DELETE_PROJECT_DOCUMENTATION_INSTRUCTION_FORBIDDEN'
+    );
+    expect(mockGraphqlRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('still refuses a default instruction, for owner and admin alike', async () => {
+    for (const request of [
+      buildRequest({ role: 'instructor', userId: OWNER_ID }),
+      buildRequest({ role: 'admin' }),
+    ]) {
+      jest.clearAllMocks();
+      mockGraphqlRequest.mockResolvedValueOnce({
+        ProjectDocumentationInstruction_by_pk: {
+          id: 42,
+          projectTypeValue: 'PROJECT_WITH_LINK',
+          isDefault: true,
+          createdByUserId: OWNER_ID,
+        },
+      });
+
+      const result = await deleteProjectDocumentationInstruction(
+        request,
+        mockLogger
+      );
+
+      expect(result.messageKey).toBe(
+        'DELETE_PROJECT_DOCUMENTATION_INSTRUCTION_IS_DEFAULT'
+      );
+    }
+  });
+
+  it('rejects roles other than admin and instructor', async () => {
+    for (const role of ['user', 'anonymous', 'instructor_access']) {
+      jest.clearAllMocks();
+
+      const result = await deleteProjectDocumentationInstruction(
+        buildRequest({ role, userId: OWNER_ID }),
+        mockLogger
+      );
+
+      expect(result.messageKey).toBe(
+        'DELETE_PROJECT_DOCUMENTATION_INSTRUCTION_UNAUTHORIZED'
+      );
+      expect(mockGraphqlRequest).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/functions/callNodeFunction/deleteProjectDocumentationInstruction/index.js
+++ b/functions/callNodeFunction/deleteProjectDocumentationInstruction/index.js
@@ -1,6 +1,9 @@
 import { GraphQLClient } from "graphql-request";
 
-const ALLOWED_ROLES = new Set(["admin"]);
+// Request roles from session_variables, not the inherited-role names used in
+// actions.yaml permissions. Instructors are additionally limited to instructions
+// they created (checked below).
+const ALLOWED_ROLES = new Set(["admin", "instructor"]);
 
 const ensureHasuraClient = () => {
   if (!process.env.HASURA_ENDPOINT || !process.env.HASURA_ADMIN_SECRET) {
@@ -19,6 +22,7 @@ const GET_INSTRUCTION = `
       id
       projectTypeValue
       isDefault
+      createdByUserId
     }
   }
 `;
@@ -62,7 +66,7 @@ export default async function deleteProjectDocumentationInstruction(req, logger)
     return {
       success: false,
       messageKey: "DELETE_PROJECT_DOCUMENTATION_INSTRUCTION_UNAUTHORIZED",
-      error: "Only admin users may delete documentation instructions",
+      error: "Only admins and instructors may delete documentation instructions",
       reassignedProjectCount: 0,
     };
   }
@@ -111,6 +115,21 @@ export default async function deleteProjectDocumentationInstruction(req, logger)
         success: false,
         messageKey: "DELETE_PROJECT_DOCUMENTATION_INSTRUCTION_IS_DEFAULT",
         error: "Default instructions cannot be deleted",
+        reassignedProjectCount: 0,
+      };
+    }
+    // Admins manage the whole catalogue; an instructor may only delete what they
+    // created. Platform rows (createdByUserId IS NULL) are therefore off limits.
+    const callerUserId = req.body?.session_variables?.["x-hasura-user-id"];
+    if (role !== "admin" && instruction.createdByUserId !== callerUserId) {
+      logger.error("Instruction does not belong to the caller", {
+        instructionId,
+        role,
+      });
+      return {
+        success: false,
+        messageKey: "DELETE_PROJECT_DOCUMENTATION_INSTRUCTION_FORBIDDEN",
+        error: "You may only delete documentation instructions you created",
         reassignedProjectCount: 0,
       };
     }

--- a/functions/callNodeFunction/index.js
+++ b/functions/callNodeFunction/index.js
@@ -31,6 +31,7 @@ import syncProgramInstructorMatrixRoom from "./syncProgramInstructorMatrixRoom/i
 import copyProjectFromTemplate from "./copyProjectFromTemplate/index.js";
 import setProjectDocumentationInstructionDefault from "./setProjectDocumentationInstructionDefault/index.js";
 import deleteProjectDocumentationInstruction from "./deleteProjectDocumentationInstruction/index.js";
+import saveProjectDocumentationInstruction from "./saveProjectDocumentationInstruction/index.js";
 import sendProjectEmail from "./sendProjectEmail/index.js";
 import sendCourseUpdateEmail from "./sendCourseUpdateEmail/index.js";
 
@@ -92,6 +93,7 @@ const functionMap = {
   copyProjectFromTemplate,
   setProjectDocumentationInstructionDefault,
   deleteProjectDocumentationInstruction,
+  saveProjectDocumentationInstruction,
   sendProjectEmail,
   sendCourseUpdateEmail,
 };

--- a/functions/callNodeFunction/lib/fileName.js
+++ b/functions/callNodeFunction/lib/fileName.js
@@ -1,0 +1,52 @@
+/**
+ * Sanitises a client-supplied file name before it is interpolated into a storage
+ * object path.
+ *
+ * `replacePlaceholders` (lib/utils.js) substitutes action inputs into the
+ * `file-path` header verbatim, so an unsanitised `filename` reaches the object
+ * key. In production GCS does not resolve `..`, which caps the damage at
+ * unreachable objects, but the emulated development bucket writes through `fs`
+ * (lib/cloud-storage.js), where the OS does resolve it - an arbitrary file write.
+ * Sanitising here fixes every saveFile/saveImage action at once.
+ *
+ * Also removes `$`, so a crafted name can no longer smuggle a RegExp replacement
+ * pattern (`$&`, `$1`) through String.replace in replacePlaceholders.
+ */
+const MAX_LENGTH = 120;
+
+/**
+ * Anything outside letters/digits/dot/underscore/hyphen is not safe in an object
+ * key. This deliberately also covers control characters (including a NUL that
+ * could truncate the path), `$`, quotes, whitespace and path separators, so no
+ * separate control-character pass is needed.
+ */
+const UNSAFE_CHARS = /[^\p{L}\p{N}._-]/gu;
+
+export function sanitizeStoredFileName(rawName, fallback = 'upload') {
+  const asString = typeof rawName === 'string' ? rawName : '';
+
+  // Keep only the last path segment: defeats "../", absolute paths and Windows
+  // separators in one step.
+  const baseName = asString.split(/[/\\]/).pop() ?? '';
+
+  const cleaned = baseName
+    .normalize('NFC')
+    .replace(UNSAFE_CHARS, '_')
+    // A run of dots would otherwise leave a traversal fragment behind.
+    .replace(/\.{2,}/g, '.')
+    // Leading dots/underscores produce hidden or ugly object names.
+    .replace(/^[._]+/, '');
+
+  if (!cleaned || cleaned === '.') return fallback;
+  if (cleaned.length <= MAX_LENGTH) return cleaned;
+
+  // Truncate the stem but keep the extension, so validateFileUpload and the
+  // content-type sniffing in cloud-storage still see the real suffix.
+  const lastDot = cleaned.lastIndexOf('.');
+  if (lastDot <= 0 || lastDot < cleaned.length - 12) {
+    return cleaned.slice(0, MAX_LENGTH);
+  }
+  const extension = cleaned.slice(lastDot);
+  const stem = cleaned.slice(0, lastDot);
+  return `${stem.slice(0, Math.max(1, MAX_LENGTH - extension.length))}${extension}`;
+}

--- a/functions/callNodeFunction/lib/fileName.test.js
+++ b/functions/callNodeFunction/lib/fileName.test.js
@@ -1,0 +1,71 @@
+import { sanitizeStoredFileName } from './fileName.js';
+
+const NUL = String.fromCharCode(0);
+const BACKSLASH = String.fromCharCode(92);
+
+describe('sanitizeStoredFileName', () => {
+  it('reduces a traversal attempt to its basename', () => {
+    expect(sanitizeStoredFileName('../../evil.pdf')).toBe('evil.pdf');
+    expect(sanitizeStoredFileName('../../../etc/passwd')).toBe('passwd');
+    expect(
+      sanitizeStoredFileName(`..${BACKSLASH}..${BACKSLASH}evil.pdf`)
+    ).toBe('evil.pdf');
+    expect(sanitizeStoredFileName('/absolute/path/doc.pdf')).toBe('doc.pdf');
+  });
+
+  it('leaves no path separator or dot-run behind', () => {
+    const result = sanitizeStoredFileName('a/../../b.pdf');
+    expect(result).not.toContain('/');
+    expect(result).not.toContain('..');
+  });
+
+  it('neutralises RegExp replacement patterns', () => {
+    // replacePlaceholders builds the object key with String.replace, where `$&`
+    // and `$1` in the replacement value would be interpreted.
+    expect(sanitizeStoredFileName('a$&b.pdf')).toBe('a__b.pdf');
+    expect(sanitizeStoredFileName('$1.pdf')).toBe('1.pdf');
+  });
+
+  it('strips control characters', () => {
+    expect(sanitizeStoredFileName(`doc${NUL}.pdf`)).toBe('doc_.pdf');
+  });
+
+  it('keeps letters, digits, dots, underscores and hyphens, including non-ASCII', () => {
+    expect(sanitizeStoredFileName('Leitfaden-v2_final.pdf')).toBe(
+      'Leitfaden-v2_final.pdf'
+    );
+    expect(sanitizeStoredFileName('Übung.pdf')).toBe('Übung.pdf');
+  });
+
+  it('replaces spaces rather than dropping them', () => {
+    expect(sanitizeStoredFileName('my doc.pdf')).toBe('my_doc.pdf');
+  });
+
+  it('falls back when nothing usable remains', () => {
+    expect(sanitizeStoredFileName('...')).toBe('upload');
+    expect(sanitizeStoredFileName('')).toBe('upload');
+    expect(sanitizeStoredFileName('/')).toBe('upload');
+    expect(sanitizeStoredFileName(undefined)).toBe('upload');
+    expect(sanitizeStoredFileName(null)).toBe('upload');
+    expect(sanitizeStoredFileName(42)).toBe('upload');
+    expect(sanitizeStoredFileName('...', 'instruction')).toBe('instruction');
+  });
+
+  it('does not produce a hidden file', () => {
+    expect(sanitizeStoredFileName('.hidden.pdf')).toBe('hidden.pdf');
+    expect(sanitizeStoredFileName('.env')).toBe('env');
+  });
+
+  it('caps the length while preserving the extension', () => {
+    const result = sanitizeStoredFileName(`${'x'.repeat(200)}.pdf`);
+    expect(result.length).toBeLessThanOrEqual(120);
+    // The extension has to survive: validateFileUpload and the content-type
+    // sniffing in cloud-storage both key off it.
+    expect(result.endsWith('.pdf')).toBe(true);
+  });
+
+  it('caps the length when there is no usable extension', () => {
+    const result = sanitizeStoredFileName('y'.repeat(200));
+    expect(result).toBe('y'.repeat(120));
+  });
+});

--- a/functions/callNodeFunction/saveFile/index.js
+++ b/functions/callNodeFunction/saveFile/index.js
@@ -3,9 +3,17 @@ import { buildCloudStorage } from "../lib/cloud-storage.js";
 import { replacePlaceholders } from "../lib/utils.js";
 import { logger } from "../index.js";
 import { maxBase64LengthForBytes, validateFileUpload } from "./fileValidation.js";
+import { sanitizeStoredFileName } from "../lib/fileName.js";
 
 const BYTES_PER_MB = 1024 * 1024;
 const DEFAULT_MAX_FILE_SIZE_MB = 20;
+
+// saveFileResult declares filePath/accessUrl as String! (actions.graphql), so every
+// return - including failures - must carry them. Omitting them makes Hasura reject
+// the whole response with "expecting not null value for field filePath" and the real
+// messageKey never reaches the client. Callers branch on `success` first, so the
+// empty strings below are never read.
+const FAILURE_FILE_FIELDS = { filePath: "", accessUrl: "" };
 
 /**
  * Saves a base64 encoded file to cloud storage.
@@ -41,7 +49,8 @@ const saveFile = async (req) => {
       return {
         success: false,
         messageKey: "INVALID_INPUT",
-        error: "Missing required fields: base64file, file-path, or bucket"
+        error: "Missing required fields: base64file, file-path, or bucket",
+        ...FAILURE_FILE_FIELDS,
       };
     }
 
@@ -64,7 +73,8 @@ const saveFile = async (req) => {
       return {
         success: false,
         messageKey: "FILE_TOO_LARGE",
-        error: `File size exceeds maximum size of ${maxFileSizeInBytes} bytes`
+        error: `File size exceeds maximum size of ${maxFileSizeInBytes} bytes`,
+        ...FAILURE_FILE_FIELDS,
       };
     }
 
@@ -80,15 +90,20 @@ const saveFile = async (req) => {
       return {
         success: false,
         messageKey: "FILE_TOO_LARGE",
-        error: `File size exceeds maximum size of ${maxFileSizeInBytes} bytes`
+        error: `File size exceeds maximum size of ${maxFileSizeInBytes} bytes`,
+        ...FAILURE_FILE_FIELDS,
       };
     }
 
     // Actions that provide an allowlist require both an accepted filename
     // extension and a matching file signature before anything reaches storage.
+    // The client-supplied name ends up in the storage object key via
+    // replacePlaceholders, so normalise it before it is validated or stored.
+    const safeFileName = sanitizeStoredFileName(req.body.input.filename);
+
     if (
       allowedFileExtensions &&
-      !validateFileUpload(req.body.input.filename ?? '', fileBuffer, allowedFileExtensions)
+      !validateFileUpload(safeFileName, fileBuffer, allowedFileExtensions)
     ) {
       logger.error("File extension or signature is not allowed", {
         fileName: req.body.input.filename,
@@ -97,11 +112,19 @@ const saveFile = async (req) => {
       return {
         success: false,
         messageKey: "INVALID_FORMAT",
-        error: "File extension or content does not match an allowed format"
+        error: "File extension or content does not match an allowed format",
+        ...FAILURE_FILE_FIELDS,
       };
     }
 
-    const filePath = replacePlaceholders(templatePath, req.body.input);
+    // base64file is excluded deliberately: it never appears in a path template and
+    // feeding a multi-MB string through RegExp replacement is pure waste (and its
+    // contents could otherwise act as a replacement pattern).
+    const { base64file: _base64file, ...pathInputs } = req.body.input;
+    const filePath = replacePlaceholders(templatePath, {
+      ...pathInputs,
+      filename: safeFileName,
+    });
     const storage = buildCloudStorage(Storage);
     const accessUrl = await storage.saveToBucket(filePath, req.headers.bucket, content, isPublic);
     
@@ -121,7 +144,8 @@ const saveFile = async (req) => {
     return {
       success: false,
       messageKey: "FILE_SAVE_ERROR",
-      error: "An error occurred while saving the file"
+      error: "An error occurred while saving the file",
+      ...FAILURE_FILE_FIELDS,
     };
   }
 };

--- a/functions/callNodeFunction/saveImage/index.js
+++ b/functions/callNodeFunction/saveImage/index.js
@@ -1,6 +1,7 @@
 import { Storage } from "@google-cloud/storage";
 import { buildCloudStorage } from "../lib/cloud-storage.js";
 import { replacePlaceholders } from "../lib/utils.js";
+import { sanitizeStoredFileName } from "../lib/fileName.js";
 import { logger } from "../index.js";
 import sharp from "sharp";
 import path from "path";
@@ -94,7 +95,10 @@ const saveImage = async (req) => {
     }
 
     // Validate image format
-    const format = extractFormatFromFileName(req.body.input.filename);
+    // Normalised before use: the name reaches the storage object key through
+    // replacePlaceholders below.
+    const safeFileName = sanitizeStoredFileName(req.body.input.filename);
+    const format = extractFormatFromFileName(safeFileName);
     if (!format || !SUPPORTED_FORMATS.includes(format.toLowerCase())) {
       logger.error("Unsupported image format", { format });
       return {
@@ -125,7 +129,11 @@ const saveImage = async (req) => {
       };
     }
 
-    const filePath = replacePlaceholders(templatePath, req.body.input);
+    const { base64file: _base64file, ...pathInputs } = req.body.input;
+    const filePath = replacePlaceholders(templatePath, {
+      ...pathInputs,
+      filename: safeFileName,
+    });
     const accessUrl = await storage.saveToBucket(filePath, req.headers.bucket, contentBuffer.toString('base64'), isPublic);
     logger.debug(`Original image saved successfully: ${filePath}, public: ${isPublic}`);
 

--- a/functions/callNodeFunction/saveProjectDocumentationInstruction/__tests__/saveProjectDocumentationInstruction.test.js
+++ b/functions/callNodeFunction/saveProjectDocumentationInstruction/__tests__/saveProjectDocumentationInstruction.test.js
@@ -1,0 +1,249 @@
+import { jest } from '@jest/globals';
+
+const mockGraphqlRequest = jest.fn();
+const mockSaveFile = jest.fn();
+
+const mockLogger = {
+  info: jest.fn(),
+  debug: jest.fn(),
+  error: jest.fn(),
+  warn: jest.fn(),
+};
+
+jest.unstable_mockModule('graphql-request', () => {
+  const actual = jest.requireActual('graphql-request');
+  return {
+    ...actual,
+    GraphQLClient: jest.fn().mockImplementation(() => ({
+      request: mockGraphqlRequest,
+    })),
+  };
+});
+
+jest.unstable_mockModule('../../saveFile/index.js', () => ({
+  default: mockSaveFile,
+}));
+
+const { default: saveProjectDocumentationInstruction } = await import('../index.js');
+
+const OWNER_ID = '11111111-1111-1111-1111-111111111111';
+const OTHER_ID = '22222222-2222-2222-2222-222222222222';
+
+const buildRequest = ({ role, userId, instructionId = 42 }) => ({
+  body: {
+    session_variables: {
+      'x-hasura-role': role,
+      ...(userId ? { 'x-hasura-user-id': userId } : {}),
+    },
+    input: {
+      base64file: 'JVBERi0=',
+      filename: 'guide.pdf',
+      projectDocumentationInstructionId: instructionId,
+    },
+  },
+  headers: {
+    bucket: 'test-bucket',
+    'file-path':
+      'project-docs-instructions/public/instruction-${projectDocumentationInstructionId}/${filename}',
+  },
+});
+
+const respondWithInstruction = (instruction) =>
+  mockGraphqlRequest.mockResolvedValue({
+    ProjectDocumentationInstruction_by_pk: instruction,
+  });
+
+describe('saveProjectDocumentationInstruction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.HASURA_ENDPOINT = 'http://localhost:8080/v1/graphql';
+    process.env.HASURA_ADMIN_SECRET = 'test-admin-secret';
+    mockSaveFile.mockResolvedValue({
+      success: true,
+      messageKey: 'FILE_SAVE_SUCCESS',
+      filePath: 'project-docs-instructions/public/instruction-42/guide.pdf',
+      accessUrl: 'https://example.com/guide.pdf',
+    });
+  });
+
+  it('lets an admin through without an ownership lookup', async () => {
+    const result = await saveProjectDocumentationInstruction(
+      buildRequest({ role: 'admin' }),
+      mockLogger
+    );
+
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
+    expect(mockSaveFile).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('delegates for an instructor who owns the instruction', async () => {
+    respondWithInstruction({
+      id: 42,
+      isDefault: false,
+      createdByUserId: OWNER_ID,
+    });
+
+    const result = await saveProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor', userId: OWNER_ID }),
+      mockLogger
+    );
+
+    expect(mockSaveFile).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(true);
+  });
+
+  it('refuses an instruction created by someone else and stores nothing', async () => {
+    respondWithInstruction({
+      id: 42,
+      isDefault: false,
+      createdByUserId: OTHER_ID,
+    });
+
+    const result = await saveProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor', userId: OWNER_ID }),
+      mockLogger
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.messageKey).toBe(
+      'SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_UNAUTHORIZED'
+    );
+    // The whole point of this handler: nothing may reach storage.
+    expect(mockSaveFile).not.toHaveBeenCalled();
+  });
+
+  it('refuses a platform instruction, which is what makes overwriting impossible', async () => {
+    respondWithInstruction({ id: 7, isDefault: false, createdByUserId: null });
+
+    const result = await saveProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor', userId: OWNER_ID, instructionId: 7 }),
+      mockLogger
+    );
+
+    expect(result.messageKey).toBe(
+      'SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_UNAUTHORIZED'
+    );
+    expect(mockSaveFile).not.toHaveBeenCalled();
+  });
+
+  it('refuses a default instruction even when the caller created it', async () => {
+    respondWithInstruction({
+      id: 42,
+      isDefault: true,
+      createdByUserId: OWNER_ID,
+    });
+
+    const result = await saveProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor', userId: OWNER_ID }),
+      mockLogger
+    );
+
+    expect(result.messageKey).toBe(
+      'SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_UNAUTHORIZED'
+    );
+    expect(mockSaveFile).not.toHaveBeenCalled();
+  });
+
+  it('reports a missing instruction', async () => {
+    respondWithInstruction(null);
+
+    const result = await saveProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor', userId: OWNER_ID }),
+      mockLogger
+    );
+
+    expect(result.messageKey).toBe(
+      'SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_NOT_FOUND'
+    );
+    expect(mockSaveFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects a role that is not admin or instructor', async () => {
+    const result = await saveProjectDocumentationInstruction(
+      buildRequest({ role: 'user', userId: OWNER_ID }),
+      mockLogger
+    );
+
+    expect(result.messageKey).toBe(
+      'SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_UNAUTHORIZED'
+    );
+    expect(mockGraphqlRequest).not.toHaveBeenCalled();
+    expect(mockSaveFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects the inherited-role name, which never appears in session variables', async () => {
+    // actions.yaml grants `instructor_access`; Hasura resolves that to the request
+    // role `instructor`. Accepting the _access spelling here would be a bug.
+    const result = await saveProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor_access', userId: OWNER_ID }),
+      mockLogger
+    );
+
+    expect(result.messageKey).toBe(
+      'SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_UNAUTHORIZED'
+    );
+    expect(mockSaveFile).not.toHaveBeenCalled();
+  });
+
+  it('rejects an instructor without a user id', async () => {
+    const result = await saveProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor' }),
+      mockLogger
+    );
+
+    expect(result.messageKey).toBe(
+      'SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_UNAUTHORIZED'
+    );
+    expect(mockSaveFile).not.toHaveBeenCalled();
+  });
+
+  it.each([0, -1, 1.5, 'abc'])(
+    'rejects the invalid instruction id %p',
+    async (instructionId) => {
+      const result = await saveProjectDocumentationInstruction(
+        buildRequest({ role: 'admin', instructionId }),
+        mockLogger
+      );
+
+      expect(result.messageKey).toBe('INVALID_INPUT');
+      expect(mockSaveFile).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects a missing instruction id', async () => {
+    const request = buildRequest({ role: 'admin' });
+    delete request.body.input.projectDocumentationInstructionId;
+
+    const result = await saveProjectDocumentationInstruction(request, mockLogger);
+
+    expect(result.messageKey).toBe('INVALID_INPUT');
+    expect(mockSaveFile).not.toHaveBeenCalled();
+  });
+
+  it('surfaces a lookup failure without storing anything', async () => {
+    mockGraphqlRequest.mockRejectedValue(new Error('boom'));
+
+    const result = await saveProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor', userId: OWNER_ID }),
+      mockLogger
+    );
+
+    expect(result.messageKey).toBe(
+      'SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_LOOKUP_FAILED'
+    );
+    expect(mockSaveFile).not.toHaveBeenCalled();
+  });
+
+  it('reports a misconfigured server without storing anything', async () => {
+    delete process.env.HASURA_ADMIN_SECRET;
+
+    const result = await saveProjectDocumentationInstruction(
+      buildRequest({ role: 'instructor', userId: OWNER_ID }),
+      mockLogger
+    );
+
+    expect(result.messageKey).toBe('SERVER_MISCONFIGURED');
+    expect(mockSaveFile).not.toHaveBeenCalled();
+  });
+});

--- a/functions/callNodeFunction/saveProjectDocumentationInstruction/index.js
+++ b/functions/callNodeFunction/saveProjectDocumentationInstruction/index.js
@@ -1,0 +1,135 @@
+import { GraphQLClient } from "graphql-request";
+import saveFile from "../saveFile/index.js";
+
+/**
+ * Roles other than admin that may store an instruction PDF. The value is the
+ * request role Hasura puts in session_variables (`instructor`), not the
+ * inherited-role name used in actions.yaml permissions (`instructor_access`).
+ */
+const NON_ADMIN_ROLES = new Set(["instructor"]);
+
+// saveFileResult declares filePath/accessUrl as String! (actions.graphql), so a
+// failure response must still carry them: omitting them (or sending null) makes
+// Hasura discard the whole payload with "expecting not null value for field
+// filePath" and the messageKey never reaches the client. Callers check `success`
+// first, so these are never read.
+const FAILURE_DEFAULTS = { filePath: "", accessUrl: "" };
+
+const ensureHasuraClient = () => {
+  if (!process.env.HASURA_ENDPOINT || !process.env.HASURA_ADMIN_SECRET) {
+    throw new Error("HASURA_ENDPOINT or HASURA_ADMIN_SECRET not configured");
+  }
+  return new GraphQLClient(process.env.HASURA_ENDPOINT, {
+    headers: {
+      "x-hasura-admin-secret": process.env.HASURA_ADMIN_SECRET,
+    },
+  });
+};
+
+const GET_INSTRUCTION_OWNER = `
+  query GetProjectDocumentationInstructionOwner($id: Int!) {
+    ProjectDocumentationInstruction_by_pk(id: $id) {
+      id
+      isDefault
+      createdByUserId
+    }
+  }
+`;
+
+/**
+ * Stores the PDF of a ProjectDocumentationInstruction.
+ *
+ * The generic saveFile handler derives the storage object key from the
+ * `projectDocumentationInstructionId` input and never checks who owns that row.
+ * Since instructors can read the `url` of every instruction they can see, calling
+ * saveFile directly would let one instructor overwrite another instruction's PDF -
+ * including admin-uploaded files that students download. This wrapper therefore
+ * verifies ownership before delegating; storage behaviour itself is unchanged.
+ */
+export default async function saveProjectDocumentationInstruction(req, logger) {
+  logger.info("########## Save Project Documentation Instruction ##########");
+
+  const sessionVariables = req.body?.session_variables || {};
+  const role = sessionVariables["x-hasura-role"];
+  const userId = sessionVariables["x-hasura-user-id"];
+
+  const instructionId = Number(req.body?.input?.projectDocumentationInstructionId);
+  if (!Number.isInteger(instructionId) || instructionId <= 0) {
+    return {
+      success: false,
+      messageKey: "INVALID_INPUT",
+      error: "projectDocumentationInstructionId must be a positive integer",
+      ...FAILURE_DEFAULTS,
+    };
+  }
+
+  // Admins manage the whole catalogue; everyone else must own the target row.
+  if (role !== "admin") {
+    if (!NON_ADMIN_ROLES.has(role) || !userId) {
+      return {
+        success: false,
+        messageKey: "SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_UNAUTHORIZED",
+        error: "Only admins and instructors may store instruction PDFs",
+        ...FAILURE_DEFAULTS,
+      };
+    }
+
+    let hasuraClient;
+    try {
+      hasuraClient = ensureHasuraClient();
+    } catch (error) {
+      logger.error("Hasura client misconfigured", { error: error.message });
+      return {
+        success: false,
+        messageKey: "SERVER_MISCONFIGURED",
+        error: error.message,
+        ...FAILURE_DEFAULTS,
+      };
+    }
+
+    let instruction;
+    try {
+      const lookup = await hasuraClient.request({
+        document: GET_INSTRUCTION_OWNER,
+        variables: { id: instructionId },
+      });
+      instruction = lookup?.ProjectDocumentationInstruction_by_pk;
+    } catch (error) {
+      logger.error("Failed to look up documentation instruction", {
+        error: error.message,
+      });
+      return {
+        success: false,
+        messageKey: "SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_LOOKUP_FAILED",
+        error: "Could not load the requested documentation instruction",
+        ...FAILURE_DEFAULTS,
+      };
+    }
+
+    if (!instruction) {
+      return {
+        success: false,
+        messageKey: "SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_NOT_FOUND",
+        error: "Documentation instruction not found",
+        ...FAILURE_DEFAULTS,
+      };
+    }
+
+    // Defaults belong to the platform catalogue even when an admin promoted an
+    // instructor-created row, so they are never writable by a non-admin.
+    if (instruction.isDefault || instruction.createdByUserId !== userId) {
+      logger.error("Instruction does not belong to the caller", {
+        instructionId,
+        role,
+      });
+      return {
+        success: false,
+        messageKey: "SAVE_PROJECT_DOCUMENTATION_INSTRUCTION_UNAUTHORIZED",
+        error: "You may only upload PDFs for documentation instructions you created",
+        ...FAILURE_DEFAULTS,
+      };
+    }
+  }
+
+  return saveFile(req, logger);
+}

--- a/functions/callNodeFunction/setProjectDocumentationInstructionDefault/index.js
+++ b/functions/callNodeFunction/setProjectDocumentationInstructionDefault/index.js
@@ -18,6 +18,7 @@ const GET_INSTRUCTION_TYPE = `
     ProjectDocumentationInstruction_by_pk(id: $id) {
       id
       projectTypeValue
+      createdByUserId
     }
   }
 `;
@@ -93,6 +94,19 @@ export default async function setProjectDocumentationInstructionDefault(req, log
         success: false,
         messageKey: "SET_PROJECT_DOCUMENTATION_INSTRUCTION_DEFAULT_NOT_FOUND",
         error: "Documentation instruction not found",
+      };
+    }
+    // A type default is part of the platform catalogue and must stay visible to
+    // every instructor. Promoting a personal upload (createdByUserId IS NOT NULL)
+    // would make a type's only default invisible to everyone but its creator, and
+    // would also take the row out of its owner's control (the update and delete
+    // permissions both exclude isDefault rows).
+    if (row.createdByUserId) {
+      return {
+        success: false,
+        messageKey: "SET_PROJECT_DOCUMENTATION_INSTRUCTION_DEFAULT_NOT_PLATFORM",
+        error:
+          "Only platform instructions can become a type default; this one belongs to an instructor",
       };
     }
     projectTypeValue = row.projectTypeValue;


### PR DESCRIPTION
## Why

Documentation instructions were an admin-only catalogue. An instructor who
wanted a write-up guide tailored to their own course had to ask an admin. This
adds an upload dialog next to **all three** instruction dropdowns (the
management grid's expanded row, **Add project**, **Confirm team**) where an
instructor can create an instruction for the current project type — and rename,
replace the PDF of, or delete the ones they created.

## Ownership model

New nullable `ProjectDocumentationInstruction.createdByUserId`:

- **NULL — platform instruction.** Admin-maintained, visible to every
  instructor. Every pre-existing row is NULL, so nothing changes for anyone
  today.
- **Set — personal instruction.** Only its creator may rename it, replace its
  PDF, or delete it. Stamped by a Hasura **insert preset**, never sent by the
  client, so ownership cannot be forged.

Instructor select is `platform OR own OR isDefault OR attached-to-a-project-I-teach-or-mentor`.
The last two clauses are correctness, not convenience: without `isDefault` a
promoted default becomes invisible and `handleSetProjectType` starts refusing
type changes; without the project clause the *mutation-driven* dropdown renders
a value outside its own options and a co-instructor can silently reassign it.
Students and anonymous keep unfiltered select so a team can always open the
instruction its project points at.

Only platform instructions can become a type default. Titles are unique per
owner, and globally unique among platform rows (a global constraint would reject
a title whose owner the caller cannot even see, and leak its existence).

## Security fixes this widening made necessary

**The main one:** `saveProjectDocumentationInstruction` derives the storage
object key from the instruction id supplied by the caller, and the generic
`saveFile` handler never checked ownership. Granting the action to instructors
as-is would have let one instructor **overwrite another instruction's PDF** —
including admin-uploaded files that students download — since the stored `url`
reveals the exact target path. A file-type allowlist does not help: the upload
is a valid PDF, just aimed at someone else's object. A dedicated handler now
verifies ownership before delegating to `saveFile`.

The seven migration-seeded defaults point at static Next.js paths and were never
reachable this way; every GCS-backed upload was.

Also in scope because they became reachable:

- **No file validation at all.** The action set no `allowed-file-extensions`, so
  `saveFile` skipped `validateFileUpload` entirely. Now `.pdf` enforced by magic
  bytes (`%PDF-` + trailing `%%EOF`), with the previously-implicit 20 MiB cap
  pinned explicitly.
- **Unsanitised `filename` in the object key.** `replacePlaceholders` substitutes
  it verbatim. Production GCS does not resolve `..`, but the emulated dev bucket
  writes through `fs`, where the OS does — an arbitrary file write. Fixed
  centrally in `saveFile` *and* `saveImage`, so it also closes the pre-existing,
  already-reachable path via `saveProjectDocumentation`.
- **Instructor-writable `url`** could point an instruction at any public object
  in the bucket → check constraint pinning owned rows to the action's prefix.
- **Promoting a personal instruction to a type default** is refused.

### Bug found along the way

`saveFile`'s failure branches omitted `filePath`/`accessUrl`, which
`saveFileResult` declares non-null. Hasura discarded the entire payload with
`expecting not null value for field "filePath"`, so `FILE_TOO_LARGE` and
`INVALID_FORMAT` never reached the client as readable messages — for any
`saveFile` action, not just this one. Fixed by returning empty strings; callers
branch on `success` first.

## Review notes

- The grid's instruction block previously rendered only when the option list was
  non-empty, which would have made the new button unreachable for a type with no
  instruction yet. The condition is widened and the dropdown itself is guarded.
- `ConfirmProjectDialog`'s seeding effect depends on the instruction list's
  identity, which the post-create refetch changes — it would have overwritten the
  freshly created selection with the type default. Now guarded per opened project.
- `FileUploadField` was **not** reused for the replace control: it always renders
  a remove button which, without a `removeMutation`, falls back to the update
  mutation and writes `url = NULL` — hiding an instruction that projects still
  reference. An explicit replace control shares the create flow's upload routine
  instead.
- `ON DELETE RESTRICT` on the new FK, not `SET NULL`: user removal here is
  anonymisation (the `User` row survives), and `SET NULL` would silently promote a
  departed instructor's private instruction to platform-wide.
- Creating from this dialog **as a super-admin** produces a platform row (no
  preset for `admin`), which is the correct admin semantic but means it will not
  appear in the dialog's "your instructions" list. Documented as intended.

## Verification

Backend contract exercised directly against Hasura with real `instructor` /
`user` / `anonymous` roles:

- insert cannot set `createdByUserId` or `isDefault` (absent from the input type)
- instructor B cannot see, update or delete instructor A's row; still sees all
  platform rows; a student **can** read A's row; anonymous cannot
- `url` outside the allowed prefix → check-constraint violation
- raw delete of a row that has a PDF → zero rows (must go through the action)
- **action with a foreign instruction id → `..._UNAUTHORIZED`, bucket object
  untouched**; platform id → same
- `../../../evil.pdf` → stored inside `instruction-<id>/`, verified on the dev
  container filesystem
- a zip renamed `.pdf` → `INVALID_FORMAT`
- delete action: non-owner → `..._FORBIDDEN`, default → `..._IS_DEFAULT`,
  owner → succeeds; `setProjectDocumentationInstructionDefault` on a personal row
  → `..._NOT_PLATFORM`

Browser (Playwright, logged in as a real instructor): create → auto-selected in
the dropdown and persisted → listed for management → rename → replace PDF →
delete, all against the running stack. Test data cleaned up afterwards.

Migration applies, rolls back (restoring the global title constraint) and
re-applies. `yarn tsc --noEmit` clean, `yarn lint` clean apart from one
pre-existing warning in `TableGrid/hooks.ts`, frontend 127/127, functions 116/116
plus 30 new tests. `matrixRoomUtils.test.js` fails on a clean tree too (it uses
`node:test`, so Jest sees no tests in it) — pre-existing and unrelated.

Docs: new §7.3a and an ownership section in `PROJECTS_USER_MANUAL.md`, plus a
§8.1 isolation matrix and negative-GraphQL checklist in
`PROJECTS_TESTING_GUIDE.md`. The stale claim that delete is unavailable for
referenced rows is corrected — the action reassigns them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Instructors can create, select, edit, replace, download, and delete their own project documentation instruction PDFs.
  * Added upload controls and empty states throughout project management workflows.
  * Newly uploaded instructions are selected automatically and handled safely when deleted or replaced.
* **Bug Fixes**
  * Enforced PDF-only uploads and a 20 MB size limit.
  * Prevented unauthorized access, editing, deletion, and use of personal instructions as defaults.
  * Improved protection against unsafe filenames and storage paths.
* **Documentation**
  * Updated user guidance and testing documentation for instructor-managed instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->