### PR TITLE
fix(projects): surface review feedback outside the project card

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/MyProjectPanel.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/MyProjectPanel.tsx
@@ -465,6 +465,7 @@ const MyProjectPanel: FC<MyProjectPanelProps> = ({
         <div className="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-900">
           {t('projects.my_project.excluded_banner')}
         </div>
+        <ProjectReviewComment ratingComment={project.ratingComment} />
         <div className="rounded-lg border border-border-primary p-4 bg-bg-secondary/30">
           <ProjectPreviewLayout
             project={project}
@@ -477,7 +478,6 @@ const MyProjectPanel: FC<MyProjectPanelProps> = ({
                   project.externalUrl?.trim()
               )
             }
-            belowTitleRow={<ProjectReviewComment ratingComment={project.ratingComment} />}
             titleRow={
               <div className="flex flex-wrap items-center gap-2 mb-1">
                 <h4 className="text-xl font-semibold text-label-primary min-w-0 break-words">
@@ -629,6 +629,8 @@ const MyProjectPanel: FC<MyProjectPanelProps> = ({
         </div>
       ) : null}
 
+      <ProjectReviewComment ratingComment={project.ratingComment} />
+
       <div className="space-y-3 min-w-0">
         {!isDeadlinePassed &&
         (project.status === ProjectStatus_enum.PROPOSED ||
@@ -652,7 +654,6 @@ const MyProjectPanel: FC<MyProjectPanelProps> = ({
                   project.externalUrl?.trim()
               )
             }
-            belowTitleRow={<ProjectReviewComment ratingComment={project.ratingComment} />}
             titleRow={
             canEditProjectMetadata ? (
               <div className="flex flex-wrap items-start gap-2 mb-1 w-full">

--- a/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/ProjectPreviewLayout.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/CourseContent/Projects/ProjectPreviewLayout.tsx
@@ -26,8 +26,6 @@ interface ProjectPreviewLayoutProps {
   taglineSlot?: ReactNode;
   /** Optional: replace description panel (e.g. inline InputField). */
   descriptionSlot?: ReactNode;
-  /** Rendered directly under `titleRow` (e.g. submission deadline). */
-  belowTitleRow?: ReactNode;
   /**
    * Also list EXCLUDED authors (marked as excluded). Set for privileged viewers
    * (instructors/admins) and the excluded author's own "My Project" view.
@@ -42,7 +40,6 @@ const ProjectPreviewLayout: FC<ProjectPreviewLayoutProps> = ({
   coverSlot,
   taglineSlot,
   descriptionSlot,
-  belowTitleRow,
   includeExcludedAuthors = false,
 }) => {
   const t = useTranslations('course');
@@ -72,7 +69,6 @@ const ProjectPreviewLayout: FC<ProjectPreviewLayoutProps> = ({
   return (
     <div className="space-y-4">
       {titleRow ? <div className="min-w-0">{titleRow}</div> : null}
-      {belowTitleRow ? <div className="min-w-0">{belowTitleRow}</div> : null}
 
       <div className="flex flex-col lg:flex-row lg:items-stretch gap-6">
         <div className="shrink-0 w-full lg:w-56">

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/ReviewProjectDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/ReviewProjectDialog.tsx
@@ -17,10 +17,6 @@ import {
   UPDATE_PROJECT_RATING_AND_COMMENT,
 } from '../../../../../queries/projectInstructor';
 import { ProjectRow } from '../../../CourseContent/Projects/types';
-import {
-  safeProjectExternalHref,
-  safeProjectResourceHref,
-} from '../../../CourseContent/Projects/projectMandatory';
 import { ProjectRating_enum } from '../../../../../__generated__/globalTypes';
 
 interface ReviewProjectDialogProps {
@@ -199,10 +195,6 @@ const ReviewProjectDialog: FC<ReviewProjectDialogProps> = ({
     }
   };
 
-  const docHref = safeProjectResourceHref(project?.documentationUrl);
-  const presHref = safeProjectResourceHref(project?.presentationUrl);
-  const extHref = safeProjectExternalHref(project?.externalUrl);
-
   return (
     <DialogShell
       open={open}
@@ -223,56 +215,10 @@ const ReviewProjectDialog: FC<ReviewProjectDialogProps> = ({
     >
       {project ? (
         <div className="space-y-6">
-          <div className="space-y-1 text-sm">
-            <p>
-              <span className="font-medium">{t('projects.review_dialog.title_label')}: </span>
-              {project.title}
-            </p>
-            {project.tagline ? (
-              <p>
-                <span className="font-medium">{t('projects.review_dialog.tagline_label')}: </span>
-                {project.tagline}
-              </p>
-            ) : null}
-            {project.description ? (
-              <p className="whitespace-pre-line">{project.description}</p>
-            ) : null}
-          </div>
-
-          {docHref || presHref || extHref ? (
-            <div className="space-y-1 text-sm">
-              {docHref ? (
-                <a
-                  href={docHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block text-status-confirmed underline"
-                >
-                  {t('projects.review_dialog.documentation_link')}
-                </a>
-              ) : null}
-              {presHref ? (
-                <a
-                  href={presHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block text-status-confirmed underline"
-                >
-                  {t('projects.review_dialog.presentation_link')}
-                </a>
-              ) : null}
-              {extHref ? (
-                <a
-                  href={extHref}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="block text-status-confirmed underline"
-                >
-                  {t('projects.review_dialog.external_link')}
-                </a>
-              ) : null}
-            </div>
-          ) : null}
+          <p className="text-sm">
+            <span className="font-medium">{t('projects.review_dialog.title_label')}: </span>
+            {project.title}
+          </p>
 
           <div className="space-y-2">
             <span className="block text-sm font-medium text-label-primary">

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1408,12 +1408,7 @@
         "confirm_button": "Bestätigen"
       },
       "review_dialog": {
-        "title": "Eingereichtes Projekt bewerten",
-        "title_label": "Titel",
-        "tagline_label": "Untertitel",
-        "documentation_link": "Dokumentation öffnen",
-        "presentation_link": "Präsentation öffnen",
-        "external_link": "Projektlink öffnen"
+        "title_label": "Titel"
       },
       "evaluate_dialog": {
         "title": "Projekt beurteilen",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1426,12 +1426,7 @@
         "confirm_button": "Confirm"
       },
       "review_dialog": {
-        "title": "Review submitted project",
-        "title_label": "Title",
-        "tagline_label": "Tagline",
-        "documentation_link": "Open documentation",
-        "presentation_link": "Open presentation",
-        "external_link": "Open project link"
+        "title_label": "Title"
       },
       "evaluate_dialog": {
         "title": "Evaluate project",


### PR DESCRIPTION
## What

Two small follow-ups on the project review flow.

**Student panel** — the instructor's review comment ("Rückmeldung der
Kursleitung") was rendered *inside* the project content card, between the
title row and the cover/description grid, where it read as part of the
project rather than as a message about it. It is now a panel-level sibling
below the status banners: directly under the "sent back for revision"
notice, above the deadline line and the card. Same treatment in the
excluded-author panel (under the red exclusion banner). Visibility is
unchanged — shown whenever a rating comment exists, for any status.

`ProjectPreviewLayout`'s `belowTitleRow` slot had no other callers and is
removed.

**Evaluation dialog** — "Projekt beurteilen" still offered light-green
documentation / presentation / project links plus tagline and description.
Those were meant to be dropped when the dialog was reworked; the dialog is
only for the verdict. Only the project title remains as context, so the
dialog now reads title → decision cards → comment textarea. The
`review_dialog` locale keys that block was the last user of are removed
from `de.json` and `en.json` (`title_label` stays).

## Test plan

- [x] `npx eslint` on the changed files — clean
- [x] `npm run type-check` — clean
- [x] `npm test` — 15 suites / 127 tests passing
- [ ] Visual check: student panel of a sent-back project shows the feedback
      box between the yellow banner and the "Abgabefrist" line, and no
      stray gap when there is no comment
- [ ] Visual check: instructor evaluation dialog shows only the title, and
      saving a verdict + comment still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Project review comments now appear in a clearer position, directly below relevant status banners and before project details.
  * Simplified the project review dialog to show only the project title, removing outdated project descriptions and resource links.
* **Documentation**
  * Updated English and German translations to match the streamlined review dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->