### PR TITLE
fix(ci): run the triage action as the PAT, not the Claude App

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -71,6 +71,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.DEPENDABOT_TRIAGE_TOKEN }}
         with:
+          # Act as the PAT, not as the Claude GitHub App. Without this the action
+          # mints an App installation token (which needs id-token: write) and hands
+          # it to Claude as GITHUB_TOKEN, overriding the GH_TOKEN set above. That
+          # App has no security_events permission, so the playbook's preflight would
+          # fail exactly as it did in the abandoned cloud-routine attempt (#1850).
+          github_token: ${{ secrets.DEPENDABOT_TRIAGE_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: >-
             --model claude-opus-5


### PR DESCRIPTION
## What

The first dispatched run of the triage workflow ([32532632716](https://github.com/eduhub-org/eduhub/actions/runs/32532632716)) failed at the Claude step with:

> Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?

`Checkout develop` succeeded, which confirms `DEPENDABOT_TRIAGE_TOKEN` is valid.

## Why not just add `id-token: write`

That would fix the error message and introduce a worse failure. With no `github_token` input, the action takes its default GitHub App path: it exchanges an OIDC token for an App installation token and exports that to Claude as `GITHUB_TOKEN`, which takes precedence over the `GH_TOKEN` this step sets in `env:`.

The `claude` GitHub App on `eduhub-org` has no `security_events` permission — that is precisely why the Claude cloud routine could not read Dependabot alerts and why #1850 was filed and that approach abandoned. Claude would authenticate fine, then fail the playbook's preflight on the alerts API.

Passing the PAT as `github_token` skips App-token minting entirely, requires no `id-token` permission, and runs Claude under the identity that actually holds *Dependabot alerts: read*.

## Still required before a green run

`CLAUDE_CODE_OAUTH_TOKEN` is not yet set as a repository secret. Until it is, the action has no Anthropic credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency triage authentication to use the designated access token.
  * Improved reliability of automated triage workflow execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->