### PR TITLE
feat(projects): show the review comment in the management grids

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/ProjectsManagementGrid.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCourseContent/CourseParticipationsTab/projects/ProjectsManagementGrid.tsx
@@ -70,6 +70,7 @@ import { PROJECT_TAGLINE_MAX_LENGTH } from '../../../CourseContent/Projects/proj
 import StatusChip from '../../../CourseContent/Projects/StatusChip';
 import { isProjectTypeEditable, canManagePublicationSuggestion } from '../../../CourseContent/Projects/projectStatusDisplay';
 import ProjectPreviewLayout from '../../../CourseContent/Projects/ProjectPreviewLayout';
+import ProjectReviewComment from '../../../CourseContent/Projects/ProjectReviewComment';
 import ProjectFormFieldSection from '../../../CourseContent/Projects/ProjectFormFieldSection';
 import ProjectSubmissionDeadlineBelowTitle from '../../../CourseContent/Projects/ProjectSubmissionDeadlineBelowTitle';
 import type { CourseProjectSubmissionDefaultSource } from '../../../CourseContent/Projects/projectEffectiveSubmissionDeadline';
@@ -815,6 +816,7 @@ const ProjectsManagementGrid: FC<ProjectsManagementGridProps> = ({
             {authorMentorSection}
 
             <div className="border-t border-border-primary pt-5 space-y-4">
+              <ProjectReviewComment ratingComment={row.ratingComment} />
               <ProjectSubmissionDeadlineBelowTitle
                 mode="instructor"
                 project={row}
@@ -963,6 +965,7 @@ const ProjectsManagementGrid: FC<ProjectsManagementGridProps> = ({
           {authorMentorSection}
 
           <div className="border-t border-border-primary pt-5 space-y-3">
+            <ProjectReviewComment ratingComment={row.ratingComment} />
             <ProjectSubmissionDeadlineBelowTitle
               mode="instructor"
               project={row}

--- a/frontend-nx/apps/edu-hub/components/pages/ManageProjectsContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageProjectsContent/index.tsx
@@ -30,6 +30,7 @@ import { Button } from '../../common/Button';
 
 import StatusChip from '../CourseContent/Projects/StatusChip';
 import ProjectPreviewLayout from '../CourseContent/Projects/ProjectPreviewLayout';
+import ProjectReviewComment from '../CourseContent/Projects/ProjectReviewComment';
 import { getDisplayAuthors } from '../CourseContent/Projects/projectAuthors';
 import {
   getProjectStatusChipKey,
@@ -300,7 +301,8 @@ const ManageProjectsContent: FC<ManageProjectsContentProps> = ({ inSettingsLayou
 
   const expandableRowComponent = useCallback(
     ({ row }: { row: AdminProjectList_Project }) => (
-      <div className="p-4">
+      <div className="p-4 space-y-4">
+        <ProjectReviewComment ratingComment={row.ratingComment} />
         <ProjectPreviewLayout
           project={row as ProjectRow}
           showResourceLinks={shouldShowProjectResourceDownloadLinks(row.status)}


### PR DESCRIPTION
## What

Render the project review comment as a visible callout in the expanded row of both instructor/admin project grids, reusing the existing `ProjectReviewComment` component.

## Why

The review comment only ever reached the authors: `MyProjectPanel` renders it as a callout, while instructors and admins still had nothing but the MUI tooltip on the status chip — invisible unless hovered, and out of reach on touch devices. So the people who wrote the verdict, and the admins reviewing it later, could not read back what was said.

## How

- `ProjectsManagementGrid.tsx` (manage course → participations → projects): the callout renders above the deadline line in both expanded-row branches — the template / no-accepted-author panel and the normal one — mirroring the ordering `MyProjectPanel` uses.
- `ManageProjectsContent/index.tsx` (admin all-projects list): the callout renders above the project preview in the expanded row.
- The dense table rows keep the tooltip, as before — a callout per row would not fit there, which is the same reasoning as in the original change.
- No new locale keys: the label stays `course.projects.my_project.review_comment_label` ("Rückmeldung der Kursleitung" / "Feedback from the course team"). It names who wrote the comment, which is still accurate for a co-instructor or an admin reading it.

## Testing

- `tsc --noEmit` on `apps/edu-hub` — clean
- ESLint on both changed files — clean
- `yarn test --testPathPattern="[Pp]roject"` — 9 suites, 72 tests passing


---
_Generated by [Claude Code](https://claude.ai/code/session_01Erv8cFoKrDU7yrusAPTfCj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project management views now display rating comments alongside project review information.
  * Rating comments are also shown when expanding project details, with improved spacing for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->