### PR TITLE
fix(deps): harmonize @keycloak/keycloak-admin-client on 26.7.2

### DIFF
--- a/functions/addKeycloakRole/index.js
+++ b/functions/addKeycloakRole/index.js
@@ -1,5 +1,4 @@
 import KcAdminClient from '@keycloak/keycloak-admin-client';
-import bodyParser from "body-parser";
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);

--- a/functions/addKeycloakRole/package.json
+++ b/functions/addKeycloakRole/package.json
@@ -3,10 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "20.0.0",
-    "body-parser": "1.20.6",
-    "node-fetch": "2.6.7",
-    "graphqurl": "1.0.1"
+    "@keycloak/keycloak-admin-client": "26.7.2"
   },
   "devDependencies": {
     "npm-watch": "^0.6.0",

--- a/functions/callNodeFunction/package.json
+++ b/functions/callNodeFunction/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "dependencies": {
     "@google-cloud/storage": "^5.3.0",
-    "@keycloak/keycloak-admin-client": "^24.0.5",
+    "@keycloak/keycloak-admin-client": "26.7.2",
     "axios": "^1.13.2",
     "body-parser": "1.20.6",
     "got": "^12.5.3",

--- a/functions/removeKeycloakRole/index.js
+++ b/functions/removeKeycloakRole/index.js
@@ -1,5 +1,4 @@
 import KcAdminClient from '@keycloak/keycloak-admin-client';
-import bodyParser from "body-parser";
 import { createRequire } from 'module';
 
 const require = createRequire(import.meta.url);

--- a/functions/removeKeycloakRole/package.json
+++ b/functions/removeKeycloakRole/package.json
@@ -3,9 +3,7 @@
   "version": "0.1.0",
   "type": "module",
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "20.0.0",
-    "body-parser": "1.20.6",
-    "node-fetch": "2.6.7",
+    "@keycloak/keycloak-admin-client": "26.7.2",
     "graphqurl": "1.0.1"
   },
   "devDependencies": {

--- a/functions/updateFromKeycloak/index.js
+++ b/functions/updateFromKeycloak/index.js
@@ -1,4 +1,7 @@
-const KcAdminClient = require("@keycloak/keycloak-admin-client").default;
+import KcAdminClient from "@keycloak/keycloak-admin-client";
+import { createRequire } from "module";
+
+const require = createRequire(import.meta.url);
 
 let mergeUserPutPayload;
 try {
@@ -26,7 +29,7 @@ function computeMatrixHandle(firstName, lastName, userId) {
   return `${first}.${last}.${uuidPrefix}`;
 }
 
-exports.updateFromKeycloak = async (req, res) => {
+export const updateFromKeycloak = async (req, res) => {
   const expectedSecret = process.env.HASURA_CLOUD_FUNCTION_SECRET;
   if (!expectedSecret) {
     return res.status(500).json({ error: "Server secret not configured" });

--- a/functions/updateFromKeycloak/package.json
+++ b/functions/updateFromKeycloak/package.json
@@ -1,10 +1,9 @@
 {
   "name": "updateFromKeycloak",
   "version": "0.1.0",
+  "type": "module",
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "^16.1.0",
-    "body-parser": "1.20.6",
-    "node-fetch": "2.6.7",
+    "@keycloak/keycloak-admin-client": "26.7.2",
     "graphqurl": "1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Four function manifests pinned **three different majors** of `@keycloak/keycloak-admin-client` (`^16.1.0`, `20.0.0` ×2, `^24.0.5`), all inside the `GHSA-r8jr-wg88-fq5c` range (`<= 26.5.5`). This pins all four to **26.7.2** exactly — the same version as the server image in `keycloak/Dockerfile` and the SPI `pom.xml` — and drops dependencies that are declared but never used.

Closes item 2 of #1866. Should close Dependabot alerts [394](https://github.com/eduhub-org/eduhub/security/dependabot/394), [395](https://github.com/eduhub-org/eduhub/security/dependabot/395), [396](https://github.com/eduhub-org/eduhub/security/dependabot/396) and [501](https://github.com/eduhub-org/eduhub/security/dependabot/501) on the next scan of `develop`.

The ESM conversion of `updateFromKeycloak` is a consequence of the bump, not the goal — see below.

## Why 26.7.2

`26.5.6` and `26.5.7` also sit above the advisory range and would have cleared the same four alerts with a much smaller dependency tree (pre-Kiota: 1.1 MB vs 7.8 MB, ~21 ms vs ~101 ms module load). They were rejected because **26.5.x is a frozen branch** — superseded by 26.6.0 a week after its last release, so it would never receive another fix. 26.7.2 keeps the client on the same version as the server, which is the rule the SPI pom already documents.

Exact pins rather than carets: these functions ship without a lockfile, so a caret means the deployed version is whatever npm resolves on the day of the deploy.

**Cost of 26.7.2:** it pulls six `@microsoft/kiota-*` packages at `1.0.0-preview.103`. They are imported eagerly (`clients.js` → `clientsV2.js` → kiota), so they load on every cold start even though the V2 API is opt-in behind `enableExperimentalApis` (default `false`).

## Unused dependencies removed

Most of the transitive exposure lived here, not in the client version:

- `node-fetch` — unused in all three role/sync functions
- `body-parser` — imported but never called in `addKeycloakRole` and `removeKeycloakRole`, declared but not imported in `updateFromKeycloak`
- `graphqurl` — unused in `addKeycloakRole` (still used by the other two)

Measured with `npm install --package-lock-only && npm audit --omit=dev`:

| Function | Before | After |
| --- | --- | --- |
| `addKeycloakRole` | 18 vulnerable prod packages (15 high) | **0** |
| `removeKeycloakRole` | 18 (15 high) | 16 (13 high) |
| `updateFromKeycloak` | 18 (15 high) | 16 (13 high) |
| `callNodeFunction` | 4 (0 high) | 4 (0 high) |

The old `high` findings were `axios` 0.24/0.27, which reached production *through* the old admin client (dropped upstream in 21.1.2). None of them ever appeared in GitHub Security: without a lockfile Dependabot only resolves direct dependencies. The 13 that remain all come from `graphqurl@1.0.1` — tracked in #1872 along with adding lockfiles.

## Why `updateFromKeycloak` became ESM

It was the only CommonJS consumer, using `require("@keycloak/keycloak-admin-client").default` against a package that has been **ESM-only since v19**. That does work on the `nodejs22` runtime via `require(esm)` — I tested it — but relying on that behaviour for an auth-critical function is a poor trade against a ten-line change. It now uses the same `createRequire` pattern as `addKeycloakRole` / `removeKeycloakRole` for the `.cjs` shared libs and `graphqurl`.

## Verification already done

Driven against a mock Keycloak Admin REST API + Hasura endpoint, on both the old and new versions:

- All three functions complete their full flow to **HTTP 200** on 26.7.2.
- **Request sequences are identical old vs new**, with one exception: 26.x requests `/admin/realms/edu-hub/clients/` with a **trailing slash** where 20/24 requested `/clients`. Present in 26.5.7 too, so it arrived between 24.0.5 and 26.5.x and ships in every 26.x release.
- The `users.update` PUT payload built by `mergeUserPutPayload` is **byte-identical** between 16.1.1 and 26.7.2.
- `callNodeFunction`: resolves 26.7.2, 122 tests pass, `createUser` and the backfill script load. `__tests__/matrixRoomUtils.test.js` fails to parse under jest — verified to fail identically on `develop`, a pre-existing `node:test`/jest collision, unrelated to this PR.

A mock proves request shapes, not that the live server accepts them. That is what the manual review below is for.

## Manual review

```bash
git fetch origin && git checkout claude/keycloak-dependabot-alert-3li8ie
rm -rf functions/{addKeycloakRole,removeKeycloakRole,updateFromKeycloak,callNodeFunction}/node_modules
docker compose up --build
```

Keycloak `localhost:28080` (`admin`/`admin`, realm `edu-hub`), Hasura `localhost:8080` (`myadminsecretkey`), function secret `test1234`. Keycloak user ids are the same UUIDs as Hasura `User.id`.

**1. ESM load (highest risk).** `docker compose logs node_functions | grep -iA5 updateFromKeycloak` — must start clean. Any `Cannot use import statement outside a module` / `require is not defined` / `ERR_MODULE_NOT_FOUND` means the conversion is wrong. This is the only change that can fail at *load* time.

**2. Trailing slash.** No separate test: all three functions call `clients.find({clientId:'hasura'})` first, so a rejected `/clients/` shows up as a 404 on the *client lookup* in every check below.

**3. addKeycloakRole.** Insert a `CourseInstructor` row → confirm the `instructor` client role on `hasura` appears in Keycloak. Then call it a second time — the idempotent no-op path depends on `listAvailableClientRoleMappings` returning empty for an already-granted role:

```bash
curl -i -X POST http://localhost:42000 -H 'content-type: application/json' \
  -H 'secret: test1234' -H 'role: instructor' \
  -d '{"event":{"data":{"new":{"userId":"<USER_UUID>"}}}}'
# 1st: 200 {}   2nd: 200 {"message":"Role 'instructor' not available for user (already assigned or unknown)"}
```

**4. removeKeycloakRole + the remaining-grant guard.** Give one user **two** `OrganizationAdmin` rows. Delete one → `org_admin` must **remain**. Delete the second → it must be **gone**.

**5. updateFromKeycloak — the check that matters most.**

```bash
curl -i -X POST http://localhost:42020 -H 'content-type: application/json' \
  -H 'secret: test1234' -d '{"input":{"userid":"<USER_UUID>","access_key":"x"}}'
```

Delete a test user's `matrix_user_handle` attribute in Keycloak, call the function, then confirm the attribute reappears **and that nothing else on the user was lost** — username, email, enabled, first/last name, other attributes, required actions, group and role memberships.

Keycloak's Admin API treats PUT as a *full replacement*; a payload missing a field clears it. `mergeUserPutPayload` is what prevents that. The payload is byte-identical between 16.1.1 and 26.7.2, but only a live server proves the server-side merge semantics did not shift across ten majors. A failure here destroys user data silently rather than erroring.

Also worth checking: an existing `matrixUserHandle` in Hasura must not change; assigning the `admin` client role in Keycloak must produce an `Admin` row.

**6. createUser** (`callNodeFunction`, 24 → 26). Create a user through the admin UI. Then attempt a **duplicate email** — must be rejected cleanly. That path exercises `users.find` and, on failure, the `users.del` rollback.

**7. Backfill script** — `docker compose exec node_functions node /functions/callNodeFunction/scripts/backfill-matrix-handles.js --dry-run`. Exercises `users.find({first, max})` pagination, which nothing else uses.

Checks 1, 3, 4 and 5 are the blocking ones.

## Out of scope

- `graphqurl` retirement and lockfiles for the Node functions — #1872
- Alert 534 (`sigstore`) — still open, item 1 of #1866
- `keycloak-js@^22.0.5` in the frontend — a different package, `npm audit` clean, no advisory

https://claude.ai/code/session_016pgGcj5Et3yx6ahPw4TSF8

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated Keycloak integration components to use a newer, consistently pinned client version.
  * Removed unused request-parsing and networking dependencies.
  * Standardized module configuration for improved compatibility and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->