### PR TITLE
fix(stujo): resolve the employer role via useManageRole and add an organization switcher

### DIFF
--- a/frontend-nx/apps/edu-hub/hooks/authentication.ts
+++ b/frontend-nx/apps/edu-hub/hooks/authentication.ts
@@ -36,9 +36,15 @@ export const useIsOrgAdmin = (): boolean => {
   return hasRole(sessionData, AuthRoles.org_admin);
 };
 
-export const useIsUserIdInList = (allowedIds: string[]): boolean => {
+// The Hasura user id of the signed-in user (the Keycloak `sub`, mapped onto the
+// x-hasura-user-id claim), or null while signed out. Single source for the claim path.
+export const useCurrentUserId = (): string | null => {
   const { data: sessionData } = useSession();
-  const userId = sessionData?.profile?.['https://hasura.io/jwt/claims']?.['x-hasura-user-id'];
+  return sessionData?.profile?.['https://hasura.io/jwt/claims']?.['x-hasura-user-id'] ?? null;
+};
+
+export const useIsUserIdInList = (allowedIds: string[]): boolean => {
+  const userId = useCurrentUserId();
   return Boolean(userId && allowedIds?.includes(userId));
 };
 

--- a/frontend-nx/apps/stujo/components/OrganizationSwitcher.tsx
+++ b/frontend-nx/apps/stujo/components/OrganizationSwitcher.tsx
@@ -1,0 +1,37 @@
+import { ChangeEvent, FC, useCallback } from 'react';
+
+import type { EmployerOrganization } from '../lib/useEmployerOrganization';
+
+interface Props {
+  organizations: EmployerOrganization[];
+  selectedId: number;
+  label: string;
+  onSelect: (id: number) => void;
+}
+
+/**
+ * Company picker for users who may post jobs for more than one organization.
+ * Callers render it only in that case — with a single organization the screens
+ * show its name as plain text instead.
+ */
+const OrganizationSwitcher: FC<Props> = ({ organizations, selectedId, label, onSelect }) => {
+  const handleChange = useCallback(
+    (event: ChangeEvent<HTMLSelectElement>) => onSelect(Number(event.target.value)),
+    [onSelect]
+  );
+
+  return (
+    <label className="stujo-org-switcher">
+      <span className="stujo-muted">{label}</span>
+      <select value={selectedId} onChange={handleChange}>
+        {organizations.map((organization) => (
+          <option key={organization.id} value={organization.id}>
+            {organization.name}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+};
+
+export default OrganizationSwitcher;

--- a/frontend-nx/apps/stujo/lib/employer.ts
+++ b/frontend-nx/apps/stujo/lib/employer.ts
@@ -33,7 +33,10 @@ export const ACTION_ROLE_CONTEXT = { role: 'user' };
 
 export const MY_JOB_ORGANIZATIONS = gql`
   query MyJobOrganizations($userId: uuid!) {
-    OrganizationAdmin(where: { userId: { _eq: $userId }, canManageJobs: { _eq: true } }) {
+    OrganizationAdmin(
+      where: { userId: { _eq: $userId }, canManageJobs: { _eq: true } }
+      order_by: { Organization: { name: asc } }
+    ) {
       id
       organizationId
       Organization {

--- a/frontend-nx/apps/stujo/lib/employer.ts
+++ b/frontend-nx/apps/stujo/lib/employer.ts
@@ -1,13 +1,30 @@
 import { gql } from '@apollo/client';
+import { useMemo } from 'react';
+
+import { useManageRole } from '@eduhub/hooks/authentication';
+import { AuthRoles } from '@eduhub/types/enums';
 
 /**
- * GraphQL documents for the employer dashboard (Mein StuJo). All queries
- * and mutations run under the `org_admin` inherited role (pinned per
- * request via the Apollo context), which resolves to org_admin_access
- * permissions in Hasura.
+ * GraphQL documents for the employer dashboard (Mein StuJo). Queries and
+ * mutations are pinned to a management role per request via the Apollo
+ * context; `org_admin` resolves to org_admin_access permissions in Hasura.
  */
 
-export const ORG_ADMIN_ROLE_CONTEXT = { role: 'org_admin' };
+/**
+ * Apollo context for the employer dashboard queries and mutations.
+ *
+ * Mirrors edu-hub's useManageRole instead of pinning `org_admin`: that role
+ * only reaches a user's JWT via the add_keycloak_org_admin_role event trigger,
+ * which fires when an OrganizationAdmin grant is inserted. A super-admin
+ * without a grant of their own therefore never carries it, and Hasura rejected
+ * every employer request — the dashboard then reported "no organization".
+ * Super-admins now use the unscoped `admin` role; the queries below scope
+ * themselves by userId/organizationId so both roles return the same rows.
+ */
+export const useEmployerRoleContext = (): { role: AuthRoles } => {
+  const role = useManageRole();
+  return useMemo(() => ({ role }), [role]);
+};
 
 // The publish/archive actions are permitted for user_access (they authorize
 // internally against OrganizationAdmin.canManageJobs), so they are called
@@ -15,8 +32,8 @@ export const ORG_ADMIN_ROLE_CONTEXT = { role: 'org_admin' };
 export const ACTION_ROLE_CONTEXT = { role: 'user' };
 
 export const MY_JOB_ORGANIZATIONS = gql`
-  query MyJobOrganizations {
-    OrganizationAdmin(where: { canManageJobs: { _eq: true } }) {
+  query MyJobOrganizations($userId: uuid!) {
+    OrganizationAdmin(where: { userId: { _eq: $userId }, canManageJobs: { _eq: true } }) {
       id
       organizationId
       Organization {

--- a/frontend-nx/apps/stujo/lib/useEmployerOrganization.ts
+++ b/frontend-nx/apps/stujo/lib/useEmployerOrganization.ts
@@ -1,0 +1,103 @@
+import { useQuery } from '@apollo/client';
+import { useRouter } from 'next/router';
+import { useSession } from 'next-auth/react';
+import { useCallback, useMemo } from 'react';
+
+import { useCurrentUserId } from '@eduhub/hooks/authentication';
+
+import { MY_JOB_ORGANIZATIONS, useEmployerRoleContext } from './employer';
+
+export type EmployerOrganization = {
+  id: number;
+  name: string;
+  JobPostingCredits: Array<{ id: number; remaining: number; jobPostingType: string | null }>;
+};
+
+// Survives reloads that drop the query string (e.g. the Stripe return URL, which
+// carries its own params). The `?org=` param still wins so shared links are stable.
+const STORAGE_KEY = 'stujo.employerOrganizationId';
+
+const parseId = (value: unknown): number | null => {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+};
+
+const readStoredId = (): number | null => {
+  if (typeof window === 'undefined') return null;
+  try {
+    return parseId(window.localStorage.getItem(STORAGE_KEY));
+  } catch {
+    // Private mode / blocked storage: fall back to the default organization.
+    return null;
+  }
+};
+
+const storeId = (id: number): void => {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, String(id));
+  } catch {
+    // Non-fatal: the `?org=` param keeps the choice for this navigation.
+  }
+};
+
+type EmployerOrganizationState = {
+  organizations: EmployerOrganization[];
+  organization: EmployerOrganization | null;
+  loading: boolean;
+  selectOrganization: (id: number) => void;
+};
+
+/**
+ * The organizations the signed-in user may post jobs for, plus the one the
+ * employer screens currently act on.
+ *
+ * A user can hold canManageJobs for several organizations; the dashboard used
+ * to take `OrganizationAdmin[0]` from an unordered query, so the second one was
+ * invisible and which one won could change between requests. Selection order is
+ * `?org=` (shareable, survives shallow navigation) -> last choice in
+ * localStorage -> the alphabetically first organization.
+ */
+export const useEmployerOrganization = (): EmployerOrganizationState => {
+  const router = useRouter();
+  const { status: sessionStatus } = useSession();
+  const employerRole = useEmployerRoleContext();
+  const currentUserId = useCurrentUserId();
+
+  const { data, loading } = useQuery(MY_JOB_ORGANIZATIONS, {
+    context: employerRole,
+    variables: { userId: currentUserId },
+    skip: sessionStatus !== 'authenticated' || !currentUserId,
+  });
+
+  const organizations = useMemo<EmployerOrganization[]>(
+    () =>
+      (data?.OrganizationAdmin ?? [])
+        .map((grant: { Organization: EmployerOrganization | null }) => grant.Organization)
+        .filter((organization: EmployerOrganization | null): organization is EmployerOrganization =>
+          Boolean(organization)
+        ),
+    [data]
+  );
+
+  const organization = useMemo<EmployerOrganization | null>(() => {
+    if (organizations.length === 0) return null;
+    const find = (id: number | null) =>
+      id === null ? undefined : organizations.find((candidate) => candidate.id === id);
+    // An unknown id (revoked grant, hand-edited link) falls through to the default
+    // rather than showing an empty dashboard.
+    return find(parseId(router.query.org)) ?? find(readStoredId()) ?? organizations[0];
+  }, [organizations, router.query.org]);
+
+  const selectOrganization = useCallback(
+    (id: number) => {
+      storeId(id);
+      router.replace({ query: { ...router.query, org: String(id) } }, undefined, {
+        shallow: true,
+      });
+    },
+    [router]
+  );
+
+  return { organizations, organization, loading, selectOrganization };
+};

--- a/frontend-nx/apps/stujo/locales/de.json
+++ b/frontend-nx/apps/stujo/locales/de.json
@@ -48,6 +48,7 @@
     "newOffer": "+ Neues Angebot",
     "checkingLogin": "Anmeldung wird geprüft …",
     "noOrganization": "Deinem Konto ist noch kein Unternehmen mit Stellen-Verwaltung zugeordnet. Bitte wende Dich an {contact}.",
+    "organizationLabel": "Unternehmen",
     "defaultContact": "das StuJo-Team",
     "loading": "Lädt …",
     "noOffers": "Noch keine Angebote – erstelle Dein erstes über „+ Neues Angebot“.",

--- a/frontend-nx/apps/stujo/locales/en.json
+++ b/frontend-nx/apps/stujo/locales/en.json
@@ -48,6 +48,7 @@
     "newOffer": "+ New offer",
     "checkingLogin": "Checking sign-in …",
     "noOrganization": "No company with job management is assigned to your account yet. Please contact {contact}.",
+    "organizationLabel": "Company",
     "defaultContact": "the StuJo team",
     "loading": "Loading …",
     "noOffers": "No offers yet – create your first one via “+ New offer”.",

--- a/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
@@ -6,17 +6,16 @@ import { signIn, useSession } from 'next-auth/react';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
-import { useCurrentUserId } from '@eduhub/hooks/authentication';
-
 import Layout from '../../components/Layout';
+import OrganizationSwitcher from '../../components/OrganizationSwitcher';
 import {
   ACTION_ROLE_CONTEXT,
   ARCHIVE_JOB_POSTING_ACTION,
-  MY_JOB_ORGANIZATIONS,
   MY_JOB_POSTINGS,
   PUBLISH_JOB_POSTING_ACTION,
   useEmployerRoleContext,
 } from '../../lib/employer';
+import { useEmployerOrganization } from '../../lib/useEmployerOrganization';
 import { resolvePortal, PortalBranding } from '../../lib/portal';
 
 type Props = { portal: PortalBranding };
@@ -51,14 +50,12 @@ const MeinStujo: FC<Props> = ({ portal }) => {
   const [notice, setNotice] = useState<string | null>(null);
 
   const employerRole = useEmployerRoleContext();
-  const currentUserId = useCurrentUserId();
-
-  const { data: orgData, loading: orgsLoading } = useQuery(MY_JOB_ORGANIZATIONS, {
-    context: employerRole,
-    variables: { userId: currentUserId },
-    skip: sessionStatus !== 'authenticated' || !currentUserId,
-  });
-  const organization = orgData?.OrganizationAdmin?.[0]?.Organization ?? null;
+  const {
+    organizations,
+    organization,
+    loading: orgsLoading,
+    selectOrganization,
+  } = useEmployerOrganization();
 
   const { data, loading, refetch } = useQuery(MY_JOB_POSTINGS, {
     context: employerRole,
@@ -178,9 +175,18 @@ const MeinStujo: FC<Props> = ({ portal }) => {
       <div className="stujo-dash-head">
         <div>
           <h1 style={{ margin: 0 }}>{t('title')}</h1>
-          <p className="stujo-muted" style={{ margin: '0.25rem 0 0' }}>
-            {organization.name}
-          </p>
+          {organizations.length > 1 ? (
+            <OrganizationSwitcher
+              organizations={organizations}
+              selectedId={organization.id}
+              label={t('organizationLabel')}
+              onSelect={selectOrganization}
+            />
+          ) : (
+            <p className="stujo-muted" style={{ margin: '0.25rem 0 0' }}>
+              {organization.name}
+            </p>
+          )}
         </div>
         <Link href="/mein-stujo/neu" className="stujo-btn stujo-btn--primary">
           {t('newOffer')}

--- a/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
@@ -6,14 +6,16 @@ import { signIn, useSession } from 'next-auth/react';
 import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
+import { useCurrentUserId } from '@eduhub/hooks/authentication';
+
 import Layout from '../../components/Layout';
 import {
   ACTION_ROLE_CONTEXT,
   ARCHIVE_JOB_POSTING_ACTION,
   MY_JOB_ORGANIZATIONS,
   MY_JOB_POSTINGS,
-  ORG_ADMIN_ROLE_CONTEXT,
   PUBLISH_JOB_POSTING_ACTION,
+  useEmployerRoleContext,
 } from '../../lib/employer';
 import { resolvePortal, PortalBranding } from '../../lib/portal';
 
@@ -48,14 +50,18 @@ const MeinStujo: FC<Props> = ({ portal }) => {
   const { status: sessionStatus } = useSession();
   const [notice, setNotice] = useState<string | null>(null);
 
+  const employerRole = useEmployerRoleContext();
+  const currentUserId = useCurrentUserId();
+
   const { data: orgData, loading: orgsLoading } = useQuery(MY_JOB_ORGANIZATIONS, {
-    context: ORG_ADMIN_ROLE_CONTEXT,
-    skip: sessionStatus !== 'authenticated',
+    context: employerRole,
+    variables: { userId: currentUserId },
+    skip: sessionStatus !== 'authenticated' || !currentUserId,
   });
   const organization = orgData?.OrganizationAdmin?.[0]?.Organization ?? null;
 
   const { data, loading, refetch } = useQuery(MY_JOB_POSTINGS, {
-    context: ORG_ADMIN_ROLE_CONTEXT,
+    context: employerRole,
     variables: { organizationId: organization?.id ?? 0 },
     skip: !organization,
   });

--- a/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
@@ -78,6 +78,10 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
   const [step, setStep] = useState<1 | 2>(1);
   const [form, setForm] = useState<FormState>(EMPTY_FORM);
   const [savedId, setSavedId] = useState<number | null>(null);
+  // Which organization the draft was inserted for. Creation fixes it: the update
+  // path never writes organizationId, so the switcher must stop steering credits
+  // and the preview once a draft exists.
+  const [draftOrganizationId, setDraftOrganizationId] = useState<number | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   // The offer PDF is the centerpiece of a StuJo posting (embedded on the
   // detail page like in the Rails app). Uploaded after the draft exists.
@@ -100,17 +104,18 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
     skip: editId === null,
   });
 
-  // An existing posting keeps the organization it was created for — the update
-  // path never writes organizationId — so editing must show that one rather than
-  // whatever the switcher last selected.
+  // A posting keeps the organization it was created for, so once one exists —
+  // loaded for editing or just inserted — it, not the switcher, decides which
+  // company the credits and the preview describe.
   const organization = useMemo(() => {
-    const postingOrganizationId = editData?.JobPosting_by_pk?.organizationId ?? null;
+    const postingOrganizationId =
+      editData?.JobPosting_by_pk?.organizationId ?? draftOrganizationId;
     if (postingOrganizationId === null) return selectedOrganization;
     return (
       organizations.find((candidate) => candidate.id === postingOrganizationId) ??
       selectedOrganization
     );
-  }, [editData, organizations, selectedOrganization]);
+  }, [draftOrganizationId, editData, organizations, selectedOrganization]);
 
   const { data: priceData } = useQuery(MY_JOB_POSTINGS, {
     context: employerRole,
@@ -226,6 +231,7 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
         });
         id = result.data?.insert_JobPosting_one?.id ?? null;
         setSavedId(id);
+        if (id) setDraftOrganizationId(organization.id);
       }
       if (id && !(await uploadPdf(id))) {
         return null;
@@ -330,7 +336,7 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
     <Layout portal={portal}>
       <h1>{editId ? 'Angebot bearbeiten' : 'Neues Stellenangebot'}</h1>
       {organizations.length > 1 &&
-        (editId === null ? (
+        (editId === null && savedId === null ? (
           <OrganizationSwitcher
             organizations={organizations}
             selectedId={organization.id}

--- a/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
@@ -2,25 +2,26 @@ import { useMutation, useQuery } from '@apollo/client';
 import type { GetServerSideProps } from 'next';
 import { useRouter } from 'next/router';
 import { signIn, useSession } from 'next-auth/react';
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import { useCurrentUserId } from '@eduhub/hooks/authentication';
 
 import Layout from '../../components/Layout';
 import JobCard from '../../components/JobCard';
+import OrganizationSwitcher from '../../components/OrganizationSwitcher';
 import {
   ACTION_ROLE_CONTEXT,
   CREATE_JOB_POSTING,
   ENUM_OPTIONS,
   GET_JOB_POSTING_FOR_EDIT,
-  MY_JOB_ORGANIZATIONS,
   MY_JOB_POSTINGS,
   PUBLISH_JOB_POSTING_ACTION,
   SAVE_JOB_POSTING_PDF,
   UPDATE_JOB_POSTING,
   useEmployerRoleContext,
 } from '../../lib/employer';
+import { useEmployerOrganization } from '../../lib/useEmployerOrganization';
 import { resolvePortal, PortalBranding } from '../../lib/portal';
 import { resolveStorageUrl } from '../../lib/storage';
 
@@ -63,6 +64,7 @@ const EMPTY_FORM: FormState = {
  * postings go live directly, paid ones redirect to Stripe Checkout.
  */
 const NeuesAngebot: FC<Props> = ({ portal }) => {
+  const t = useTranslations('meinStujo');
   const tType = useTranslations('jobType');
   const tOccupation = useTranslations('jobOccupation');
   const tRegion = useTranslations('jobRegion');
@@ -83,25 +85,37 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
 
   const employerRole = useEmployerRoleContext();
-
-  const { data: orgData, loading: orgsLoading } = useQuery(MY_JOB_ORGANIZATIONS, {
-    context: employerRole,
-    variables: { userId: currentUserId },
-    skip: sessionStatus !== 'authenticated' || !currentUserId,
-  });
-  const organization = orgData?.OrganizationAdmin?.[0]?.Organization ?? null;
+  const {
+    organizations,
+    organization: selectedOrganization,
+    loading: orgsLoading,
+    selectOrganization,
+  } = useEmployerOrganization();
 
   const { data: enums } = useQuery(ENUM_OPTIONS);
-  const { data: priceData } = useQuery(MY_JOB_POSTINGS, {
-    context: employerRole,
-    variables: { organizationId: organization?.id ?? 0 },
-    skip: !organization,
-  });
 
   const { data: editData } = useQuery(GET_JOB_POSTING_FOR_EDIT, {
     context: employerRole,
     variables: { id: editId ?? 0 },
     skip: editId === null,
+  });
+
+  // An existing posting keeps the organization it was created for — the update
+  // path never writes organizationId — so editing must show that one rather than
+  // whatever the switcher last selected.
+  const organization = useMemo(() => {
+    const postingOrganizationId = editData?.JobPosting_by_pk?.organizationId ?? null;
+    if (postingOrganizationId === null) return selectedOrganization;
+    return (
+      organizations.find((candidate) => candidate.id === postingOrganizationId) ??
+      selectedOrganization
+    );
+  }, [editData, organizations, selectedOrganization]);
+
+  const { data: priceData } = useQuery(MY_JOB_POSTINGS, {
+    context: employerRole,
+    variables: { organizationId: organization?.id ?? 0 },
+    skip: !organization,
   });
 
   const [createPosting, { loading: creating }] = useMutation(CREATE_JOB_POSTING, {
@@ -193,6 +207,9 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
 
   const saveDraft = async (): Promise<number | null> => {
     setErrorMessage(null);
+    // The form only renders once an organization is resolved, so this is
+    // unreachable — it keeps the create branch below type-safe.
+    if (!organization) return null;
     try {
       let id = savedId;
       if (id) {
@@ -312,6 +329,19 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
   return (
     <Layout portal={portal}>
       <h1>{editId ? 'Angebot bearbeiten' : 'Neues Stellenangebot'}</h1>
+      {organizations.length > 1 &&
+        (editId === null ? (
+          <OrganizationSwitcher
+            organizations={organizations}
+            selectedId={organization.id}
+            label={t('organizationLabel')}
+            onSelect={selectOrganization}
+          />
+        ) : (
+          <p className="stujo-muted" style={{ margin: '0 0 0.75rem' }}>
+            {t('organizationLabel')}: {organization.name}
+          </p>
+        ))}
       <div className="stujo-steps">
         <span className={step === 1 ? 'stujo-step stujo-step--active' : 'stujo-step'}>
           1 · Angebot erstellen

--- a/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
@@ -5,6 +5,8 @@ import { signIn, useSession } from 'next-auth/react';
 import { FC, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
+import { useCurrentUserId } from '@eduhub/hooks/authentication';
+
 import Layout from '../../components/Layout';
 import JobCard from '../../components/JobCard';
 import {
@@ -14,10 +16,10 @@ import {
   GET_JOB_POSTING_FOR_EDIT,
   MY_JOB_ORGANIZATIONS,
   MY_JOB_POSTINGS,
-  ORG_ADMIN_ROLE_CONTEXT,
   PUBLISH_JOB_POSTING_ACTION,
   SAVE_JOB_POSTING_PDF,
   UPDATE_JOB_POSTING,
+  useEmployerRoleContext,
 } from '../../lib/employer';
 import { resolvePortal, PortalBranding } from '../../lib/portal';
 import { resolveStorageUrl } from '../../lib/storage';
@@ -65,10 +67,10 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
   const tOccupation = useTranslations('jobOccupation');
   const tRegion = useTranslations('jobRegion');
   const router = useRouter();
-  const { data: session, status: sessionStatus } = useSession();
+  const { status: sessionStatus } = useSession();
   // Contact for status mails (published/expired/payment failed) and the
   // Stripe customer — without it those flows silently do nothing.
-  const currentUserId = (session as any)?.profile?.sub ?? null;
+  const currentUserId = useCurrentUserId();
   const editId = typeof router.query.id === 'string' ? Number(router.query.id) : null;
 
   const [step, setStep] = useState<1 | 2>(1);
@@ -80,30 +82,33 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
   const [pdfFile, setPdfFile] = useState<File | null>(null);
   const [pdfUrl, setPdfUrl] = useState<string | null>(null);
 
+  const employerRole = useEmployerRoleContext();
+
   const { data: orgData, loading: orgsLoading } = useQuery(MY_JOB_ORGANIZATIONS, {
-    context: ORG_ADMIN_ROLE_CONTEXT,
-    skip: sessionStatus !== 'authenticated',
+    context: employerRole,
+    variables: { userId: currentUserId },
+    skip: sessionStatus !== 'authenticated' || !currentUserId,
   });
   const organization = orgData?.OrganizationAdmin?.[0]?.Organization ?? null;
 
   const { data: enums } = useQuery(ENUM_OPTIONS);
   const { data: priceData } = useQuery(MY_JOB_POSTINGS, {
-    context: ORG_ADMIN_ROLE_CONTEXT,
+    context: employerRole,
     variables: { organizationId: organization?.id ?? 0 },
     skip: !organization,
   });
 
   const { data: editData } = useQuery(GET_JOB_POSTING_FOR_EDIT, {
-    context: ORG_ADMIN_ROLE_CONTEXT,
+    context: employerRole,
     variables: { id: editId ?? 0 },
     skip: editId === null,
   });
 
   const [createPosting, { loading: creating }] = useMutation(CREATE_JOB_POSTING, {
-    context: ORG_ADMIN_ROLE_CONTEXT,
+    context: employerRole,
   });
   const [updatePosting, { loading: updating }] = useMutation(UPDATE_JOB_POSTING, {
-    context: ORG_ADMIN_ROLE_CONTEXT,
+    context: employerRole,
   });
   const [publishPosting, { loading: publishing }] = useMutation(PUBLISH_JOB_POSTING_ACTION, {
     context: ACTION_ROLE_CONTEXT,

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -438,6 +438,39 @@ a:focus {
   margin-bottom: 1rem;
 }
 
+/* Company picker, shown only when a user may post for several organizations. */
+.stujo-org-switcher {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  margin: 0.25rem 0 0.75rem;
+  font-size: 0.8rem;
+}
+
+.stujo-org-switcher select {
+  max-width: 20rem;
+  padding: 0.3rem 0.6rem;
+  font-family: inherit;
+  font-size: 14px;
+  color: var(--stujo-text);
+  background: #fff;
+  border: 2px solid var(--stujo-border);
+  border-radius: 0;
+}
+
+@media (max-width: 640px) {
+  .stujo-dash-head {
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .stujo-org-switcher select {
+    max-width: none;
+    /* Comfortable touch target on phones. */
+    min-height: 44px;
+  }
+}
+
 .stujo-stats {
   display: flex;
   gap: 1rem;

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -433,6 +433,8 @@ a:focus {
 
 .stujo-dash-head {
   display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   justify-content: space-between;
   align-items: center;
   margin-bottom: 1rem;
@@ -448,7 +450,8 @@ a:focus {
 }
 
 .stujo-org-switcher select {
-  max-width: 20rem;
+  /* Mobile first: full width, comfortable touch target. */
+  min-height: 44px;
   padding: 0.3rem 0.6rem;
   font-family: inherit;
   font-size: 14px;
@@ -458,16 +461,10 @@ a:focus {
   border-radius: 0;
 }
 
-@media (max-width: 640px) {
-  .stujo-dash-head {
-    flex-wrap: wrap;
-    gap: 0.75rem;
-  }
-
+@media (min-width: 641px) {
   .stujo-org-switcher select {
-    max-width: none;
-    /* Comfortable touch target on phones. */
-    min-height: 44px;
+    min-height: 0;
+    max-width: 20rem;
   }
 }
 


### PR DESCRIPTION
## Why

A super-admin opening `/mein-stujo` got *"Deinem Konto ist noch kein
Unternehmen mit Stellen-Verwaltung zugeordnet"* even with `canManageJobs`
ticked — and ticking that flag could never help, because it writes a DB column,
not a Keycloak role.

The employer screens pinned every query to the `org_admin` Hasura role. That
role only reaches a JWT through the `add_keycloak_org_admin_role` event
trigger, which fires when an `OrganizationAdmin` grant is **inserted**. A
super-admin without a grant of their own never carries it, so Hasura rejected
the request and the page reported "no organization". edu-hub never hit this
because its manage screens resolve the role through `useManageRole()`, which
returns `admin` for super-admins — StuJo was the only surface hardcoding
`org_admin`.

While in there: a user with `canManageJobs` for **two** organizations only ever
saw one of them, picked as `OrganizationAdmin[0]` from a query with no
`order_by`.

## What changed

**`fix(stujo): use the manage role for employer queries`**

- Resolve the role through edu-hub's existing `useManageRole()` instead of
  hardcoding `org_admin`: super-admins use `admin`, everyone else keeps the
  tenant-scoped `org_admin`.
- `admin` bypasses row-level filters, so `MyJobOrganizations` now filters on
  `userId` explicitly. Without it a super-admin would have landed on an
  arbitrary employer's organization.
- Add `useCurrentUserId` to edu-hub's auth hooks as the single place reading
  the `x-hasura-user-id` claim; route `useIsUserIdInList` and the
  `contactUserId` lookup in `neu.tsx` through it (drops an `any` cast).

**`feat(stujo): let employers switch between their organizations`**

- New `useEmployerOrganization` hook: orders grants by company name and
  resolves the active one from `?org=` → `localStorage` → first. The param
  makes a selection shareable; storage covers the cases that drop the query
  string (the Stripe return URL, and the repost handler's
  `router.replace('/mein-stujo')`).
- New `OrganizationSwitcher`, rendered **only when there is more than one
  grant** — a single organization keeps today's plain name line.
- Editing resolves the posting's *own* organization from `organizationId`
  rather than the selected one. Previously, editing company B's posting while
  company A was selected showed B's posting under A's name, credits and price.
  The switcher is hidden in edit mode (the update path never writes
  `organizationId`, so a posting can't be reassigned).
- Adds `meinStujo.organizationLabel` to both locale files.

## Reused, not rebuilt

`useManageRole` and the `AuthRoles` enum from edu-hub via the `@eduhub/*` alias
the stujo app already uses for `config/apollo` and `AuthStoreUpdater`. The
switcher select follows the existing `.stujo-field select` treatment. edu-hub
has no org-switcher component to borrow — its manage screens list all
organizations as table rows instead — so that one component is new.

## Verification

- `tsc --noEmit` on `apps/stujo` and `apps/edu-hub`: exit 0. It caught a real
  nullability hole in `saveDraft`'s create branch that the previously untyped
  `organization` had been hiding; guarded rather than asserted.
- `yarn lint`: 0 errors (one pre-existing `TableGrid/hooks.ts` warning,
  untouched here).
- `yarn build:stujo`: production build compiles, all routes generated.

Not exercised against a live super-admin or two-organization session — no such
session available locally — so the role resolution and selection precedence are
verified by construction and build, not by observation.

## Follow-up, not in this PR

Ordinary employers whose `OrganizationAdmin` row predates the
`add_keycloak_org_admin_role` trigger (or whose trigger call failed) still lack
the Keycloak role and will still see "kein Unternehmen". A one-off script
re-asserting the role for everyone holding a grant would close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added organization selection for employers managing multiple companies.
  * Organization choices are preserved and reflected in the page URL.
  * New job postings can be assigned to a selected company, while existing postings retain their company.
  * Added responsive styling for the company selector, including improved mobile usability.
  * Added English and German labels for the company selector.

* **Bug Fixes**
  * Improved organization access filtering so only authorized companies are shown.
  * Added clearer handling when no company is available for a job posting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->