### PR TITLE
Change course continuation email trigger from exceeded to reached limit

### DIFF
--- a/backend/metadata/cron_triggers.yaml
+++ b/backend/metadata/cron_triggers.yaml
@@ -45,7 +45,7 @@
       value: check_course_continuation
     - name: Hasura-Secret
       value_from_env: HASURA_CLOUD_FUNCTION_SECRET
-  comment: Asks enrollees who exceeded the course max missed sessions whether they intend to continue
+  comment: Asks enrollees who reached the course max missed sessions to attend the remaining sessions or tell us if they drop out
 - name: send_project_deadline_reminders
   webhook: '{{CLOUD_FUNCTION_LINK_CALL_PYTHON_FUNCTION}}'
   schedule: 0 8 * * *

--- a/backend/migrations/default/1787659382246_update_course_continuation_email_template/down.sql
+++ b/backend/migrations/default/1787659382246_update_course_continuation_email_template/down.sql
@@ -1,0 +1,21 @@
+-- Restores the previous "you missed more sessions than allowed" wording.
+
+UPDATE "public"."MailTemplateType"
+SET "comment" = 'Sent when a user exceeds the course''s max missed sessions, asking whether they intend to continue'
+WHERE "value" = 'COURSE_CONTINUATION_INQUIRY';
+
+UPDATE "public"."MailTemplate"
+SET "subject" = 'Möchtest du weitermachen? / Do you want to continue? - [Enrollment:CourseId--Course:Name]',
+    "content" = '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body>
+  <p>Hallo [User:FirstName] [User:LastName],</p>
+  <p>uns ist aufgefallen, dass du mehr Termine von <strong>[Enrollment:CourseId--Course:Name]</strong> verpasst hast, als für einen erfolgreichen Abschluss vorgesehen sind.</p>
+  <p>Möchtest du den Kurs weiterhin besuchen? Bitte gib uns kurz Bescheid bzw. wende dich an das Kursteam. Den Kurs findest du hier: <a href="[Enrollment:CourseLink]">[Enrollment:CourseLink]</a></p>
+  <p>Viele Grüße,<br>Dein EduHub Team</p>
+  <hr style="margin:2em 0;border:none;border-top:1px solid #ccc;" />
+  <p>Hello [User:FirstName] [User:LastName],</p>
+  <p>We noticed that you have missed more sessions of <strong>[Enrollment:CourseId--Course:Name]</strong> than allowed for a successful completion.</p>
+  <p>Do you still intend to continue the course? Please let us know or contact the course team. You can find the course here: <a href="[Enrollment:CourseLink]">[Enrollment:CourseLink]</a></p>
+  <p>Best regards,<br>The EduHub Team</p>
+  </body></html>',
+    "updated_at" = NOW()
+WHERE "type" = 'COURSE_CONTINUATION_INQUIRY' AND "courseId" IS NULL;

--- a/backend/migrations/default/1787659382246_update_course_continuation_email_template/up.sql
+++ b/backend/migrations/default/1787659382246_update_course_continuation_email_template/up.sql
@@ -15,13 +15,13 @@ SET "subject" = 'Bitte keine weiteren Termine verpassen / Please don''t miss fur
   <p>Hallo [User:FirstName] [User:LastName],</p>
   <p>uns ist aufgefallen, dass du bei <strong>[Enrollment:CourseId--Course:Name]</strong> inzwischen so viele Termine verpasst hast, wie für einen erfolgreichen Abschluss maximal möglich ist.</p>
   <p>Wir würden dich gerne weiter dabei haben: Bitte achte darauf, keine weiteren Termine zu verpassen, damit du den Kurs erfolgreich abschließen kannst.</p>
-  <p>Falls du nicht mehr teilnehmen möchtest, gib uns einfach kurz Bescheid oder wende dich an das Kursteam – dann können wir den Platz weitergeben. Den Kurs findest du hier: <a href="[Enrollment:CourseLink]">[Enrollment:CourseLink]</a></p>
+  <p>Falls du nicht mehr teilnehmen möchtest, gib uns einfach kurz Bescheid oder wende dich an das Kursteam – und schreib uns gerne kurz, woran es gelegen hat. Dein Feedback hilft uns, die Kurse besser zu machen. Den Kurs findest du hier: <a href="[Enrollment:CourseLink]">[Enrollment:CourseLink]</a></p>
   <p>Viele Grüße,<br>Dein EduHub Team</p>
   <hr style="margin:2em 0;border:none;border-top:1px solid #ccc;" />
   <p>Hello [User:FirstName] [User:LastName],</p>
   <p>We noticed that you have now missed as many sessions of <strong>[Enrollment:CourseId--Course:Name]</strong> as are allowed for a successful completion.</p>
   <p>We would love to keep you on board: please make sure not to miss any further sessions so that you can still complete the course successfully.</p>
-  <p>If you no longer want to take part, just send us a short note or contact the course team – that way we can offer your spot to someone else. You can find the course here: <a href="[Enrollment:CourseLink]">[Enrollment:CourseLink]</a></p>
+  <p>If you no longer want to take part, just send us a short note or contact the course team – and feel free to tell us briefly what made you stop. Your feedback helps us improve our courses. You can find the course here: <a href="[Enrollment:CourseLink]">[Enrollment:CourseLink]</a></p>
   <p>Best regards,<br>The EduHub Team</p>
   </body></html>',
     "updated_at" = NOW()

--- a/backend/migrations/default/1787659382246_update_course_continuation_email_template/up.sql
+++ b/backend/migrations/default/1787659382246_update_course_continuation_email_template/up.sql
@@ -1,0 +1,28 @@
+-- The COURSE_CONTINUATION_INQUIRY mail is now sent as soon as a participant
+-- *reaches* the course's max missed sessions (instead of only once the limit
+-- is exceeded), so the wording becomes a friendly heads-up: attend the
+-- remaining sessions, or drop us a short note if you no longer want to
+-- take part. Only the default template (courseId IS NULL) is touched;
+-- course-specific templates stay as their teams wrote them.
+
+UPDATE "public"."MailTemplateType"
+SET "comment" = 'Sent when a user reaches the course''s max missed sessions, asking them to attend the remaining sessions or to let us know if they want to stop'
+WHERE "value" = 'COURSE_CONTINUATION_INQUIRY';
+
+UPDATE "public"."MailTemplate"
+SET "subject" = 'Bitte keine weiteren Termine verpassen / Please don''t miss further sessions - [Enrollment:CourseId--Course:Name]',
+    "content" = '<!DOCTYPE html><html><head><meta charset="UTF-8"></head><body>
+  <p>Hallo [User:FirstName] [User:LastName],</p>
+  <p>uns ist aufgefallen, dass du bei <strong>[Enrollment:CourseId--Course:Name]</strong> inzwischen so viele Termine verpasst hast, wie für einen erfolgreichen Abschluss maximal möglich ist.</p>
+  <p>Wir würden dich gerne weiter dabei haben: Bitte achte darauf, keine weiteren Termine zu verpassen, damit du den Kurs erfolgreich abschließen kannst.</p>
+  <p>Falls du nicht mehr teilnehmen möchtest, gib uns einfach kurz Bescheid oder wende dich an das Kursteam – dann können wir den Platz weitergeben. Den Kurs findest du hier: <a href="[Enrollment:CourseLink]">[Enrollment:CourseLink]</a></p>
+  <p>Viele Grüße,<br>Dein EduHub Team</p>
+  <hr style="margin:2em 0;border:none;border-top:1px solid #ccc;" />
+  <p>Hello [User:FirstName] [User:LastName],</p>
+  <p>We noticed that you have now missed as many sessions of <strong>[Enrollment:CourseId--Course:Name]</strong> as are allowed for a successful completion.</p>
+  <p>We would love to keep you on board: please make sure not to miss any further sessions so that you can still complete the course successfully.</p>
+  <p>If you no longer want to take part, just send us a short note or contact the course team – that way we can offer your spot to someone else. You can find the course here: <a href="[Enrollment:CourseLink]">[Enrollment:CourseLink]</a></p>
+  <p>Best regards,<br>The EduHub Team</p>
+  </body></html>',
+    "updated_at" = NOW()
+WHERE "type" = 'COURSE_CONTINUATION_INQUIRY' AND "courseId" IS NULL;

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -2623,7 +2623,7 @@
       "PROJECT_DEADLINE_REMINDER": "Gesendet 48 Stunden vor dem Abgabetermin eines Projekts",
       "SESSION_RESCHEDULED": "Gesendet an Teilnehmende, wenn sich Datum oder Zeit eines Termins ändert",
       "PAYMENT_RECEIPT": "Gesendet, wenn eine Rechnung für eine Kurs- oder Event-Anmeldung bezahlt wurde",
-      "COURSE_CONTINUATION_INQUIRY": "Gesendet, wenn Teilnehmende mehr Termine versäumt haben als für den Kurs erlaubt"
+      "COURSE_CONTINUATION_INQUIRY": "Gesendet, wenn Teilnehmende so viele Termine versäumt haben, wie für den Kurs maximal erlaubt sind – mit der Bitte, keine weiteren Termine zu verpassen oder kurz Bescheid zu geben, falls sie nicht mehr teilnehmen möchten"
     },
     "delete_confirmation": "Bist du sicher, dass du die E-Mail-Vorlage '{title}' löschen möchtest?",
     "unknown_trigger": "Unbekannter Auslöser-Typ",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -2638,7 +2638,7 @@
       "PROJECT_DEADLINE_REMINDER": "Sent 48 hours before a project's submission deadline",
       "SESSION_RESCHEDULED": "Sent to participants when a session's date or time changes",
       "PAYMENT_RECEIPT": "Sent when an invoice for a course or event enrollment is paid",
-      "COURSE_CONTINUATION_INQUIRY": "Sent when a participant exceeds the course's limit of missed sessions"
+      "COURSE_CONTINUATION_INQUIRY": "Sent when a participant reaches the course's limit of missed sessions, asking them not to miss further sessions or to let the team know if they want to stop"
     },
     "delete_confirmation": "Are you sure you want to delete the email template '{title}'?",
     "unknown_trigger": "Unknown trigger type",

--- a/functions/callPythonFunction/__tests__/test_check_course_continuation.py
+++ b/functions/callPythonFunction/__tests__/test_check_course_continuation.py
@@ -1,0 +1,97 @@
+"""Unit tests for the course-continuation inquiry threshold."""
+import pytest
+
+from pythonFunctions import check_course_continuation as mod
+
+TEMPLATE = {
+    "subject": "Please don't miss further sessions - [Enrollment:CourseId--Course:Name]",
+    "content": "<p>Hi [User:FirstName]</p>",
+    "from": "noreply@opencampus.sh",
+    "cc": None,
+    "bcc": None,
+}
+
+
+def _user(uid, email="jane@example.com"):
+    return {"id": uid, "email": email, "firstName": "Jane", "lastName": "Doe"}
+
+
+def _course(course_id, max_missed, enrolled_users, missed_by_user):
+    """Builds a Course node as the Hasura query returns it.
+
+    ``missed_by_user`` maps a user id to how many MISSED attendances that
+    user has; each of those becomes its own session with one attendance.
+    """
+    sessions = []
+    for uid, count in missed_by_user.items():
+        for _ in range(count):
+            sessions.append({"Attendances": [{"userId": uid}]})
+    return {
+        "id": course_id,
+        "title": f"Course {course_id}",
+        "maxMissedSessions": max_missed,
+        "CourseEnrollments": [{"User": user} for user in enrolled_users],
+        "Sessions": sessions,
+    }
+
+
+class FakeClient:
+    def __init__(self, courses):
+        self.courses = courses
+
+    def send_query(self, query, variables):
+        return {"data": {"Course": self.courses}}
+
+
+@pytest.fixture
+def run(monkeypatch):
+    """Runs the function against canned courses, returning the queued mails."""
+
+    def _run(courses):
+        queued = []
+        monkeypatch.setattr(mod, "EduHubClient", lambda: FakeClient(courses))
+        monkeypatch.setattr(mod, "get_default_mail_template", lambda client, mail_type: TEMPLATE)
+        monkeypatch.setattr(mod, "already_sent_keys", lambda client, mail_type, candidates, key_fields: set())
+
+        def _queue_mail(client, template, to, replacements, metadata=None):
+            queued.append({"to": to, "metadata": metadata, "replacements": replacements})
+            return True
+
+        monkeypatch.setattr(mod, "queue_mail", _queue_mail)
+        result = mod.check_course_continuation({})
+        assert result["success"] is True
+        return queued
+
+    return _run
+
+
+class TestThreshold:
+    def test_notifies_when_limit_is_reached(self, run):
+        user = _user(1)
+        queued = run([_course(7, 2, [user], {1: 2})])
+
+        assert len(queued) == 1
+        assert queued[0]["to"] == user["email"]
+        assert queued[0]["metadata"] == {
+            "type": mod.MAIL_TYPE,
+            "courseId": 7,
+            "userId": 1,
+        }
+
+    def test_notifies_when_limit_is_exceeded(self, run):
+        assert len(run([_course(7, 2, [_user(1)], {1: 5})])) == 1
+
+    def test_no_mail_below_the_limit(self, run):
+        assert run([_course(7, 2, [_user(1)], {1: 1})]) == []
+
+    def test_zero_limit_needs_one_actual_absence(self, run):
+        # maxMissedSessions = 0 must not mail everyone who has been present.
+        assert run([_course(7, 0, [_user(1)], {})]) == []
+        assert len(run([_course(7, 0, [_user(1)], {1: 1})])) == 1
+
+    def test_skips_users_without_email(self, run):
+        assert run([_course(7, 1, [_user(1, email=None)], {1: 3})]) == []
+
+    def test_skips_courses_without_limit(self, run):
+        course = _course(7, None, [_user(1)], {1: 3})
+        assert run([course]) == []

--- a/functions/callPythonFunction/pythonFunctions/check_course_continuation.py
+++ b/functions/callPythonFunction/pythonFunctions/check_course_continuation.py
@@ -16,9 +16,14 @@ MAIL_TYPE = "COURSE_CONTINUATION_INQUIRY"
 def check_course_continuation(arguments):
     """
     For running courses with a maxMissedSessions limit, finds active
-    (CONFIRMED/REGISTERED) enrollees whose number of MISSED sessions has
-    *exceeded* that limit and asks them (once, deduped via MailLog metadata)
-    whether they intend to continue the course.
+    (CONFIRMED/REGISTERED) enrollees who have *reached* that limit and asks
+    them (once, deduped via MailLog metadata) to attend the remaining
+    sessions or to let us know if they no longer want to take part.
+
+    The mail goes out as soon as the limit is reached - i.e. after the last
+    absence that still allows a successful completion - so participants get
+    a heads-up while they can still act on it, instead of only once the
+    limit is already blown.
 
     Returns:
         dict: { success, data: { notifiedCount } } or { success, error }
@@ -62,8 +67,8 @@ def check_course_continuation(arguments):
             logging.warning(f"{MAIL_TYPE} template missing; skipping")
             return {"success": True, "data": {"notifiedCount": 0}}
 
-        # Collect everyone over their course's limit first, so the dedup lookup
-        # can be restricted to this run's candidates.
+        # Collect everyone at or over their course's limit first, so the dedup
+        # lookup can be restricted to this run's candidates.
         candidates = []
         for course in courses:
             max_missed = course.get("maxMissedSessions")
@@ -83,8 +88,12 @@ def check_course_continuation(arguments):
                 uid = user.get("id")
                 if not uid or not user.get("email"):
                     continue
-                if missed_by_user.get(uid, 0) <= max_missed:
-                    continue  # only when the limit is EXCEEDED
+                missed = missed_by_user.get(uid, 0)
+                # Reaching the limit is the trigger, not exceeding it. A
+                # course allowing 0 missed sessions still needs one actual
+                # absence before there is anything to write about.
+                if missed < max(max_missed, 1):
+                    continue
                 candidates.append({"courseId": course["id"], "userId": uid, "course": course, "user": user})
 
         key_fields = ["courseId", "userId"]


### PR DESCRIPTION
## Summary
This PR changes the timing of the course continuation inquiry email from being sent when a participant *exceeds* the max missed sessions limit to being sent when they *reach* it. This provides participants with a heads-up while they can still act on it, rather than only notifying them after the limit is already blown.

## Key Changes

- **Logic Update**: Modified `check_course_continuation.py` to trigger notifications when `missed >= max_missed` instead of `missed > max_missed`, with special handling for courses with a 0-session limit (requires at least 1 actual absence)

- **Email Template**: Updated the default course continuation email template with new wording that:
  - Changes from "Do you want to continue?" to "Please don't miss further sessions"
  - Shifts tone from inquiry to friendly heads-up
  - Asks participants to either attend remaining sessions or notify the course team if they want to drop out
  - Includes bilingual German/English content

- **Database Migration**: Added migration files to update the `MailTemplate` and `MailTemplateType` records with new subject, content, and description, with corresponding rollback migration

- **Documentation**: Updated:
  - Function docstring to reflect the new trigger condition and behavior
  - Cron trigger comment in metadata
  - Localization strings in both German and English to describe the new trigger condition

## Implementation Details

The key logic change uses `if missed < max(max_missed, 1)` to ensure:
- Courses with `maxMissedSessions = 0` still require at least 1 actual absence before triggering
- Courses with `maxMissedSessions > 0` trigger exactly when the limit is reached
- The deduplication mechanism (via MailLog metadata) prevents duplicate notifications for the same user/course combination

https://claude.ai/code/session_01EL3TRzUD1yHkoF5HfiFy2A