### PR TITLE
fix(infra): give the edu service the Stripe webhook secrets

### DIFF
--- a/infrastructure/application/01_secrets.tf
+++ b/infrastructure/application/01_secrets.tf
@@ -387,3 +387,21 @@ resource "google_secret_manager_secret_iam_member" "stripe_webhook_secret" {
   member     = "serviceAccount:${google_service_account.custom_cloud_function_account.email}"
   depends_on = [google_secret_manager_secret.stripe_webhook_secret]
 }
+
+# The edu Cloud Run service hosts the Stripe webhook handler and sets no
+# service_account_name, so it runs as the default compute service account —
+# the two bindings above only cover the cloud function. These bindings are
+# per-member, so granting the compute account does not revoke that access.
+resource "google_secret_manager_secret_iam_member" "stripe_secret_key_eduhub" {
+  secret_id  = google_secret_manager_secret.stripe_secret_key.id
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:${data.google_project.eduhub.number}-compute@developer.gserviceaccount.com"
+  depends_on = [google_secret_manager_secret.stripe_secret_key]
+}
+
+resource "google_secret_manager_secret_iam_member" "stripe_webhook_secret_eduhub" {
+  secret_id  = google_secret_manager_secret.stripe_webhook_secret.id
+  role       = "roles/secretmanager.secretAccessor"
+  member     = "serviceAccount:${data.google_project.eduhub.number}-compute@developer.gserviceaccount.com"
+  depends_on = [google_secret_manager_secret.stripe_webhook_secret]
+}

--- a/infrastructure/application/07_edu.tf
+++ b/infrastructure/application/07_edu.tf
@@ -104,6 +104,29 @@ resource "google_cloud_run_service" "eduhub" {
             }
           }
         }
+        # The Stripe webhook handler (pages/api/webhooks/stripe.ts) runs in this
+        # service, not in the cloud function: it needs the secret key to build
+        # the client and the signing secret to verify event signatures. Without
+        # both it answers every delivery with 500 "Stripe not configured", so a
+        # paid course enrollment or job posting is charged but never published.
+        env {
+          name = "STRIPE_SECRET_KEY"
+          value_from {
+            secret_key_ref {
+              name = google_secret_manager_secret.stripe_secret_key.secret_id
+              key  = "latest"
+            }
+          }
+        }
+        env {
+          name = "STRIPE_WEBHOOK_SECRET"
+          value_from {
+            secret_key_ref {
+              name = google_secret_manager_secret.stripe_webhook_secret.secret_id
+              key  = "latest"
+            }
+          }
+        }
       }
     }
 
@@ -134,5 +157,9 @@ resource "google_cloud_run_service" "eduhub" {
     google_secret_manager_secret_version.nextauth_secret,
     google_secret_manager_secret_version.keycloak_hasura_client_secret,
     google_secret_manager_secret_version.ghost_newsletter_credentials_encryption_key,
+    google_secret_manager_secret_version.stripe_secret_key,
+    google_secret_manager_secret_version.stripe_webhook_secret,
+    google_secret_manager_secret_iam_member.stripe_secret_key_eduhub,
+    google_secret_manager_secret_iam_member.stripe_webhook_secret_eduhub,
   ]
 }


### PR DESCRIPTION
## Problem

The Stripe webhook handler lives in the **edu-hub Next.js app** (`frontend-nx/apps/edu-hub/pages/api/webhooks/stripe.ts`), not in the cloud function, and bails out immediately unless both Stripe values are present:

```ts
const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
if (!stripeSecretKey || !webhookSecret) {
  console.error('Stripe configuration missing');
  return res.status(500).json({ error: 'Stripe not configured' });
}
```

The `edu` Cloud Run service received neither:

- `STRIPE_SECRET_KEY` was mounted only into the cloud function (`06_cloud-functions.tf:361`). The service's env block (`07_edu.tf`) carried `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` but no secret.
- `stripe_webhook_secret` was created in Secret Manager and IAM-bound (`01_secrets.tf:268-389`) but **no service consumed it at all**.

Confirmed against production:

```
GET  https://edu.opencampus.sh/api/webhooks/stripe  -> 405  (handler reachable)
POST https://edu.opencampus.sh/api/webhooks/stripe  -> 500  {"error":"Stripe not configured"}
```

**Impact:** publishing happens in the webhook, so a paid course enrollment or StuJo job posting was charged by Stripe and issued a real invoice, while the posting stayed in `PENDING_PAYMENT` and no `Invoice` row was ever written. Found while preparing a live 50 ct payment test for the StuJo job board.

## Change

1. `07_edu.tf` — mount `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` on the service, using the same `secret_key_ref` pattern as the other secrets there.
2. `01_secrets.tf` — add `secretAccessor` bindings for the **default compute service account**. The `edu` service sets no `service_account_name`, so it runs as `<project-number>-compute@developer.gserviceaccount.com`, whereas both Stripe secrets were granted only to `custom_cloud_function_account`. Cloud Run cannot start a revision whose runtime account may not read a mounted secret, so without this the deploy fails rather than silently misbehaving. `google_secret_manager_secret_iam_member` is per-member, so the cloud function keeps its access.
3. `07_edu.tf` — extend the existing `depends_on` with the two secret versions and the two new bindings.

## Verifying after deploy

```
curl -s -X POST https://edu.opencampus.sh/api/webhooks/stripe \
  -H 'Content-Type: application/json' -d '{}'
```

- `400 {"error":"Missing Stripe signature"}` → configured correctly
- `500 {"error":"Stripe not configured"}` → still missing

## Notes

- Requires `stripe_secret_key` and `stripe_webhook_secret` to hold valid live values in the Terraform Cloud workspace; this PR only wires them through.
- Terraform variables and Secret Manager resources are unchanged — no new secrets, no new variables.
- `terraform fmt -check` clean on both files.
- Unrelated but worth knowing before the live test: a webhook endpoint pinned to an old account API version (e.g. `2019-12-03`) delivers Checkout Session payloads without `amount_total`, `amount_subtotal`, `total_details` or `invoice`, all of which `lib/stripeJobPosting.ts` reads. The fallbacks are silent, so the `Invoice` row would record 0,00 € with no invoice link. Pin the endpoint to a current API version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stripe payment and webhook services are now securely connected to the application.
  * Cloud Run can access the required Stripe credentials through managed secrets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->