### PR TITLE
fix(stripe): stop offering EU bank transfer at checkout

### DIFF
--- a/frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts
+++ b/frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts
@@ -9,8 +9,8 @@ import type Stripe from 'stripe';
  *
  * Business decisions (2026-07-10):
  * - Instant publish on checkout completion — also for delayed payment
- *   methods (SEPA debit, bank transfer), matching the old Rails
- *   post-first/pay-later flow. The invoice starts as ISSUED and is
+ *   methods (SEPA debit), matching the old Rails post-first/pay-later
+ *   flow. The invoice starts as ISSUED and is
  *   flipped to PAID on async_payment_succeeded.
  * - On async_payment_failed the posting is taken offline again (DRAFT),
  *   the invoice is CANCELLED and the employer is notified.
@@ -299,8 +299,8 @@ export async function handleJobPostingCheckoutCompleted(
       userId: buyerUserId,
       jobPostingId: posting.id,
       invoiceNumber: `STUJO-${session.id}`,
-      // Card payments are settled at completion; SEPA/bank transfer settle
-      // later (async_payment_succeeded flips the invoice to PAID).
+      // Card payments are settled at completion; SEPA settles later
+      // (async_payment_succeeded flips the invoice to PAID).
       status: session.payment_status === 'paid' ? 'PAID' : 'ISSUED',
       netTotal,
       vatTotal,
@@ -344,7 +344,7 @@ export async function handleJobPostingCheckoutCompleted(
 }
 
 /**
- * Delayed payment (SEPA/bank transfer) settled: invoice ISSUED -> PAID.
+ * Delayed payment (SEPA) settled: invoice ISSUED -> PAID.
  */
 export async function handleJobPostingAsyncPaymentSucceeded(
   client: GraphQLClient,

--- a/frontend-nx/apps/edu-hub/pages/api/webhooks/stripe.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/webhooks/stripe.ts
@@ -433,7 +433,7 @@ const handleStripeWebhook = async (
                     : session.payment_intent?.id ?? null,
                 stripeInvoice: session.invoice as string | Stripe.Invoice | null,
               },
-              // SEPA / bank transfer settle later: ISSUED until
+              // SEPA settles later: ISSUED until
               // async_payment_succeeded flips the invoice to PAID.
               session.payment_status === 'paid' ? 'PAID' : 'ISSUED'
             );

--- a/functions/callNodeFunction/__tests__/stripeTax.test.js
+++ b/functions/callNodeFunction/__tests__/stripeTax.test.js
@@ -1,0 +1,34 @@
+import { buildPaymentMethodConfig } from '../lib/stripeTax.js';
+
+describe('buildPaymentMethodConfig', () => {
+  it('offers card and SEPA debit, and lets Stripe create the customer when there is no email', () => {
+    expect(buildPaymentMethodConfig()).toEqual({
+      payment_method_types: ['card', 'sepa_debit'],
+      customer_creation: 'always',
+    });
+  });
+
+  it('attaches an existing customer instead of creating a second one', () => {
+    expect(buildPaymentMethodConfig('cus_123')).toEqual({
+      customer: 'cus_123',
+      payment_method_types: ['card', 'sepa_debit'],
+    });
+  });
+
+  it.each([[null], ['cus_123']])(
+    'never offers bank transfer (%s) — the capability is unactivated and Stripe rejects the whole session',
+    (customerId) => {
+      const config = buildPaymentMethodConfig(customerId);
+
+      expect(config.payment_method_types).not.toContain('customer_balance');
+      expect(config.payment_method_options).toBeUndefined();
+    }
+  );
+
+  it('returns a fresh array per call so a caller cannot mutate the next session', () => {
+    const first = buildPaymentMethodConfig();
+    first.payment_method_types.push('klarna');
+
+    expect(buildPaymentMethodConfig().payment_method_types).toEqual(['card', 'sepa_debit']);
+  });
+});

--- a/functions/callNodeFunction/createStripeCheckout/index.js
+++ b/functions/callNodeFunction/createStripeCheckout/index.js
@@ -476,8 +476,8 @@ export default async function createStripeCheckout(req, logger) {
       });
     }
 
-    // Bank transfer (customer_balance) requires an existing Stripe
-    // customer; without an email the session degrades to card+SEPA.
+    // A named customer keeps repeat purchases and their invoices on one
+    // record; without an email Stripe creates one during checkout instead.
     let stripeCustomerId = null;
     if (emailToUse && emailToUse.trim() !== '' && emailToUse.includes('@')) {
       stripeCustomerId = await getOrCreateCustomer(stripe, emailToUse.trim());
@@ -487,8 +487,8 @@ export default async function createStripeCheckout(req, logger) {
     const sessionConfig = {
       line_items: lineItems,
       mode: 'payment',
-      // Agreed payment methods (card, SEPA debit, EU bank transfer);
-      // delayed methods settle via checkout.session.async_payment_* events.
+      // Card and SEPA debit; the latter settles via the
+      // checkout.session.async_payment_* events.
       ...buildPaymentMethodConfig(stripeCustomerId),
       // Stripe issues a real, sequentially numbered invoice (§14 UStG);
       // the webhook stores its hosted/PDF URLs on the Invoice row.

--- a/functions/callNodeFunction/lib/stripeTax.js
+++ b/functions/callNodeFunction/lib/stripeTax.js
@@ -76,10 +76,9 @@ export function buildInvoiceCreation(organization) {
 }
 
 /**
- * Finds (by email) or creates the Stripe Customer for a checkout. The
- * bank-transfer method (customer_balance) requires sessions to be created
- * with an existing customer — customer_creation is not sufficient
- * (verified against the test-mode API).
+ * Finds (by email) or creates the Stripe Customer for a checkout, so
+ * repeat purchases attach to one customer record and its invoices stay
+ * together, instead of customer_creation minting a new one each time.
  *
  * @param {import('stripe').Stripe} stripe
  * @param {string} email
@@ -96,32 +95,26 @@ export async function getOrCreateCustomer(stripe, email, name = null) {
 }
 
 /**
- * Payment methods agreed for both flows (2026-07-10): card, SEPA direct
- * debit and EU bank transfer (pay later). SEPA and bank transfer settle
- * asynchronously — webhook consumers must handle
+ * Payment methods offered in both flows: card and SEPA direct debit.
+ * SEPA settles asynchronously — webhook consumers must handle
  * checkout.session.async_payment_succeeded / _failed.
  *
- * Bank transfer is only offered when a Stripe customer exists (pass its
- * id, see getOrCreateCustomer); without one the session degrades to
- * card + SEPA.
+ * EU bank transfer (customer_balance) was part of the 2026-07-10
+ * agreement but is not offered: the capability needs additional
+ * verification that the live account does not have, and Checkout
+ * rejects the whole session when an unactivated type is listed. Adding
+ * it back means one entry here plus its payment_method_options block
+ * (funding_type 'bank_transfer', eu_bank_transfer country DE) and a
+ * customer on the session. The longer-term direction is to stop
+ * hardcoding the list and pass a payment_method_configuration chosen
+ * per course instead (issue #1889).
  *
  * @param {string|null} customerId
  */
 export function buildPaymentMethodConfig(customerId = null) {
+  const types = ['card', 'sepa_debit'];
   if (!customerId) {
-    return {
-      payment_method_types: ['card', 'sepa_debit'],
-      customer_creation: 'always',
-    };
+    return { payment_method_types: types, customer_creation: 'always' };
   }
-  return {
-    customer: customerId,
-    payment_method_types: ['card', 'sepa_debit', 'customer_balance'],
-    payment_method_options: {
-      customer_balance: {
-        funding_type: 'bank_transfer',
-        bank_transfer: { type: 'eu_bank_transfer', eu_bank_transfer: { country: 'DE' } },
-      },
-    },
-  };
+  return { customer: customerId, payment_method_types: types };
 }

--- a/functions/callNodeFunction/publishJobPosting/index.js
+++ b/functions/callNodeFunction/publishJobPosting/index.js
@@ -16,8 +16,8 @@ import {
  * - Free type (price 0, e.g. MINIJOB)  -> publish immediately
  * - Available JobPostingCredit          -> consume one credit, publish
  * - Otherwise                           -> status PENDING_PAYMENT + Stripe
- *   Checkout Session (card, SEPA debit, bank transfer; net price + fixed
- *   19% VAT). The webhook publishes on checkout.session.completed.
+ *   Checkout Session (card, SEPA debit; net price + fixed 19% VAT).
+ *   The webhook publishes on checkout.session.completed.
  *
  * Caller must be an OrganizationAdmin with canManageJobs for the posting's
  * organization. Direct status changes are blocked by Hasura permissions,
@@ -374,8 +374,9 @@ export default async function publishJobPosting(req, logger) {
       }
     }
 
-    // Bank transfer (customer_balance) requires an existing Stripe
-    // customer; without a contact email the session degrades to card+SEPA.
+    // A named customer keeps an organization's postings and their
+    // invoices on one record; without a contact email Stripe creates one
+    // during checkout instead.
     let customerId = null;
     if (posting.ContactUser?.email) {
       customerId = await getOrCreateCustomer(
@@ -388,8 +389,8 @@ export default async function publishJobPosting(req, logger) {
     const sessionConfig = {
       line_items: [lineItem],
       mode: 'payment',
-      // Agreed payment methods: card, SEPA direct debit, bank transfer
-      // (pay later, parity with the old invoice flow).
+      // Card and SEPA direct debit; the latter settles via the
+      // checkout.session.async_payment_* events.
       ...buildPaymentMethodConfig(customerId),
       // Stripe issues a real, sequentially numbered invoice (§14 UStG).
       invoice_creation: buildInvoiceCreation(sellerOrganization),


### PR DESCRIPTION
## What

Removes EU bank transfer (`customer_balance`) from the payment methods offered in both Stripe checkout flows, leaving card and SEPA direct debit.

## Why

The capability needs an additional Stripe verification the live account does not have. Checkout rejects the **whole session** when an unactivated payment method type is listed, so publishing a job posting (and enrolling in a paid course) failed outright:

```
The payment method type provided: customer_balance is invalid. Please ensure
the provided type is activated in your dashboard …
```

This blocks the production payment test. Nothing is lost for users — the method was never actually offered, it only produced an error.

## What's in it

- `lib/stripeTax.js` — `buildPaymentMethodConfig` drops `customer_balance` and its `payment_method_options` block.
- The `getOrCreateCustomer` lookup **stays**. Its comments justified it by bank transfer, but it earns its place on its own: repeat purchases and their invoices attach to one customer record instead of `customer_creation` minting a new one each time. Comments reworded accordingly at the three sites that repeated the old rationale.
- Comment-only touch-ups in `stripeJobPosting.ts` and `webhooks/stripe.ts`, which described the delayed-settlement path as "SEPA / bank transfer".
- New `__tests__/stripeTax.test.js` — five tests over both branches, including that neither ever offers `customer_balance`.

**No webhook changes.** SEPA also settles asynchronously, so `checkout.session.async_payment_succeeded` / `_failed` handling is unchanged.

## Alternative considered

A try/retry that drops `customer_balance` when Stripe rejects it. Rejected: the capability is inactive indefinitely, so that means one guaranteed-failing Stripe call before every successful checkout in both flows, permanently, plus an error per checkout in the logs — a runtime cost to paper over a config mismatch, and it would silently keep stripping the method once verification does complete.

The real fix is #1889: let admins pick a `payment_method_configuration` per course and stop hardcoding `payment_method_types`, so Stripe renders whatever is activated and eligible and an unavailable method is simply absent instead of fatal.

## Verification

- `functions/callNodeFunction`: `npm test` → 170 passed, 14 suites. The one failing suite (`matrixRoomUtils.test.js`, "must contain at least one test") is a pre-existing `node:test` file Jest picks up on `develop`, untouched here.
- `frontend-nx`: `tsc --noEmit` clean; `yarn lint` 0 errors (1 pre-existing warning in `TableGrid/hooks.ts`); webhook tests 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Stripe Checkout now supports card and SEPA Direct Debit payments for paid job postings.
  * Bank transfer payment options are no longer available during checkout.
  * Payments that settle later through SEPA continue to be handled asynchronously.

* **Tests**
  * Added coverage to verify supported payment methods, customer handling, and consistent checkout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->