### PR TITLE
fix(manage): interpolate the title and drop course-only wording

### DIFF
--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/ProgramManagementDashboard.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/ProgramManagementDashboard.tsx
@@ -7,6 +7,7 @@ import { useManageProgramWhere } from '../../../hooks/manageScope';
 import { PROGRAMS_WITH_MINIMUM_PROPERTIES } from '../../../queries/programList';
 import { Programs } from '../../../queries/__generated__/Programs';
 import { ProgramType } from '../../../types/enums';
+import { programTypeMessageKey } from '../../../helpers/programType';
 import { Program_bool_exp } from '../../../__generated__/globalTypes';
 import ManageCoursesContent from './index';
 
@@ -48,14 +49,10 @@ const ProgramManagementDashboard: FC<ProgramManagementDashboardProps> = ({ progr
     // programs from the management UI (creation is platform-admin only and always produces a
     // COURSES program owned by no organization), so an informative empty state is shown instead
     // of a blank page to explain how to get unblocked.
-    const emptyStateKey =
-      programType === ProgramType.EVENTS
-        ? 'empty_state.events'
-        : programType === ProgramType.DEGREES
-        ? 'empty_state.degrees'
-        : 'empty_state.courses';
     return (
-      <div className="max-w-screen-xl mx-auto py-8 text-center text-gray-500">{t(emptyStateKey)}</div>
+      <div className="max-w-screen-xl mx-auto py-8 text-center text-gray-500">
+        {t(`empty_state.${programTypeMessageKey(programType)}`)}
+      </div>
     );
   }
 

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/SelectProgramDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/SelectProgramDialog.tsx
@@ -4,16 +4,20 @@ import { FC, useCallback, useState } from 'react';
 import { MdClose } from 'react-icons/md';
 import { Programs_Program } from '../../../queries/__generated__/Programs';
 import { Button } from '../../common/Button';
+import { programTypeMessageKey } from '../../../helpers/programType';
+import { ProgramType } from '../../../types/enums';
 
 interface SelectProgramDialogProps {
   open: boolean;
   programs: Programs_Program[];
   onClose: (confirmed: boolean, selectedProgram: Programs_Program | null) => void;
-  title: string;
+  /** Decides whether the dialog talks about courses, events or degrees. */
+  programType: ProgramType;
 }
 
-export const SelectProgramDialog: FC<SelectProgramDialogProps> = ({ open, programs, onClose, title }) => {
+export const SelectProgramDialog: FC<SelectProgramDialogProps> = ({ open, programs, onClose, programType }) => {
   const t = useTranslations('manageCourses');
+  const messageKey = programTypeMessageKey(programType);
   const [selectedProgram, setSelectedProgram] = useState<Programs_Program | null>(null);
 
   const handleCancel = useCallback(() => {
@@ -34,7 +38,7 @@ export const SelectProgramDialog: FC<SelectProgramDialogProps> = ({ open, progra
     <Dialog open={open} onClose={handleCancel} maxWidth="sm" fullWidth>
       <DialogTitle className="light">
         <div className="flex justify-between items-center">
-          <span className="text-label-primary">{title}</span>
+          <span className="text-label-primary">{t(`copy_to_program_dialog.title.${messageKey}`)}</span>
           <button
             onClick={handleCancel}
             className="p-1 rounded-full hover:bg-gray-200 transition-colors text-label-primary"
@@ -47,7 +51,7 @@ export const SelectProgramDialog: FC<SelectProgramDialogProps> = ({ open, progra
 
       <DialogContent className="light">
         <div className="mb-4">
-          <p className="text-label-primary">{t('copy_courses_to_program_dialog.description')}</p>
+          <p className="text-label-primary">{t(`copy_to_program_dialog.description.${messageKey}`)}</p>
         </div>
 
         <div className="max-h-96 overflow-auto mb-6">
@@ -70,7 +74,7 @@ export const SelectProgramDialog: FC<SelectProgramDialogProps> = ({ open, progra
         <div className="flex justify-between">
           <Button onClick={handleCancel}>{t('cancel')}</Button>
           <Button filled onClick={handleConfirm} disabled={!selectedProgram}>
-            {t('copy_courses_to_program_dialog.button')}
+            {t(`copy_to_program_dialog.button.${messageKey}`)}
           </Button>
         </div>
       </DialogContent>

--- a/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageCoursesContent/index.tsx
@@ -20,6 +20,7 @@ import {
   UpdateCourseAchievementCertificatePossibleVariables,
 } from '../../../queries/__generated__/UpdateCourseAchievementCertificatePossible';
 import { isKnownCourseGroupOptionTitle } from '../../../helpers/courseGroupOptions';
+import { programTypeMessageKey } from '../../../helpers/programType';
 import { DEGREE_COURSES } from '../../../queries/courseDegree';
 import { DegreeCourses } from '../../../queries/__generated__/DegreeCourses';
 import { DELETE_A_COURSE } from '../../../queries/mutateCourse';
@@ -80,6 +81,10 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
     () => ({ Program: { type: { _eq: programType } } }),
     [programType]
   );
+
+  // Suffix of the program-type-aware message keys, so dialogs and snackbars talk about events or
+  // degrees instead of courses when this page manages those.
+  const messageKey = programTypeMessageKey(programType);
 
   const headline = useMemo(() => {
     switch (programType) {
@@ -294,7 +299,7 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
     try {
       await insertCourse({
         variables: {
-          title: t('default_course_title'),
+          title: t(`default_title.${messageKey}`),
           applicationEnd:
             selectedProgram?.defaultApplicationEnd && new Date(selectedProgram.defaultApplicationEnd) > new Date()
               ? selectedProgram.defaultApplicationEnd
@@ -306,14 +311,14 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
         refetchQueries: ['AdminCourseList'],
       });
 
-      setSuccessMessage(t('notifications.course_added_success'));
+      setSuccessMessage(t(`notifications.added_success.${messageKey}`));
       setShowSuccessNotification(true);
     } catch (error) {
       console.error('Error adding course:', error);
-      setErrorMessage(t('notifications.course_add_failed'));
+      setErrorMessage(t(`notifications.add_failed.${messageKey}`));
       setShowErrorNotification(true);
     }
-  }, [filter.where.programId?._eq, sortedPrograms, insertCourse, t]);
+  }, [filter.where.programId?._eq, sortedPrograms, insertCourse, t, messageKey]);
 
   // Bulk action handlers
   const handleBulkAction = useCallback(
@@ -336,8 +341,8 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
           setSuccessMessage(
             t(
               selectedCourses.length === 1
-                ? 'notifications.courses_published_success_singular'
-                : 'notifications.courses_published_success_plural',
+                ? `notifications.published_success_singular.${messageKey}`
+                : `notifications.published_success_plural.${messageKey}`,
               {
                 count: selectedCourses.length,
               }
@@ -359,8 +364,8 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
           setSuccessMessage(
             t(
               selectedCourses.length === 1
-                ? 'notifications.courses_unpublished_success_singular'
-                : 'notifications.courses_unpublished_success_plural',
+                ? `notifications.unpublished_success_singular.${messageKey}`
+                : `notifications.unpublished_success_plural.${messageKey}`,
               {
                 count: selectedCourses.length,
               }
@@ -374,11 +379,11 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
         }
       } catch (error) {
         console.error(`Error during bulk ${action} action:`, error);
-        setErrorMessage(t('notifications.bulk_action_failed', { action }));
+        setErrorMessage(t(`notifications.bulk_action_failed.${messageKey}`));
         setShowErrorNotification(true);
       }
     },
-    [updateCourse, t]
+    [updateCourse, t, messageKey]
   );
 
   const bulkActions = [
@@ -553,8 +558,8 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
           setSuccessMessage(
             t(
               coursesToCopy.length === 1
-                ? 'notifications.courses_copied_success_singular'
-                : 'notifications.courses_copied_success_plural',
+                ? `notifications.copied_success_singular.${messageKey}`
+                : `notifications.copied_success_plural.${messageKey}`,
               {
                 count: coursesToCopy.length,
                 programTitle: targetProgram.title,
@@ -569,7 +574,7 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
 
       setCoursesToCopy([]);
     },
-    [coursesToCopy, copyCourses, t]
+    [coursesToCopy, copyCourses, t, messageKey]
   );
 
   const courseStatus = (status: string) => {
@@ -674,7 +679,7 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
         minSize: 250,
         enableSorting: true,
         cell: ({ row }) => {
-          const defaultTitle = t('default_course_title');
+          const defaultTitle = t(`default_title.${messageKey}`);
 
           return (
             <div className="grid w-full grid-cols-[minmax(0,1fr)_auto] items-center gap-2 pr-3">
@@ -764,7 +769,7 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
               {hasCustomTemplates && (
                 <MdMarkEmailRead
                   className="w-4 h-4 text-blue-600 ml-1"
-                  title={t('table_header.has_custom_templates')}
+                  title={t(`table_header.has_custom_templates.${messageKey}`)}
                 />
               )}
             </div>
@@ -774,6 +779,7 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
     ],
     [
       t,
+      messageKey,
       handleApplicationEndChange,
       locale,
       getApplicationsCount,
@@ -849,8 +855,8 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
           deleteIdType="number"
           role={manageRole}
           generateDeletionConfirmationQuestion={(row) =>
-            t('delete_button.delete_course_confirmation', {
-              title: row.title || t('delete_button.untitled_course'),
+            t(`delete_button.delete_confirmation.${messageKey}`, {
+              title: row.title || t(`default_title.${messageKey}`),
             })
           }
         />
@@ -860,7 +866,7 @@ const ManageCoursesContent: FC<IProps> = ({ programs, programType }) => {
         open={showProgramDialog}
         programs={sortedPrograms}
         onClose={handleProgramDialogClose}
-        title={t('copy_courses_to_program_dialog.title')}
+        programType={programType}
       />
 
       <NotificationSnackbar

--- a/frontend-nx/apps/edu-hub/helpers/programType.ts
+++ b/frontend-nx/apps/edu-hub/helpers/programType.ts
@@ -1,0 +1,19 @@
+import { ProgramType } from '../types/enums';
+
+/**
+ * Suffix of the program-type-aware translation keys in the `manageCourses` namespace, e.g.
+ * `notifications.added_success.events` or `empty_state.degrees`.
+ *
+ * The manage courses/events/degrees pages all render `ManageCoursesContent` with a different
+ * `programType`, so every user-facing message needs one wording variant per program type.
+ */
+export const programTypeMessageKey = (programType: ProgramType): 'courses' | 'events' | 'degrees' => {
+  switch (programType) {
+    case ProgramType.EVENTS:
+      return 'events';
+    case ProgramType.DEGREES:
+      return 'degrees';
+    default:
+      return 'courses';
+  }
+};

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -1059,7 +1059,11 @@
       "program": "Programm",
       "status": "Status",
       "email_templates": "Vorlagen",
-      "has_custom_templates": "Dieser Kurs hat kursspezifische E-Mail-Vorlagen"
+      "has_custom_templates": {
+        "courses": "Dieser Kurs hat eigene E-Mail-Vorlagen",
+        "events": "Dieses Event hat eigene E-Mail-Vorlagen",
+        "degrees": "Dieses Degree hat eigene E-Mail-Vorlagen"
+      }
     },
     "error_loading_programs": "Die Programme konnten nicht geladen werden. Bitte versuche es später erneut.",
     "empty_state": {
@@ -1071,7 +1075,11 @@
     "close": "Schließen",
     "cancel": "Abbrechen",
     "not_published": "Nicht veröffentlicht",
-    "default_course_title": "Unbenannter Kurs",
+    "default_title": {
+      "courses": "Unbenannter Kurs",
+      "events": "Unbenanntes Event",
+      "degrees": "Unbenanntes Degree"
+    },
     "title": "Kurse verwalten",
     "all_programs": "Alle",
     "course_degree_title": {
@@ -1196,32 +1204,83 @@
     "add_event_button": "Event hinzufügen",
     "add_degree_button": "Degree hinzufügen",
     "delete_button": {
-      "delete_course_confirmation": "Bist du sicher, dass du den Kurs '{title}' löschen möchtest?",
-      "untitled_course": "Unbenannter Kurs"
+      "delete_confirmation": {
+        "courses": "Bist du sicher, dass du den Kurs „{title}“ löschen möchtest?",
+        "events": "Bist du sicher, dass du das Event „{title}“ löschen möchtest?",
+        "degrees": "Bist du sicher, dass du das Degree „{title}“ löschen möchtest?"
+      }
     },
     "bulk_action": {
       "publish": "Ausgewählte veröffentlichen",
       "unpublish": "Ausgewählte zurückziehen",
       "copy": "In Programm kopieren"
     },
-    "copy_courses_to_program_dialog": {
-      "title": "Kurse in Programm kopieren",
-      "description": "Wähle das Zielprogramm aus, in das die Kurse kopiert werden sollen:",
-      "button": "Kurse kopieren"
+    "copy_to_program_dialog": {
+      "title": {
+        "courses": "Kurse in Programm kopieren",
+        "events": "Events in Programm kopieren",
+        "degrees": "Degrees in Programm kopieren"
+      },
+      "description": {
+        "courses": "Wähle das Zielprogramm aus, in das die Kurse kopiert werden sollen:",
+        "events": "Wähle das Zielprogramm aus, in das die Events kopiert werden sollen:",
+        "degrees": "Wähle das Zielprogramm aus, in das die Degrees kopiert werden sollen:"
+      },
+      "button": {
+        "courses": "Kurse kopieren",
+        "events": "Events kopieren",
+        "degrees": "Degrees kopieren"
+      }
     },
     "notifications": {
-      "course_added_success": "Kurs erfolgreich hinzugefügt",
-      "course_add_failed": "Fehler beim Hinzufügen des Kurses. Bitte versuche es erneut.",
-      "courses_published_success_singular": "{count} Kurs erfolgreich veröffentlicht",
-      "courses_published_success_plural": "{count} Kurse erfolgreich veröffentlicht",
-      "courses_unpublished_success_singular": "{count} Kurs erfolgreich zurückgezogen",
-      "courses_unpublished_success_plural": "{count} Kurse erfolgreich zurückgezogen",
-      "bulk_action_failed": "Fehler beim {action} der Kurse. Bitte versuche es erneut.",
+      "added_success": {
+        "courses": "Kurs erfolgreich hinzugefügt",
+        "events": "Event erfolgreich hinzugefügt",
+        "degrees": "Degree erfolgreich hinzugefügt"
+      },
+      "add_failed": {
+        "courses": "Fehler beim Hinzufügen des Kurses. Bitte versuche es erneut.",
+        "events": "Fehler beim Hinzufügen des Events. Bitte versuche es erneut.",
+        "degrees": "Fehler beim Hinzufügen des Degrees. Bitte versuche es erneut."
+      },
+      "published_success_singular": {
+        "courses": "{count} Kurs erfolgreich veröffentlicht",
+        "events": "{count} Event erfolgreich veröffentlicht",
+        "degrees": "{count} Degree erfolgreich veröffentlicht"
+      },
+      "published_success_plural": {
+        "courses": "{count} Kurse erfolgreich veröffentlicht",
+        "events": "{count} Events erfolgreich veröffentlicht",
+        "degrees": "{count} Degrees erfolgreich veröffentlicht"
+      },
+      "unpublished_success_singular": {
+        "courses": "{count} Kurs erfolgreich zurückgezogen",
+        "events": "{count} Event erfolgreich zurückgezogen",
+        "degrees": "{count} Degree erfolgreich zurückgezogen"
+      },
+      "unpublished_success_plural": {
+        "courses": "{count} Kurse erfolgreich zurückgezogen",
+        "events": "{count} Events erfolgreich zurückgezogen",
+        "degrees": "{count} Degrees erfolgreich zurückgezogen"
+      },
+      "bulk_action_failed": {
+        "courses": "Die Massenaktion für die ausgewählten Kurse ist fehlgeschlagen. Bitte versuche es erneut.",
+        "events": "Die Massenaktion für die ausgewählten Events ist fehlgeschlagen. Bitte versuche es erneut.",
+        "degrees": "Die Massenaktion für die ausgewählten Degrees ist fehlgeschlagen. Bitte versuche es erneut."
+      },
       "attendance_certificate_update_failed": "Fehler beim Aktualisieren der Teilnahmebescheinigung-Einstellung",
       "achievement_certificate_update_failed": "Fehler beim Aktualisieren der Leistungsbescheinigung-Einstellung",
       "application_end_update_failed": "Fehler beim Aktualisieren des Bewerbungsendes",
-      "courses_copied_success_singular": "{count} Kurs erfolgreich in {programTitle} kopiert",
-      "courses_copied_success_plural": "{count} Kurse erfolgreich in {programTitle} kopiert"
+      "copied_success_singular": {
+        "courses": "{count} Kurs erfolgreich in {programTitle} kopiert",
+        "events": "{count} Event erfolgreich in {programTitle} kopiert",
+        "degrees": "{count} Degree erfolgreich in {programTitle} kopiert"
+      },
+      "copied_success_plural": {
+        "courses": "{count} Kurse erfolgreich in {programTitle} kopiert",
+        "events": "{count} Events erfolgreich in {programTitle} kopiert",
+        "degrees": "{count} Degrees erfolgreich in {programTitle} kopiert"
+      }
     }
   },
   "manageCourse": {
@@ -1913,7 +1972,7 @@
       "help_text": "Standard Formbricks Survey für Kurseinschreibungen. Kurse können dies mit ihrer eigenen Einschreibungs-Survey URL überschreiben."
     },
     "delete_button": {
-      "delete_program_confirmation": "Bist du sicher, dass du das Programm '{title}' löschen möchtest?",
+      "delete_program_confirmation": "Bist du sicher, dass du das Programm „{title}“ löschen möchtest?",
       "untitled_program": "Unbenanntes Programm"
     },
     "Certificates": {
@@ -1980,7 +2039,7 @@
       "programs_published_success_plural": "{count} Programme wurden erfolgreich veröffentlicht",
       "programs_unpublished_success_singular": "Programm wurde erfolgreich zurückgezogen",
       "programs_unpublished_success_plural": "{count} Programme wurden erfolgreich zurückgezogen",
-      "bulk_action_failed": "Massenaktion '{action}' ist fehlgeschlagen"
+      "bulk_action_failed": "Die Massenaktion ist fehlgeschlagen. Bitte versuche es erneut."
     }
   },
   "manageUsers": {
@@ -2613,7 +2672,7 @@
       "PAYMENT_RECEIPT": "Gesendet, wenn eine Rechnung für eine Kurs- oder Event-Anmeldung bezahlt wurde",
       "COURSE_CONTINUATION_INQUIRY": "Gesendet, wenn Teilnehmende so viele Termine versäumt haben, wie für den Kurs maximal erlaubt sind – mit der Bitte, keine weiteren Termine zu verpassen oder kurz Bescheid zu geben, falls sie nicht mehr teilnehmen möchten"
     },
-    "delete_confirmation": "Bist du sicher, dass du die E-Mail-Vorlage '{title}' löschen möchtest?",
+    "delete_confirmation": "Bist du sicher, dass du die E-Mail-Vorlage „{title}“ löschen möchtest?",
     "unknown_trigger": "Unbekannter Auslöser-Typ",
     "categories": {
       "all": "Alle",

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -1075,7 +1075,11 @@
       "program": "Program",
       "status": "Status",
       "email_templates": "Templates",
-      "has_custom_templates": "This course has custom email templates"
+      "has_custom_templates": {
+        "courses": "This course has custom email templates",
+        "events": "This event has custom email templates",
+        "degrees": "This degree has custom email templates"
+      }
     },
     "error_loading_programs": "The programs could not be loaded. Please try again later.",
     "empty_state": {
@@ -1087,7 +1091,11 @@
     "close": "Close",
     "cancel": "Cancel",
     "not_published": "Not Published",
-    "default_course_title": "Untitled Course",
+    "default_title": {
+      "courses": "Untitled Course",
+      "events": "Untitled Event",
+      "degrees": "Untitled Degree"
+    },
     "title": "Manage Courses",
     "all_programs": "All",
     "course_degree_title": {
@@ -1214,32 +1222,83 @@
     "add_event_button": "Add Event",
     "add_degree_button": "Add Degree",
     "delete_button": {
-      "delete_course_confirmation": "Are you sure you want to delete the course '{title}'?",
-      "untitled_course": "Untitled Course"
+      "delete_confirmation": {
+        "courses": "Are you sure you want to delete the course \"{title}\"?",
+        "events": "Are you sure you want to delete the event \"{title}\"?",
+        "degrees": "Are you sure you want to delete the degree \"{title}\"?"
+      }
     },
     "bulk_action": {
       "publish": "Publish Selected",
       "unpublish": "Unpublish Selected",
       "copy": "Copy to Program"
     },
-    "copy_courses_to_program_dialog": {
-      "title": "Copy Courses to Program",
-      "description": "Select the target program where the courses should be copied:",
-      "button": "Copy Courses"
+    "copy_to_program_dialog": {
+      "title": {
+        "courses": "Copy Courses to Program",
+        "events": "Copy Events to Program",
+        "degrees": "Copy Degrees to Program"
+      },
+      "description": {
+        "courses": "Select the target program where the courses should be copied:",
+        "events": "Select the target program where the events should be copied:",
+        "degrees": "Select the target program where the degrees should be copied:"
+      },
+      "button": {
+        "courses": "Copy Courses",
+        "events": "Copy Events",
+        "degrees": "Copy Degrees"
+      }
     },
     "notifications": {
-      "course_added_success": "Course added successfully",
-      "course_add_failed": "Failed to add course. Please try again.",
-      "courses_published_success_singular": "Successfully published {count} course",
-      "courses_published_success_plural": "Successfully published {count} courses",
-      "courses_unpublished_success_singular": "Successfully unpublished {count} course",
-      "courses_unpublished_success_plural": "Successfully unpublished {count} courses",
-      "bulk_action_failed": "Failed to {action} courses. Please try again.",
+      "added_success": {
+        "courses": "Course added successfully",
+        "events": "Event added successfully",
+        "degrees": "Degree added successfully"
+      },
+      "add_failed": {
+        "courses": "Failed to add course. Please try again.",
+        "events": "Failed to add event. Please try again.",
+        "degrees": "Failed to add degree. Please try again."
+      },
+      "published_success_singular": {
+        "courses": "Successfully published {count} course",
+        "events": "Successfully published {count} event",
+        "degrees": "Successfully published {count} degree"
+      },
+      "published_success_plural": {
+        "courses": "Successfully published {count} courses",
+        "events": "Successfully published {count} events",
+        "degrees": "Successfully published {count} degrees"
+      },
+      "unpublished_success_singular": {
+        "courses": "Successfully unpublished {count} course",
+        "events": "Successfully unpublished {count} event",
+        "degrees": "Successfully unpublished {count} degree"
+      },
+      "unpublished_success_plural": {
+        "courses": "Successfully unpublished {count} courses",
+        "events": "Successfully unpublished {count} events",
+        "degrees": "Successfully unpublished {count} degrees"
+      },
+      "bulk_action_failed": {
+        "courses": "The bulk action on the selected courses failed. Please try again.",
+        "events": "The bulk action on the selected events failed. Please try again.",
+        "degrees": "The bulk action on the selected degrees failed. Please try again."
+      },
       "attendance_certificate_update_failed": "Failed to update attendance certificate setting",
       "achievement_certificate_update_failed": "Failed to update achievement certificate setting",
       "application_end_update_failed": "Failed to update application end date",
-      "courses_copied_success_singular": "Successfully copied {count} course to {programTitle}",
-      "courses_copied_success_plural": "Successfully copied {count} courses to {programTitle}"
+      "copied_success_singular": {
+        "courses": "Successfully copied {count} course to {programTitle}",
+        "events": "Successfully copied {count} event to {programTitle}",
+        "degrees": "Successfully copied {count} degree to {programTitle}"
+      },
+      "copied_success_plural": {
+        "courses": "Successfully copied {count} courses to {programTitle}",
+        "events": "Successfully copied {count} events to {programTitle}",
+        "degrees": "Successfully copied {count} degrees to {programTitle}"
+      }
     }
   },
   "manageCourse": {
@@ -1928,7 +1987,7 @@
       "help_text": "Default Formbricks survey for course enrollments. Courses can override this with their own enrollment survey URL."
     },
     "delete_button": {
-      "delete_program_confirmation": "Are you sure you want to delete the program '{title}'?",
+      "delete_program_confirmation": "Are you sure you want to delete the program \"{title}\"?",
       "untitled_program": "Untitled Program"
     },
     "Certificates": {
@@ -1995,7 +2054,7 @@
       "programs_published_success_plural": "{count} programs were successfully published",
       "programs_unpublished_success_singular": "Program was successfully unpublished",
       "programs_unpublished_success_plural": "{count} programs were successfully unpublished",
-      "bulk_action_failed": "Bulk action '{action}' failed"
+      "bulk_action_failed": "The bulk action failed. Please try again."
     }
   },
   "manageUsers": {
@@ -2628,7 +2687,7 @@
       "PAYMENT_RECEIPT": "Sent when an invoice for a course or event enrollment is paid",
       "COURSE_CONTINUATION_INQUIRY": "Sent when a participant reaches the course's limit of missed sessions, asking them not to miss further sessions or to let the team know if they want to stop"
     },
-    "delete_confirmation": "Are you sure you want to delete the email template '{title}'?",
+    "delete_confirmation": "Are you sure you want to delete the email template \"{title}\"?",
     "unknown_trigger": "Unknown trigger type",
     "categories": {
       "all": "All",

--- a/frontend-nx/apps/edu-hub/locales/messages.test.ts
+++ b/frontend-nx/apps/edu-hub/locales/messages.test.ts
@@ -1,0 +1,81 @@
+import de from './de.json';
+import en from './en.json';
+
+type MessageTree = { [key: string]: string | MessageTree };
+
+const LOCALES: Array<[string, MessageTree]> = [
+  ['de', de as unknown as MessageTree],
+  ['en', en as unknown as MessageTree],
+];
+
+const flatten = (tree: MessageTree, prefix = ''): Array<[string, string]> =>
+  Object.entries(tree).flatMap(([key, value]) => {
+    const path = prefix ? `${prefix}.${key}` : key;
+    return typeof value === 'string' ? [[path, value] as [string, string]] : flatten(value, path);
+  });
+
+const resolve = (tree: MessageTree, path: string): string | MessageTree | undefined =>
+  path.split('.').reduce<string | MessageTree | undefined>((node, part) => {
+    if (typeof node !== 'object' || node === null) return undefined;
+    return node[part];
+  }, tree);
+
+describe.each(LOCALES)('%s.json', (_locale, messages) => {
+  // In ICU message syntax an apostrophe directly in front of a placeholder escapes it, so
+  // "the course '{title}'" renders the literal text {title} instead of the course title.
+  it('does not escape placeholders with an apostrophe', () => {
+    const escaped = flatten(messages)
+      .filter(([, message]) => message.includes("'{"))
+      .map(([path]) => path);
+
+    expect(escaped).toEqual([]);
+  });
+});
+
+// The manage courses/events/degrees pages share ManageCoursesContent and select the wording
+// variant matching their program type, so every variant has to exist in both locales.
+describe.each(LOCALES)('manageCourses messages in %s.json', (_locale, messages) => {
+  const PROGRAM_TYPES = ['courses', 'events', 'degrees'];
+
+  const PROGRAM_TYPE_AWARE_KEYS = [
+    'table_header.has_custom_templates',
+    'default_title',
+    'delete_button.delete_confirmation',
+    'empty_state',
+    'copy_to_program_dialog.title',
+    'copy_to_program_dialog.description',
+    'copy_to_program_dialog.button',
+    'notifications.added_success',
+    'notifications.add_failed',
+    'notifications.published_success_singular',
+    'notifications.published_success_plural',
+    'notifications.unpublished_success_singular',
+    'notifications.unpublished_success_plural',
+    'notifications.bulk_action_failed',
+    'notifications.copied_success_singular',
+    'notifications.copied_success_plural',
+  ];
+
+  it.each(PROGRAM_TYPE_AWARE_KEYS)('has one %s variant per program type', (key) => {
+    const group = resolve(messages.manageCourses as MessageTree, key);
+
+    expect(group).toBeDefined();
+    expect(Object.keys(group as MessageTree).sort()).toEqual([...PROGRAM_TYPES].sort());
+    for (const programType of PROGRAM_TYPES) {
+      expect(typeof (group as MessageTree)[programType]).toBe('string');
+    }
+  });
+
+  it.each(PROGRAM_TYPES)('keeps the title placeholder in the %s deletion confirmation', (programType) => {
+    const group = resolve(messages.manageCourses as MessageTree, 'delete_button.delete_confirmation') as MessageTree;
+
+    expect(group[programType]).toContain('{title}');
+  });
+
+  it.each(PROGRAM_TYPES)('keeps count and program placeholders in the %s copy notification', (programType) => {
+    const group = resolve(messages.manageCourses as MessageTree, 'notifications.copied_success_plural') as MessageTree;
+
+    expect(group[programType]).toContain('{count}');
+    expect(group[programType]).toContain('{programTitle}');
+  });
+});


### PR DESCRIPTION
## Bug 1 — the deletion dialog showed `{title}` literally

`manageCourses.delete_button.delete_course_confirmation` wrapped the placeholder in ASCII apostrophes:

```
"Bist du sicher, dass du den Kurs '{title}' löschen möchtest?"
```

next-intl parses messages as ICU, where an apostrophe directly in front of `{` **escapes** the placeholder — so the dialog rendered the literal text `{title}`. The same mistake existed in three more messages, all fixed here:

| key | page |
| --- | --- |
| `manageCourses.delete_button.delete_course_confirmation` | manage courses / events / degrees |
| `managePrograms.delete_button.delete_program_confirmation` | manage programs |
| `managePrograms.notifications.bulk_action_failed` | manage programs |
| `manageEmailTemplates.delete_confirmation` | email templates |

German now uses `„{title}“`, English `"{title}"`.

## Bug 2 — manage events / manage degrees still said "Kurs"

`/manage/events` and `/manage/degrees` render the same `ManageCoursesContent` with a different `programType`, but only the headline, the add button and the empty state were program-type aware. Every dialog, snackbar and tooltip still talked about courses.

Each of these `manageCourses` messages now has a `courses` / `events` / `degrees` variant, picked through the new shared `programTypeMessageKey` helper (which `ProgramManagementDashboard` also reuses for the existing `empty_state` keys):

- `delete_button.delete_confirmation` — the reported dialog
- `default_title` — title of a newly added element and the title-column placeholder (replaces `default_course_title` and the duplicate `delete_button.untitled_course`)
- `notifications.added_success` / `add_failed`
- `notifications.published_success_*` / `unpublished_success_*`
- `notifications.copied_success_*`
- `notifications.bulk_action_failed`
- `copy_to_program_dialog.title` / `description` / `button` (renamed from `copy_courses_to_program_dialog`)
- `table_header.has_custom_templates` tooltip

German follows the wording already visible on those pages — "Event" and "Degree", matching the headlines and the add buttons — rather than introducing "Veranstaltung"/"Studiengang".

## Also fixed

Both `bulk_action_failed` messages interpolated the raw English action id, so a failed bulk publish read *"Fehler beim publish der Kurse"*. They no longer name the action.

## Not covered

The form labels and help texts inside the expandable detail row (`ects.help_text`, `registration_type.help_text`, `learning_goals.help_text`, `instructors.label`, `project_options.*`, `cover_image.alt`, …) still say "Kurs"/"course" on all three pages. They are labels rather than messages and `ExpandableCourseRow` does not receive `programType`, so rewording them is a larger, separate change. `empty_state.*` keeps its existing "Veranstaltung"/"Studiengang" wording, which is now the only place on these pages using those terms.

## Verification

- `apps/edu-hub/locales/messages.test.ts` (new, 46 cases): guards that no message escapes a placeholder with an apostrophe in either locale file — the exact bug above — and that every program-type-aware key has all three variants with their placeholders intact.
- Full frontend suite: 224 tests, 22 suites, all passing.
- `tsc --noEmit` and `eslint` clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
