### PR TITLE
feat(stripe): describe what was sold in the payment list

### DIFF
--- a/functions/callNodeFunction/__tests__/stripeTax.test.js
+++ b/functions/callNodeFunction/__tests__/stripeTax.test.js
@@ -1,4 +1,8 @@
-import { buildPaymentMethodConfig } from '../lib/stripeTax.js';
+import {
+  buildPaymentMethodConfig,
+  buildCoursePaymentDescription,
+  buildJobPostingPaymentDescription,
+} from '../lib/stripeTax.js';
 
 describe('buildPaymentMethodConfig', () => {
   it('offers card and SEPA debit, and lets Stripe create the customer when there is no email', () => {
@@ -30,5 +34,52 @@ describe('buildPaymentMethodConfig', () => {
     first.payment_method_types.push('klarna');
 
     expect(buildPaymentMethodConfig().payment_method_types).toEqual(['card', 'sepa_debit']);
+  });
+});
+
+describe('buildCoursePaymentDescription', () => {
+  it('names the app, the selling organization, the title and the program type', () => {
+    expect(buildCoursePaymentDescription('COURSES', 'Design Thinking', 'opencampus')).toBe(
+      'EduHub opencampus Design Thinking (Kurs)'
+    );
+  });
+
+  it.each([
+    ['EVENTS', 'EduHub opencampus Demo Day (Event)'],
+    ['DEGREES', 'EduHub opencampus Demo Day (Degree)'],
+  ])('translates the %s program type', (programType, expected) => {
+    expect(buildCoursePaymentDescription(programType, 'Demo Day', 'opencampus')).toBe(expected);
+  });
+
+  it('falls back to the raw enum for a program type added later', () => {
+    expect(buildCoursePaymentDescription('BOOTCAMPS', 'Demo Day', 'opencampus')).toBe(
+      'EduHub opencampus Demo Day (BOOTCAMPS)'
+    );
+  });
+
+  it('drops missing parts instead of printing null', () => {
+    expect(buildCoursePaymentDescription(null, 'Design Thinking', null)).toBe(
+      'EduHub Design Thinking'
+    );
+  });
+
+  it('shortens a long title but keeps the program type visible', () => {
+    const description = buildCoursePaymentDescription('COURSES', 'x'.repeat(200), 'opencampus');
+    expect(description.startsWith('EduHub opencampus xxx')).toBe(true);
+    expect(description.endsWith('\u2026 (Kurs)')).toBe(true);
+  });
+});
+
+describe('buildJobPostingPaymentDescription', () => {
+  it('uses the same shape as the course description', () => {
+    expect(buildJobPostingPaymentDescription('Werkstudent Frontend', 'ACME GmbH')).toBe(
+      'StuJo ACME GmbH Werkstudent Frontend (Stellenanzeige)'
+    );
+  });
+
+  it('stays readable when the posting has no organization name', () => {
+    expect(buildJobPostingPaymentDescription('Werkstudent Frontend', null)).toBe(
+      'StuJo Werkstudent Frontend (Stellenanzeige)'
+    );
   });
 });

--- a/functions/callNodeFunction/__tests__/stripeTax.test.js
+++ b/functions/callNodeFunction/__tests__/stripeTax.test.js
@@ -63,10 +63,9 @@ describe('buildCoursePaymentDescription', () => {
     );
   });
 
-  it('shortens a long title but keeps the program type visible', () => {
+  it('shortens a long title to 120 characters but keeps the program type visible', () => {
     const description = buildCoursePaymentDescription('COURSES', 'x'.repeat(200), 'opencampus');
-    expect(description.startsWith('EduHub opencampus xxx')).toBe(true);
-    expect(description.endsWith('\u2026 (Kurs)')).toBe(true);
+    expect(description).toBe(`EduHub opencampus ${'x'.repeat(119)}\u2026 (Kurs)`);
   });
 });
 

--- a/functions/callNodeFunction/createStripeCheckout/index.js
+++ b/functions/callNodeFunction/createStripeCheckout/index.js
@@ -6,6 +6,7 @@ import {
   buildInvoiceCreation,
   buildPaymentMethodConfig,
   getOrCreateCustomer,
+  buildCoursePaymentDescription,
 } from '../lib/stripeTax.js';
 
 const GET_COURSE_AND_ADDONS = `
@@ -18,6 +19,7 @@ const GET_COURSE_AND_ADDONS = `
       stripeProductId
       stripePriceId
       Program {
+        type
         Organization {
           id
           name
@@ -528,6 +530,13 @@ export default async function createStripeCheckout(req, logger) {
         })()
       },
       payment_intent_data: {
+        // Without this Stripe shows the PaymentIntent id in the dashboard's
+        // payment list instead of what was sold.
+        description: buildCoursePaymentDescription(
+          course.Program?.type || null,
+          course.title || null,
+          organization?.name || null
+        ),
         metadata: {
           courseId: String(courseId),
           courseName: course.title || '',

--- a/functions/callNodeFunction/lib/stripeTax.js
+++ b/functions/callNodeFunction/lib/stripeTax.js
@@ -76,6 +76,68 @@ export function buildInvoiceCreation(organization) {
 }
 
 /**
+ * Readable label per ProgramType enum value for the payment description.
+ * An unknown value falls through to the raw enum rather than vanishing,
+ * so a program type added later still shows something useful.
+ */
+const PROGRAM_TYPE_LABELS = {
+  COURSES: 'Kurs',
+  EVENTS: 'Event',
+  DEGREES: 'Degree',
+};
+
+// Stripe accepts long descriptions, but the dashboard's payment list is one
+// line — keep the title short enough that the organization stays visible.
+const TITLE_MAX_LENGTH = 120;
+
+function shortenTitle(title) {
+  if (!title) {
+    return null;
+  }
+  return title.length > TITLE_MAX_LENGTH ? `${title.slice(0, TITLE_MAX_LENGTH - 1)}\u2026` : title;
+}
+
+/**
+ * App, then seller, then what was bought, with the kind of offering in
+ * brackets at the end. Missing parts drop out rather than printing null.
+ */
+function buildDescription(app, organizationName, title, typeLabel) {
+  const text = [app, organizationName, shortenTitle(title)].filter(Boolean).join(' ');
+  return typeLabel ? `${text} (${typeLabel})` : text;
+}
+
+/**
+ * Description for a course/event/degree enrollment payment, e.g.
+ * "EduHub opencampus Design Thinking (Kurs)".
+ *
+ * Without a description Stripe prints the PaymentIntent id in the
+ * dashboard's payment list, which is unreadable next to the other
+ * integrations settling on the same account.
+ *
+ * @param {string|null} programType - Program.type (COURSES, EVENTS, DEGREES)
+ * @param {string|null} title - course title
+ * @param {string|null} organizationName - selling organization
+ * @returns {string}
+ */
+export function buildCoursePaymentDescription(programType, title, organizationName) {
+  const label = PROGRAM_TYPE_LABELS[programType] || programType || null;
+  return buildDescription('EduHub', organizationName, title, label);
+}
+
+/**
+ * Description for a StuJo job posting payment, e.g.
+ * "StuJo ACME GmbH Werkstudent Frontend (Stellenanzeige)" — same shape as
+ * the course one so the dashboard's payment list scans consistently.
+ *
+ * @param {string|null} title - posting title
+ * @param {string|null} organizationName - posting organization
+ * @returns {string}
+ */
+export function buildJobPostingPaymentDescription(title, organizationName) {
+  return buildDescription('StuJo', organizationName, title, 'Stellenanzeige');
+}
+
+/**
  * Finds (by email) or creates the Stripe Customer for a checkout, so
  * repeat purchases attach to one customer record and its invoices stay
  * together, instead of customer_creation minting a new one each time.

--- a/functions/callNodeFunction/publishJobPosting/index.js
+++ b/functions/callNodeFunction/publishJobPosting/index.js
@@ -3,6 +3,7 @@ import { GraphQLClient, gql } from 'graphql-request';
 
 import {
   buildInvoiceCreation,
+  buildJobPostingPaymentDescription,
   buildPaymentMethodConfig,
   getOrCreateCustomer,
   getOrCreateTaxRate,
@@ -405,6 +406,12 @@ export default async function publishJobPosting(req, logger) {
         source: 'stujo',
       },
       payment_intent_data: {
+        // Without this Stripe shows the PaymentIntent id in the dashboard's
+        // payment list instead of what was sold.
+        description: buildJobPostingPaymentDescription(
+          posting.title || null,
+          posting.Organization?.name || null
+        ),
         metadata: {
           jobPostingId: String(posting.id),
           organizationId: String(posting.organizationId),


### PR DESCRIPTION
## Problem

Neither Stripe checkout flow set `payment_intent_data.description`, so Stripe falls back to printing the PaymentIntent id in the dashboard's **Transaktionen → Beschreibung** column. The first live EduHub payment shows up as `pi_3U9MHEFesUe3q8Zi1YgFR5vE`, sitting next to readable rows from the other integrations that settle on the same `opencampus` account ("INSTAGRIP YOGAMATTE Motiv:blau", …).

## Change

Both flows now send a description built from data they already load:

```
EduHub opencampus Design Thinking (Kurs)
StuJo ACME GmbH Werkstudent Frontend (Stellenanzeige)
```

App, seller, what was bought, kind of offering in brackets at the end.

- `buildCoursePaymentDescription` / `buildJobPostingPaymentDescription` in `functions/callNodeFunction/lib/stripeTax.js`, sharing one assembler so both lists scan the same way.
- `ProgramType` is translated to a readable label (`COURSES` → Kurs, `EVENTS` → Event, `DEGREES` → Degree). An unrecognised value falls through to the raw enum, so a program type added later still shows something instead of vanishing.
- Missing parts drop out rather than printing `null`; a long title is shortened so the type stays visible.
- The course flow needed `Program.type` added to `GET_COURSE_AND_ADDONS`. Both flows query with the Hasura admin secret, so no permission change is needed. The job posting flow already loaded `title` and `Organization.name`.

This is dashboard/ops-facing only. The customer-facing invoice memo (`invoice_creation.invoice_data.description`) is deliberately left unset — the line items already name the product.

## Tests

Eight new cases in `__tests__/stripeTax.test.js` covering both builders: the happy path, each program type label, the unknown-enum fallback, missing organization/type, and title shortening. `stripeTax.test.js` is 13/13 green; the full `callNodeFunction` suite is 178/178.

`__tests__/matrixRoomUtils.test.js` still fails at suite level ("Your test suite must contain at least one test") — it is a `node:test` file that Jest picks up. Pre-existing on `develop` and untouched here.

## Follow-up

Unrelated to this PR, but found while looking at the same dashboard: Stripe's own invoice numbering scheme is worth settling now, while only one invoice exists. See the discussion in #1889's neighbourhood — no issue filed yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Stripe payment records now display clear, human-readable descriptions for course purchases and paid job postings.
  * Course descriptions include the program type, course title, and organization name where available.
  * Job posting descriptions include the posting title and organization name where available.
  * Long course titles are shortened automatically, while missing details are omitted gracefully.
* **Tests**
  * Added coverage for translated and unknown program types, missing information, and title truncation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->