### PR TITLE
feat(stujo): send the invoice with the job posting confirmation

### DIFF
--- a/backend/metadata/actions.graphql
+++ b/backend/metadata/actions.graphql
@@ -688,7 +688,7 @@ type CourseAddonMapping {
 
 
 type Mutation {
-  publishJobPosting(jobPostingId: Int!): PublishJobPostingResult!
+  publishJobPosting(jobPostingId: Int!, acceptTerms: Boolean): PublishJobPostingResult!
 }
 
 type Mutation {

--- a/backend/metadata/cron_triggers.yaml
+++ b/backend/metadata/cron_triggers.yaml
@@ -135,3 +135,27 @@
     - name: Hasura-Secret
       value_from_env: HASURA_CLOUD_FUNCTION_SECRET
   comment: Enforces the guest data retention period - anonymizes guests whose events all ended more than AppSettings.guestDataRetentionMonths ago, and deletes signups that were never confirmed (GDPR Art. 5(1)(e))
+- name: send_pending_job_posting_mails
+  webhook: '{{CLOUD_FUNCTION_LINK_CALL_NODE_FUNCTION}}'
+  schedule: '*/15 * * * *'
+  include_in_metadata: true
+  payload: {}
+  retry_conf:
+    num_retries: 0
+    retry_interval_seconds: 10
+    timeout_seconds: 3699
+    tolerance_seconds: 21600
+  headers:
+    - name: name
+      value: sendPendingJobPostingMails
+    - name: secret
+      value_from_env: HASURA_CLOUD_FUNCTION_SECRET
+  comment: >-
+    Backstop for the StuJo job posting confirmation mail, which carries the
+    invoice PDF and is therefore held until Stripe finalizes the invoice.
+    Normally sent at checkout.session.completed or on invoice.finalized; this
+    sweep covers the case where neither fired (most plausibly because
+    invoice.finalized is not enabled on the Stripe endpoint), so an employer
+    never pays without hearing anything. Note the headers differ from the Python
+    crons - callNodeFunction dispatches on name/secret, not
+    Function-Name/Hasura-Secret.

--- a/backend/metadata/databases/default/tables/public_AppSettings.yaml
+++ b/backend/metadata/databases/default/tables/public_AppSettings.yaml
@@ -24,6 +24,7 @@ select_permissions:
         - privacyUrl
         - secondaryColor
         - showFaqSection
+        - termsUrl
         - timeZone
         - updated_at
       filter: {}

--- a/backend/metadata/databases/default/tables/public_Invoice.yaml
+++ b/backend/metadata/databases/default/tables/public_Invoice.yaml
@@ -35,6 +35,7 @@ select_permissions:
         - stripeHostedInvoiceUrl
         - stripeInvoicePdfUrl
         - stripeInvoiceId
+        - stripeInvoiceNumber
         - updated_at
         - userId
         - vatTotal
@@ -59,6 +60,7 @@ select_permissions:
         - stripeHostedInvoiceUrl
         - stripeInvoicePdfUrl
         - stripeInvoiceId
+        - stripeInvoiceNumber
         - updated_at
         - userId
         - vatTotal
@@ -88,6 +90,7 @@ select_permissions:
         - stripeHostedInvoiceUrl
         - stripeInvoicePdfUrl
         - stripeInvoiceId
+        - stripeInvoiceNumber
         - updated_at
         - userId
         - vatTotal

--- a/backend/metadata/databases/default/tables/public_JobPosting.yaml
+++ b/backend/metadata/databases/default/tables/public_JobPosting.yaml
@@ -156,6 +156,7 @@ select_permissions:
         - contactUserId
         - type
         - status
+        - termsAcceptedAt
         - region
         - occupation
         - title

--- a/backend/migrations/default/1788200000000_alter_table_public_MailLog_add_column_attachments/down.sql
+++ b/backend/migrations/default/1788200000000_alter_table_public_MailLog_add_column_attachments/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."MailLog" DROP COLUMN IF EXISTS "attachments";

--- a/backend/migrations/default/1788200000000_alter_table_public_MailLog_add_column_attachments/up.sql
+++ b/backend/migrations/default/1788200000000_alter_table_public_MailLog_add_column_attachments/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."MailLog" ADD COLUMN "attachments" jsonb NULL;
+
+COMMENT ON COLUMN "public"."MailLog"."attachments" IS E'Array of file descriptors the send-mail function fetches over HTTPS and attaches, e.g. [{"url": "https://invoice.stripe.com/.../pdf", "filename": "rechnung-A1B2-0001.pdf", "contentType": "application/pdf"}]. Never stores file bytes. Only admin-secret code writes MailLog, and send-mail additionally restricts fetches to an allowlist of hosts. A fetch failure degrades to sending the mail without the attachment.';

--- a/backend/migrations/default/1788200000001_update_job_posting_published_mail_template/down.sql
+++ b/backend/migrations/default/1788200000001_update_job_posting_published_mail_template/down.sql
@@ -1,0 +1,8 @@
+UPDATE "public"."MailTemplateType"
+SET "comment" = 'Sent to the employer contact when a job posting is published'
+WHERE "value" = 'JOB_POSTING_PUBLISHED';
+
+UPDATE "public"."MailTemplate"
+SET "subject" = 'Dein Stellenangebot ist online: [JobPosting:Title]',
+    "content" = '<p>Hallo,</p><p>Dein Stellenangebot <b>[JobPosting:Title]</b> ist jetzt veröffentlicht und bis zum <b>[JobPosting:ExpiresAt]</b> auf allen StuJo-Portalen sichtbar.</p><p>Du kannst Dein Angebot jederzeit unter <a href="[JobPosting:DashboardUrl]">Mein StuJo</a> bearbeiten oder archivieren.</p><p>Viel Erfolg bei der Suche!<br>Dein StuJo-Team</p>'
+WHERE "type" = 'JOB_POSTING_PUBLISHED' AND "courseId" IS NULL;

--- a/backend/migrations/default/1788200000001_update_job_posting_published_mail_template/up.sql
+++ b/backend/migrations/default/1788200000001_update_job_posting_published_mail_template/up.sql
@@ -1,0 +1,49 @@
+-- The publish confirmation becomes the single transactional mail for a StuJo
+-- posting: confirmation + payment receipt + invoice (the PDF is attached via
+-- MailLog.attachments) + the reference to the terms.
+--
+-- The invoice section is wrapped in a [#if:Invoice] block so one template also
+-- serves free (MINIJOB) and credit-funded postings, which have no invoice at
+-- all. See applyConditionalBlocks in
+-- frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts.
+--
+-- Uses <ul>/<li> rather than <table>: the admin editor sanitises content with
+-- DOMPurify (EmailEditor.tsx) and would silently strip tables on save.
+--
+-- Only the default template (courseId IS NULL) is touched; per-course
+-- overrides do not exist for job postings.
+
+UPDATE "public"."MailTemplateType"
+SET "comment" = 'Sent to the employer contact when a job posting is published; carries the payment receipt, the invoice number and the invoice PDF as an attachment. Conditional blocks: [#if:Invoice] wraps the whole invoice section, [#if:InvoicePdf] the attachment sentence, [#if:InvoiceLink] the online link, [#if:InvoicePending] the fallback when neither exists yet, [#if:TermsAccepted] the consent date'
+WHERE "value" = 'JOB_POSTING_PUBLISHED';
+
+UPDATE "public"."MailTemplate"
+SET "subject" = 'Dein Stellenangebot ist online: [JobPosting:Title]',
+    "content" = '<p>Hallo,</p>
+<p>Dein Stellenangebot <strong>[JobPosting:Title]</strong> ist seit dem [JobPosting:PublishedAt] veröffentlicht und bis zum <strong>[JobPosting:ExpiresAt]</strong> auf allen StuJo-Portalen sichtbar.</p>
+<h3>Dein Angebot</h3>
+<ul>
+<li>Titel: <strong>[JobPosting:Title]</strong></li>
+<li>Kategorie: [JobPosting:Type]</li>
+<li>Unternehmen: [Organization:Name]</li>
+<li>Online bis: [JobPosting:ExpiresAt]</li>
+</ul>
+<h3>Zahlung</h3>
+<p>[JobPosting:Payment]</p>
+[#if:Invoice]<h3>Deine Rechnung</h3>
+<ul>
+<li>Rechnungsnummer: <strong>[Invoice:Number]</strong></li>
+<li>Rechnungsdatum: [Invoice:Date]</li>
+<li>Nettobetrag: [Invoice:NetTotal]</li>
+<li>zzgl. [Invoice:VatRate] % MwSt.: [Invoice:VatTotal]</li>
+<li>Gesamtbetrag: <strong>[Invoice:GrossTotal]</strong></li>
+<li>Status: [Invoice:PaymentStatus]</li>
+</ul>
+[#if:InvoicePdf]<p>Die Rechnung liegt dieser E-Mail als PDF bei.</p>
+[/if:InvoicePdf][#if:InvoiceLink]<p>Du kannst sie jederzeit online abrufen: <a href="[Invoice:HostedUrl]">Rechnung ansehen</a></p>
+[/if:InvoiceLink][#if:InvoicePending]<p>Das Rechnungsdokument stellen wir Dir in Kürze separat zu.</p>
+[/if:InvoicePending][/if:Invoice]<p>Dein Angebot bearbeiten oder archivieren kannst Du jederzeit unter <a href="[JobPosting:DashboardUrl]">Mein StuJo</a>.</p>
+<p>Viel Erfolg bei der Suche!<br>Dein StuJo-Team</p>
+<hr>
+<p><span style="font-size:0.85em;color:#666;">Es gelten unsere <a href="[Legal:TermsUrl]">Allgemeinen Geschäftsbedingungen</a>[#if:TermsAccepted], denen Du am [JobPosting:TermsAcceptedAt] bei der Veröffentlichung zugestimmt hast[/if:TermsAccepted].</span></p>'
+WHERE "type" = 'JOB_POSTING_PUBLISHED' AND "courseId" IS NULL;

--- a/backend/migrations/default/1788200000002_alter_table_public_JobPosting_add_column_termsAcceptedAt/down.sql
+++ b/backend/migrations/default/1788200000002_alter_table_public_JobPosting_add_column_termsAcceptedAt/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."JobPosting" DROP COLUMN IF EXISTS "termsAcceptedAt";

--- a/backend/migrations/default/1788200000002_alter_table_public_JobPosting_add_column_termsAcceptedAt/up.sql
+++ b/backend/migrations/default/1788200000002_alter_table_public_JobPosting_add_column_termsAcceptedAt/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."JobPosting" ADD COLUMN "termsAcceptedAt" timestamptz NULL;
+
+COMMENT ON COLUMN "public"."JobPosting"."termsAcceptedAt" IS 'When the employer accepted the terms at the point of purchase. Server-controlled: written by the publishJobPosting action only, never by the client, because a forgeable or backdatable timestamp would not evidence anything. Which version of the terms was accepted is recovered from the git history of the terms page, as described in docs/LEGAL_DOCUMENTS.md.';

--- a/backend/migrations/default/1788200000003_alter_table_public_AppSettings_add_column_termsUrl/down.sql
+++ b/backend/migrations/default/1788200000003_alter_table_public_AppSettings_add_column_termsUrl/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."AppSettings" DROP COLUMN IF EXISTS "termsUrl";

--- a/backend/migrations/default/1788200000003_alter_table_public_AppSettings_add_column_termsUrl/up.sql
+++ b/backend/migrations/default/1788200000003_alter_table_public_AppSettings_add_column_termsUrl/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."AppSettings" ADD COLUMN "termsUrl" text NULL;
+
+COMMENT ON COLUMN "public"."AppSettings"."termsUrl" IS 'Terms and conditions (AGB) URL for this white-label portal, shown in the footer and next to the paid-publish button. Null falls back to the StuJo default, matching how imprintUrl and privacyUrl behave.';

--- a/backend/migrations/default/1788200000004_alter_table_public_Invoice_add_column_stripeInvoiceNumber/down.sql
+++ b/backend/migrations/default/1788200000004_alter_table_public_Invoice_add_column_stripeInvoiceNumber/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "public"."Invoice" DROP COLUMN IF EXISTS "stripeInvoiceNumber";

--- a/backend/migrations/default/1788200000004_alter_table_public_Invoice_add_column_stripeInvoiceNumber/up.sql
+++ b/backend/migrations/default/1788200000004_alter_table_public_Invoice_add_column_stripeInvoiceNumber/up.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."Invoice" ADD COLUMN "stripeInvoiceNumber" text NULL;
+
+COMMENT ON COLUMN "public"."Invoice"."stripeInvoiceNumber" IS 'Stripe''s sequential invoice document number (e.g. VGD1VIPO-0001) as printed on the invoice PDF. Distinct from "invoiceNumber" (our own internal record key, prefix + checkout session) and from "stripeInvoiceId" (the in_... object reference). Null while the Stripe invoice is still a draft, because Stripe assigns the number on finalization.';

--- a/backend/migrations/default/1788200000005_add_MailLog_job_posting_dedup_index/down.sql
+++ b/backend/migrations/default/1788200000005_add_MailLog_job_posting_dedup_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS "public"."MailLog_job_posting_mail_unique";

--- a/backend/migrations/default/1788200000005_add_MailLog_job_posting_dedup_index/up.sql
+++ b/backend/migrations/default/1788200000005_add_MailLog_job_posting_dedup_index/up.sql
@@ -1,0 +1,12 @@
+-- The job posting confirmation can be queued from three places: the Stripe
+-- checkout webhook, the invoice.finalized webhook and the sweep. Each checks
+-- MailLog before inserting, but that is a read followed by a write: two
+-- deliveries arriving together can both pass the check and the employer gets
+-- the same mail twice, attachment and all.
+--
+-- Let the database decide instead. Partial, so it constrains only rows that
+-- carry a job posting dedup key and leaves every other mail alone.
+
+CREATE UNIQUE INDEX "MailLog_job_posting_mail_unique"
+  ON "public"."MailLog" ((metadata ->> 'type'), (metadata ->> 'jobPostingId'))
+  WHERE metadata ? 'jobPostingId';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,15 @@ services:
       # not the production fallback in stujoBaseUrl.ts.
       NEXT_PUBLIC_STUJO_URL: http://localhost:5001
       NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL: ${NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL:-}
+      # The Stripe webhook route lives in this app (pages/api/webhooks/stripe.ts),
+      # so it needs the keys too -- without them `stripe listen --forward-to
+      # localhost:5000/api/webhooks/stripe` (docs/STRIPE_INTEGRATION.md) only
+      # ever gets "Stripe not configured".
+      STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
+      STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
+      STUJO_FRONTEND_URL: ${STUJO_FRONTEND_URL:-http://localhost:5001}
+      STUJO_TERMS_URL: ${STUJO_TERMS_URL:-https://www.stujo.net/agb}
+      STUJO_ADMIN_EMAIL: ${STUJO_ADMIN_EMAIL:-}
       MM_URL: ${MM_URL:-https://chat.opencampus.sh}
       # Enable file watching in Docker environment
       CHOKIDAR_USEPOLLING: "true"
@@ -95,6 +104,7 @@ services:
       FORMBRICKS_API_KEY: ${FORMBRICKS_API_KEY:-}
       FORMBRICKS_API_URL: ${FORMBRICKS_API_URL:-https://app.formbricks.com}
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
+      STUJO_TERMS_URL: ${STUJO_TERMS_URL:-https://www.stujo.net/agb}
       MATRIX_HOMESERVER_URL: ${MATRIX_HOMESERVER_URL:-}
       MATRIX_SERVER_NAME: ${MATRIX_SERVER_NAME:-}
       MATRIX_ELEMENT_CLIENT_URL: ${MATRIX_ELEMENT_CLIENT_URL:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
       STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
       STUJO_FRONTEND_URL: ${STUJO_FRONTEND_URL:-http://localhost:5001}
-      STUJO_TERMS_URL: ${STUJO_TERMS_URL:-https://www.stujo.net/agb}
+      STUJO_TERMS_URL: ${STUJO_TERMS_URL:-}
       STUJO_ADMIN_EMAIL: ${STUJO_ADMIN_EMAIL:-}
       MM_URL: ${MM_URL:-https://chat.opencampus.sh}
       # Enable file watching in Docker environment
@@ -104,7 +104,7 @@ services:
       FORMBRICKS_API_KEY: ${FORMBRICKS_API_KEY:-}
       FORMBRICKS_API_URL: ${FORMBRICKS_API_URL:-https://app.formbricks.com}
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
-      STUJO_TERMS_URL: ${STUJO_TERMS_URL:-https://www.stujo.net/agb}
+      STUJO_TERMS_URL: ${STUJO_TERMS_URL:-}
       MATRIX_HOMESERVER_URL: ${MATRIX_HOMESERVER_URL:-}
       MATRIX_SERVER_NAME: ${MATRIX_SERVER_NAME:-}
       MATRIX_ELEMENT_CLIENT_URL: ${MATRIX_ELEMENT_CLIENT_URL:-}

--- a/docs/STRIPE_INTEGRATION.md
+++ b/docs/STRIPE_INTEGRATION.md
@@ -110,8 +110,18 @@ EduHub integrates with [Stripe](https://stripe.com) to handle course enrollment 
    - Select events to listen for:
      - `checkout.session.completed`
      - `checkout.session.expired`
+     - `checkout.session.async_payment_succeeded`
+     - `checkout.session.async_payment_failed`
      - `payment_intent.payment_failed`
+     - `invoice.finalized`
    - Click **Add endpoint**
+
+   > **`invoice.finalized` is required for StuJo job postings.** Their
+   > confirmation mail carries the invoice PDF, and Stripe finalizes
+   > `invoice_creation` invoices asynchronously, so the PDF often does not exist
+   > yet at `checkout.session.completed`. Without this event the mail falls
+   > through to the `send_pending_job_posting_mails` cron sweep and arrives up to
+   > ~30 minutes late. Nothing fails loudly if you forget it, so check it here.
 
 2. **Get Webhook Signing Secret**:
    - Click on your newly created webhook endpoint
@@ -135,7 +145,10 @@ EduHub integrates with [Stripe](https://stripe.com) to handle course enrollment 
    - Select the same events as staging:
      - `checkout.session.completed`
      - `checkout.session.expired`
+     - `checkout.session.async_payment_succeeded`
+     - `checkout.session.async_payment_failed`
      - `payment_intent.payment_failed`
+     - `invoice.finalized`
    - Click **Add endpoint**
 
 3. **Get Live Webhook Signing Secret**:
@@ -199,9 +212,27 @@ To configure Stripe for staging/production:
    - Triggered when a checkout session expires without payment
    - Updates enrollment: `paymentStatus = FAILED`
 
-3. **`payment_intent.payment_failed`**
+3. **`checkout.session.async_payment_succeeded`**
+   - Delayed payment method (SEPA direct debit) settled
+   - Course: enrollment confirmed. Job posting: invoice `ISSUED` -> `PAID`
+
+4. **`checkout.session.async_payment_failed`**
+   - Delayed payment failed after the fact
+   - Job posting: taken offline (`DRAFT`), invoice `CANCELLED`, employer notified
+
+5. **`payment_intent.payment_failed`**
    - Triggered when a payment attempt fails
    - Updates enrollment: `paymentStatus = FAILED`
+
+6. **`invoice.finalized`**
+   - Stripe has assigned the invoice its document number and rendered the PDF
+   - Backfills `Invoice.stripeInvoiceNumber` / `stripeInvoicePdfUrl` /
+     `stripeHostedInvoiceUrl`
+   - For job postings, releases the confirmation mail with the PDF attached if
+     it was not already sent at checkout time. Handled by
+     `handleJobPostingInvoiceFinalized` in `lib/stripeJobPosting.ts`; the
+     `send_pending_job_posting_mails` cron is the backstop when this event never
+     arrives.
 
 ### Webhook Security
 

--- a/frontend-nx/apps/edu-hub/components/inputs/EmailEditor.tsx
+++ b/frontend-nx/apps/edu-hub/components/inputs/EmailEditor.tsx
@@ -43,11 +43,20 @@ export function getTemplateCategory(templateType?: string): string {
   ];
   const generalTemplates = ['USER_CREATED'];
   const organizerTemplates = ['ORGANIZER_ADDED'];
+  // StuJo job board mails address employers, not participants, so none of the
+  // enrollment placeholders apply to them.
+  const jobPostingTemplates = [
+    'JOB_POSTING_PUBLISHED',
+    'JOB_POSTING_EXPIRED',
+    'JOB_POSTING_ADMIN_NOTICE',
+    'JOB_POSTING_PAYMENT_FAILED',
+  ];
 
   if (sessionTemplates.includes(templateType)) return 'session';
   if (enrollmentTemplates.includes(templateType)) return 'enrollment';
   if (generalTemplates.includes(templateType)) return 'general';
   if (organizerTemplates.includes(templateType)) return 'organizer';
+  if (jobPostingTemplates.includes(templateType)) return 'jobposting';
 
   return 'enrollment';
 }
@@ -79,6 +88,34 @@ const EMAIL_PLACEHOLDERS: EditorVariable[] = [
   { text: '[Session:ReminderTime]', label: 'Reminder Time', categories: ['session'] },
   { text: '[System:PasswordResetLink]', label: 'Password Reset Link', categories: ['general'] },
   { text: '[System:PortalUrl]', label: 'Portal URL', categories: ['general'] },
+  // StuJo job board. Substituted by the two local replacers in
+  // lib/stripeJobPosting.ts and publishJobPosting/index.js, not by the shared
+  // registry in emailTemplateVariables.js.
+  { text: '[JobPosting:Title]', label: 'Posting Title', categories: ['jobposting'] },
+  { text: '[JobPosting:Type]', label: 'Posting Category', categories: ['jobposting'] },
+  { text: '[JobPosting:PublishedAt]', label: 'Published Date', categories: ['jobposting'] },
+  { text: '[JobPosting:ExpiresAt]', label: 'Expiry Date', categories: ['jobposting'] },
+  { text: '[JobPosting:Payment]', label: 'Payment Summary', categories: ['jobposting'] },
+  { text: '[JobPosting:DashboardUrl]', label: 'Employer Dashboard Link', categories: ['jobposting'] },
+  { text: '[JobPosting:RepostUrl]', label: 'Repost Link', categories: ['jobposting'] },
+  { text: '[JobPosting:AdminUrl]', label: 'Admin Link', categories: ['jobposting'] },
+  { text: '[JobPosting:TermsAcceptedAt]', label: 'Terms Accepted Date', categories: ['jobposting'] },
+  { text: '[Organization:Name]', label: 'Employer Name', categories: ['jobposting'] },
+  { text: '[Invoice:Number]', label: 'Invoice Number', categories: ['jobposting'] },
+  { text: '[Invoice:Date]', label: 'Invoice Date', categories: ['jobposting'] },
+  { text: '[Invoice:NetTotal]', label: 'Invoice Net', categories: ['jobposting'] },
+  { text: '[Invoice:VatRate]', label: 'VAT Rate', categories: ['jobposting'] },
+  { text: '[Invoice:VatTotal]', label: 'VAT Amount', categories: ['jobposting'] },
+  { text: '[Invoice:GrossTotal]', label: 'Invoice Gross', categories: ['jobposting'] },
+  { text: '[Invoice:HostedUrl]', label: 'Invoice Online Link', categories: ['jobposting'] },
+  { text: '[Invoice:PaymentStatus]', label: 'Payment Status', categories: ['jobposting'] },
+  { text: '[Legal:TermsUrl]', label: 'Terms URL', categories: ['jobposting'] },
+  // Conditional blocks, offered as chips so a deleted one can be rebuilt.
+  { text: '[#if:Invoice][/if:Invoice]', label: 'Block: has invoice', categories: ['jobposting'] },
+  { text: '[#if:InvoicePdf][/if:InvoicePdf]', label: 'Block: PDF attached', categories: ['jobposting'] },
+  { text: '[#if:InvoiceLink][/if:InvoiceLink]', label: 'Block: invoice link', categories: ['jobposting'] },
+  { text: '[#if:InvoicePending][/if:InvoicePending]', label: 'Block: invoice follows', categories: ['jobposting'] },
+  { text: '[#if:TermsAccepted][/if:TermsAccepted]', label: 'Block: consent date', categories: ['jobposting'] },
 ];
 
 const sanitizeEmailHtml = (content: string): string =>

--- a/frontend-nx/apps/edu-hub/components/pages/ManageEmailTemplateEditor/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageEmailTemplateEditor/index.tsx
@@ -71,7 +71,43 @@ const ManageEmailTemplateEditor: FC<ManageEmailTemplateEditorProps> = ({ templat
         '\\[Session:ReminderTime\\]': 'tomorrow',
         '\\[System:PasswordResetLink\\]': 'https://keycloak.example.com/reset',
         '\\[System:PortalUrl\\]': 'https://edu.opencampus.sh',
+        // StuJo job board
+        '\\[JobPosting:Title\\]': 'Werkstudent:in Frontend',
+        '\\[JobPosting:Type\\]': 'Studentenjob',
+        '\\[JobPosting:PublishedAt\\]': '29. August 2026',
+        '\\[JobPosting:ExpiresAt\\]': '24. Oktober 2026',
+        '\\[JobPosting:Payment\\]': '59,50 € (bezahlt)',
+        '\\[JobPosting:DashboardUrl\\]': 'https://stujo.opencampus.sh/mein-stujo',
+        '\\[JobPosting:RepostUrl\\]': 'https://stujo.opencampus.sh/mein-stujo?repost=1',
+        '\\[JobPosting:AdminUrl\\]': 'https://edu.opencampus.sh/manage/settings/jobboerse',
+        '\\[JobPosting:TermsAcceptedAt\\]': '29. August 2026',
+        '\\[Organization:Name\\]': 'Beispiel GmbH',
+        '\\[Invoice:Number\\]': 'VGD1VIPO-0001',
+        '\\[Invoice:Date\\]': '29. August 2026',
+        '\\[Invoice:NetTotal\\]': '50,00 €',
+        '\\[Invoice:VatRate\\]': '19',
+        '\\[Invoice:VatTotal\\]': '9,50 €',
+        '\\[Invoice:GrossTotal\\]': '59,50 €',
+        '\\[Invoice:HostedUrl\\]': 'https://invoice.stripe.com/i/example',
+        '\\[Invoice:PaymentStatus\\]': 'bezahlt',
+        '\\[Legal:TermsUrl\\]': 'https://www.stujo.net/agb',
       };
+      // Conditional blocks are resolved before substitution, all flags on, so
+      // the preview shows the fullest variant instead of raw [#if:...] markers.
+      // Mirrors applyConditionalBlocks in lib/stripeJobPosting.ts.
+      const showAllConditionalBlocks = (text: string): string => {
+        const pattern = /\[#if:([A-Za-z]+)\]([\s\S]*?)\[\/if:\1\]/g;
+        let result = text || '';
+        for (let pass = 0; pass < 5; pass += 1) {
+          const next = result.replace(pattern, (_match, _key, body: string) => body);
+          if (next === result) return next;
+          result = next;
+        }
+        return result;
+      };
+      previewContent = showAllConditionalBlocks(previewContent);
+      previewSubject = showAllConditionalBlocks(previewSubject);
+
       Object.entries(sampleReplacements).forEach(([pattern, replacement]) => {
         const regex = new RegExp(pattern, 'g');
         previewContent = previewContent.replace(regex, replacement);

--- a/frontend-nx/apps/edu-hub/helpers/emailTemplateCategories.test.ts
+++ b/frontend-nx/apps/edu-hub/helpers/emailTemplateCategories.test.ts
@@ -38,6 +38,11 @@ describe('getEmailTemplateCategory', () => {
     'SESSION_RESCHEDULED',
     'PAYMENT_RECEIPT',
     'COURSE_CONTINUATION_INQUIRY',
+    'JOB_POSTING_PUBLISHED',
+    'JOB_POSTING_EXPIRED',
+    'JOB_POSTING_ADMIN_NOTICE',
+    'JOB_POSTING_PAYMENT_FAILED',
+    'JOB_ALERT',
   ];
 
   it.each(knownTypes)('maps known type %s to a real category (not "other")', (type) => {
@@ -74,6 +79,18 @@ describe('getEmailTemplateCategory', () => {
     expect(getEmailTemplateCategory('ORGANIZER_ADDED')).toBe('system');
   });
 
+  it('maps the StuJo job board types to "jobboard"', () => {
+    expect(getEmailTemplateCategory('JOB_POSTING_PUBLISHED')).toBe('jobboard');
+    expect(getEmailTemplateCategory('JOB_POSTING_EXPIRED')).toBe('jobboard');
+    expect(getEmailTemplateCategory('JOB_POSTING_ADMIN_NOTICE')).toBe('jobboard');
+    expect(getEmailTemplateCategory('JOB_POSTING_PAYMENT_FAILED')).toBe('jobboard');
+    expect(getEmailTemplateCategory('JOB_ALERT')).toBe('jobboard');
+  });
+
+  it('shows the job board as a tab rather than hiding it behind "Sonstige"', () => {
+    expect(EMAIL_TEMPLATE_CATEGORIES).toContain('jobboard');
+  });
+
   it('falls back to "other" for unknown types so they never disappear from the UI', () => {
     expect(getEmailTemplateCategory('SOME_FUTURE_TYPE')).toBe('other');
   });
@@ -86,5 +103,35 @@ describe('getEmailTemplateCategory', () => {
 
   it('no longer treats project notifications as upcoming', () => {
     expect(UPCOMING_EMAIL_TEMPLATE_CATEGORIES).not.toContain('projects');
+  });
+});
+
+describe('job board template labels', () => {
+  // A type mapped to a category but missing from the locale files renders as
+  // "Unbekannter Auslöser-Typ" in the editor, which is how the JOB_POSTING_*
+  // templates were effectively invisible before.
+  const de = require('../locales/de.json');
+  const en = require('../locales/en.json');
+  const jobBoardTypes = [
+    'JOB_POSTING_PUBLISHED',
+    'JOB_POSTING_EXPIRED',
+    'JOB_POSTING_ADMIN_NOTICE',
+    'JOB_POSTING_PAYMENT_FAILED',
+    'JOB_ALERT',
+  ];
+
+  it.each(jobBoardTypes)('has a German name and trigger description for %s', (type) => {
+    expect(de.manageEmailTemplates.template_types[type]).toBeTruthy();
+    expect(de.manageEmailTemplates.triggers[type]).toBeTruthy();
+  });
+
+  it.each(jobBoardTypes)('has an English name and trigger description for %s', (type) => {
+    expect(en.manageEmailTemplates.template_types[type]).toBeTruthy();
+    expect(en.manageEmailTemplates.triggers[type]).toBeTruthy();
+  });
+
+  it('names the jobboard category in both locales', () => {
+    expect(de.manageEmailTemplates.categories.jobboard).toBeTruthy();
+    expect(en.manageEmailTemplates.categories.jobboard).toBeTruthy();
   });
 });

--- a/frontend-nx/apps/edu-hub/helpers/emailTemplateCategories.ts
+++ b/frontend-nx/apps/edu-hub/helpers/emailTemplateCategories.ts
@@ -4,13 +4,20 @@
  * get a category here; anything unmapped falls back to 'other' so it never
  * disappears from the UI.
  */
-export type EmailTemplateCategory = 'application' | 'projects' | 'sessions' | 'system' | 'other';
+export type EmailTemplateCategory =
+  | 'application'
+  | 'projects'
+  | 'sessions'
+  | 'jobboard'
+  | 'system'
+  | 'other';
 
 /** Categories shown as tabs, in display order ('other' is appended only when present). */
 export const EMAIL_TEMPLATE_CATEGORIES: EmailTemplateCategory[] = [
   'application',
   'projects',
   'sessions',
+  'jobboard',
   'system',
 ];
 
@@ -54,6 +61,13 @@ const CATEGORY_BY_TYPE: Record<string, EmailTemplateCategory> = {
   // System / account
   USER_CREATED: 'system',
   ORGANIZER_ADDED: 'system',
+  // StuJo job board (the postings are sold through the same platform, but the
+  // mails go to employers rather than participants)
+  JOB_POSTING_PUBLISHED: 'jobboard',
+  JOB_POSTING_EXPIRED: 'jobboard',
+  JOB_POSTING_ADMIN_NOTICE: 'jobboard',
+  JOB_POSTING_PAYMENT_FAILED: 'jobboard',
+  JOB_ALERT: 'jobboard',
 };
 
 export const getEmailTemplateCategory = (type: string): EmailTemplateCategory =>

--- a/frontend-nx/apps/edu-hub/lib/stripeInvoice.ts
+++ b/frontend-nx/apps/edu-hub/lib/stripeInvoice.ts
@@ -1,0 +1,85 @@
+import { randomUUID } from 'node:crypto';
+import type Stripe from 'stripe';
+
+/**
+ * Shared helpers for the Stripe-generated invoice document, used by both the
+ * course checkout path (pages/api/webhooks/stripe.ts) and the StuJo job
+ * posting path (lib/stripeJobPosting.ts).
+ */
+
+/**
+ * Generates a unique invoice number for Stripe Checkout payments.
+ * Uses session/payment intent ID as unique suffix when available.
+ * Falls back to crypto.randomUUID() when both are absent to avoid collisions.
+ *
+ * This is our own record key, not the number printed on the Stripe document --
+ * that one is `ResolvedStripeInvoice.number`, stored separately in
+ * `Invoice.stripeInvoiceNumber`.
+ */
+export function generateInvoiceNumber(
+  prefix: string,
+  sessionId?: string | null,
+  paymentIntentId?: string | null
+): string {
+  const suffix = sessionId || paymentIntentId || `web-${randomUUID()}`;
+  return `${prefix}-${suffix}`;
+}
+
+export type ResolvedStripeInvoice = {
+  id: string | null;
+  /** Stripe's sequential document number, e.g. VGD1VIPO-0001. Null while draft. */
+  number: string | null;
+  hostedUrl: string | null;
+  pdfUrl: string | null;
+  status: Stripe.Invoice.Status | null;
+};
+
+const EMPTY_INVOICE: ResolvedStripeInvoice = {
+  id: null,
+  number: null,
+  hostedUrl: null,
+  pdfUrl: null,
+  status: null,
+};
+
+/**
+ * Resolves the Stripe-generated invoice document (invoice_creation) so the
+ * Invoice row carries the legally required document references.
+ *
+ * Reads once and returns whatever exists right now. With `invoice_creation`
+ * Stripe finalizes asynchronously, so `number` and `pdfUrl` may still be null;
+ * callers must handle that rather than waiting here. Polling inside a webhook
+ * would burn the ~20s delivery budget against timing Stripe does not promise --
+ * finalization can lag by an hour, or up to 72 hours if deliveries are failing.
+ * The `invoice.finalized` event is the supported signal instead.
+ *
+ * Never throws: a Stripe outage must not turn a completed payment into a failed
+ * webhook. On error it falls back to the bare reference.
+ */
+export async function resolveStripeInvoice(
+  stripe: Stripe,
+  invoiceRef: string | Stripe.Invoice | null | undefined
+): Promise<ResolvedStripeInvoice> {
+  if (!invoiceRef) {
+    return { ...EMPTY_INVOICE };
+  }
+
+  try {
+    const invoice =
+      typeof invoiceRef === 'string' ? await stripe.invoices.retrieve(invoiceRef) : invoiceRef;
+
+    return {
+      id: invoice.id ?? null,
+      number: invoice.number ?? null,
+      hostedUrl: invoice.hosted_invoice_url ?? null,
+      pdfUrl: invoice.invoice_pdf ?? null,
+      status: invoice.status ?? null,
+    };
+  } catch (err) {
+    console.warn('Could not resolve Stripe invoice document:', err);
+    return {
+      ...EMPTY_INVOICE,
+      id: typeof invoiceRef === 'string' ? invoiceRef : null,
+    };
+  }
+}

--- a/frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts
+++ b/frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts
@@ -1,6 +1,8 @@
 import { GraphQLClient, gql } from 'graphql-request';
 import type Stripe from 'stripe';
 
+import { generateInvoiceNumber, resolveStripeInvoice } from './stripeInvoice';
+
 /**
  * StuJo job posting handling for the Stripe webhook (phase 4 of
  * docs/STUJO_INTEGRATION_PLAN.md). Sessions created by the
@@ -25,6 +27,7 @@ const GET_POSTING_FOR_WEBHOOK = gql`
       status
       expiresAt
       organizationId
+      termsAcceptedAt
       ContactUser {
         email
       }
@@ -81,6 +84,7 @@ const INSERT_JOB_INVOICE = gql`
     $stripeCheckoutSessionId: String
     $stripePaymentIntentId: String
     $stripeInvoiceId: String
+    $stripeInvoiceNumber: String
     $stripeHostedInvoiceUrl: String
     $stripeInvoicePdfUrl: String
   ) {
@@ -98,6 +102,7 @@ const INSERT_JOB_INVOICE = gql`
         stripeCheckoutSessionId: $stripeCheckoutSessionId
         stripePaymentIntentId: $stripePaymentIntentId
         stripeInvoiceId: $stripeInvoiceId
+        stripeInvoiceNumber: $stripeInvoiceNumber
         stripeHostedInvoiceUrl: $stripeHostedInvoiceUrl
         stripeInvoicePdfUrl: $stripeInvoicePdfUrl
       }
@@ -110,6 +115,55 @@ const INSERT_JOB_INVOICE = gql`
 const UPDATE_INVOICE_STATUS = gql`
   mutation UpdateJobInvoiceStatus($id: Int!, $status: InvoiceStatus_enum!) {
     update_Invoice_by_pk(pk_columns: { id: $id }, _set: { status: $status }) {
+      id
+    }
+  }
+`;
+
+/**
+ * Dedup lookup for a mail that can now be queued from three places (checkout,
+ * invoice.finalized, and the sweep). Mirrors the containment approach of
+ * already_sent_keys in functions/callPythonFunction/pythonFunctions/mail_helpers.py,
+ * which the MailLog_metadata_idx GIN index exists to serve.
+ */
+const GET_QUEUED_JOB_MAIL = gql`
+  query GetQueuedJobPostingMail($contains: jsonb!) {
+    MailLog(where: { metadata: { _contains: $contains } }, limit: 1) {
+      id
+    }
+  }
+`;
+
+const GET_INVOICE_BY_STRIPE_ID = gql`
+  query GetJobInvoiceByStripeId($stripeInvoiceId: String!) {
+    Invoice(where: { stripeInvoiceId: { _eq: $stripeInvoiceId } }, limit: 1) {
+      id
+      jobPostingId
+      invoiceNumber
+      netTotal
+      vatTotal
+      grossTotal
+      currency
+      status
+    }
+  }
+`;
+
+const BACKFILL_INVOICE_DOCUMENT = gql`
+  mutation BackfillJobInvoiceDocument(
+    $id: Int!
+    $stripeInvoiceNumber: String
+    $stripeHostedInvoiceUrl: String
+    $stripeInvoicePdfUrl: String
+  ) {
+    update_Invoice_by_pk(
+      pk_columns: { id: $id }
+      _set: {
+        stripeInvoiceNumber: $stripeInvoiceNumber
+        stripeHostedInvoiceUrl: $stripeHostedInvoiceUrl
+        stripeInvoicePdfUrl: $stripeInvoicePdfUrl
+      }
+    ) {
       id
     }
   }
@@ -134,9 +188,20 @@ const INSERT_MAIL_LOG = gql`
     $to: String!
     $bcc: String
     $status: String!
+    $attachments: jsonb
+    $metadata: jsonb
   ) {
     insert_MailLog_one(
-      object: { subject: $subject, content: $content, from: $from, to: $to, bcc: $bcc, status: $status }
+      object: {
+        subject: $subject
+        content: $content
+        from: $from
+        to: $to
+        bcc: $bcc
+        status: $status
+        attachments: $attachments
+        metadata: $metadata
+      }
     ) {
       id
     }
@@ -144,6 +209,71 @@ const INSERT_MAIL_LOG = gql`
 `;
 
 const DEFAULT_DURATION_DAYS = 56;
+
+/**
+ * Display labels for JobPostingType. The enum table deliberately keeps labels
+ * in the frontend i18n files, which the mail pipeline cannot reach, so the
+ * two queuers carry their own copy. Keep in sync with the identical map in
+ * functions/callNodeFunction/publishJobPosting/index.js.
+ */
+const JOB_POSTING_TYPE_LABELS: Record<string, string> = {
+  MINIJOB: 'Minijob',
+  WORKING_STUDENT: 'Studentenjob',
+  INTERNSHIP: 'Praktikum',
+  STATE_RECOGNITION_INTERNSHIP: 'Anerkennungspraktikum',
+  THESIS: 'Abschlussarbeit',
+  TRAINEE: 'Trainee-Stelle',
+  PERMANENT: 'Festanstellung',
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Drops [#if:Flag] ... [/if:Flag] sections whose flag is falsy and unwraps the
+ * rest, so one template can serve paid, free and credit-funded postings.
+ *
+ * Loops because String.replace does not rescan replaced regions, and the
+ * invoice block nests an inner [#if:InvoiceLink].
+ */
+export function applyConditionalBlocks(text: string, flags: Record<string, boolean>): string {
+  const pattern = /\[#if:([A-Za-z]+)\]([\s\S]*?)\[\/if:\1\]/g;
+  let result = text || '';
+  for (let pass = 0; pass < 5; pass += 1) {
+    const next = result.replace(pattern, (_match, key: string, body: string) =>
+      flags[key] ? body : ''
+    );
+    if (next === result) return next;
+    result = next;
+  }
+  return result;
+}
+
+function formatAmount(cents: number, currency: string): string {
+  const symbol = currency.toUpperCase() === 'EUR' ? '\u20ac' : currency.toUpperCase();
+  return `${(cents / 100).toFixed(2).replace('.', ',')} ${symbol}`;
+}
+
+function formatDate(date: Date): string {
+  return date.toLocaleDateString('de-DE', { year: 'numeric', month: 'long', day: 'numeric' });
+}
+
+/** Invoice figures the confirmation mail renders; null on free/credit postings. */
+type InvoiceMailData = {
+  number: string;
+  hostedUrl: string | null;
+  netTotal: number;
+  vatTotal: number;
+  grossTotal: number;
+  currency: string;
+  paid: boolean;
+};
 
 type PostingForWebhook = {
   JobPosting_by_pk: {
@@ -153,6 +283,7 @@ type PostingForWebhook = {
     status: string;
     expiresAt: string | null;
     organizationId: number;
+    termsAcceptedAt: string | null;
     ContactUser: { email: string } | null;
     Organization: { name: string } | null;
   } | null;
@@ -166,19 +297,51 @@ export function parseJobPostingId(value: string | undefined): number | null {
   return parsed;
 }
 
-function replaceVars(text: string, vars: Record<string, string>): string {
+/**
+ * Substitutes [Entity:Field] placeholders. Values are HTML-escaped by default
+ * because they are employer-controlled and the result is sent as HTML -- the
+ * admin notice carries the same values into a staff inbox. Subjects are plain
+ * text, so they pass { html: false }.
+ */
+function replaceVars(
+  text: string,
+  vars: Record<string, string>,
+  options: { html?: boolean } = {}
+): string {
+  const { html = true } = options;
   let result = text || '';
   for (const [key, value] of Object.entries(vars)) {
-    result = result.split(key).join(value ?? '');
+    const replacement = value ?? '';
+    result = result.split(key).join(html ? escapeHtml(replacement) : replacement);
   }
   return result;
+}
+
+/**
+ * True when this mail has already been queued for this posting. Deliberately
+ * not gated on Invoice existence: the mail may legitimately be sent on a later
+ * delivery than the one that created the invoice row.
+ */
+export async function hasQueuedJobPostingMail(
+  client: GraphQLClient,
+  templateType: string,
+  jobPostingId: number
+): Promise<boolean> {
+  const { MailLog } = await client.request<{ MailLog: Array<{ id: number }> }>(
+    GET_QUEUED_JOB_MAIL,
+    { contains: { type: templateType, jobPostingId } }
+  );
+  return MailLog.length > 0;
 }
 
 async function queueMail(
   client: GraphQLClient,
   templateType: string,
   to: string,
-  vars: Record<string, string>
+  vars: Record<string, string>,
+  flags: Record<string, boolean> = {},
+  attachments: Array<{ url: string; filename: string; contentType: string }> | null = null,
+  jobPostingId: number | null = null
 ) {
   try {
     const templateData = await client.request<{
@@ -190,12 +353,14 @@ async function queueMail(
       return;
     }
     await client.request(INSERT_MAIL_LOG, {
-      subject: replaceVars(template.subject, vars),
-      content: replaceVars(template.content, vars),
+      subject: replaceVars(applyConditionalBlocks(template.subject, flags), vars, { html: false }),
+      content: replaceVars(applyConditionalBlocks(template.content, flags), vars),
       from: template.from || 'noreply@stujo.net',
       to,
       bcc: template.bcc || null,
       status: 'READY_TO_SEND',
+      attachments,
+      metadata: jobPostingId === null ? null : { type: templateType, jobPostingId },
     });
   } catch (error) {
     // Mails must never fail the webhook.
@@ -203,24 +368,98 @@ async function queueMail(
   }
 }
 
+/**
+ * Every key here must also be produced by publishAndNotify in
+ * functions/callNodeFunction/publishJobPosting/index.js -- the replacer only
+ * substitutes keys it is handed, so a key missing on the free/credit path
+ * would reach the employer as literal "[Invoice:Number]" text.
+ */
 function buildMailVars(
   posting: NonNullable<PostingForWebhook['JobPosting_by_pk']>,
   expiresAt: Date | null,
-  paymentDescription: string
+  paymentDescription: string,
+  invoice: InvoiceMailData | null = null
 ): Record<string, string> {
   const frontendUrl = process.env.STUJO_FRONTEND_URL || process.env.FRONTEND_URL || '';
+  const vatRate =
+    invoice && invoice.netTotal > 0 ? String(Math.round((invoice.vatTotal / invoice.netTotal) * 100)) : '';
   return {
     '[JobPosting:Title]': posting.title,
-    '[JobPosting:Type]': posting.type,
-    '[JobPosting:ExpiresAt]': expiresAt
-      ? expiresAt.toLocaleDateString('de-DE', { year: 'numeric', month: 'long', day: 'numeric' })
+    '[JobPosting:Type]': JOB_POSTING_TYPE_LABELS[posting.type] || posting.type,
+    '[JobPosting:ExpiresAt]': expiresAt ? formatDate(expiresAt) : '',
+    '[JobPosting:PublishedAt]': formatDate(new Date()),
+    '[JobPosting:TermsAcceptedAt]': posting.termsAcceptedAt
+      ? formatDate(new Date(posting.termsAcceptedAt))
       : '',
     '[JobPosting:DashboardUrl]': `${frontendUrl}/mein-stujo`,
     '[JobPosting:RepostUrl]': `${frontendUrl}/mein-stujo?repost=${posting.id}`,
     '[JobPosting:AdminUrl]': `${frontendUrl}/manage/jobboerse?posting=${posting.id}`,
     '[Organization:Name]': posting.Organization?.name || '',
     '[JobPosting:Payment]': paymentDescription,
+    '[Invoice:Number]': invoice?.number || '',
+    '[Invoice:Date]': invoice ? formatDate(new Date()) : '',
+    '[Invoice:NetTotal]': invoice ? formatAmount(invoice.netTotal, invoice.currency) : '',
+    '[Invoice:VatRate]': vatRate,
+    '[Invoice:VatTotal]': invoice ? formatAmount(invoice.vatTotal, invoice.currency) : '',
+    '[Invoice:GrossTotal]': invoice ? formatAmount(invoice.grossTotal, invoice.currency) : '',
+    '[Invoice:HostedUrl]': invoice?.hostedUrl || '',
+    '[Invoice:PaymentStatus]': invoice ? (invoice.paid ? 'bezahlt' : 'Zahlung ausstehend') : '',
+    '[Legal:TermsUrl]': process.env.STUJO_TERMS_URL || 'https://www.stujo.net/agb',
   };
+}
+
+/**
+ * Queues the single combined confirmation mail, PDF attached.
+ *
+ * Called from three places -- checkout.session.completed when Stripe has
+ * already finalized the invoice, the invoice.finalized handler when it had not,
+ * and the sendPendingJobPostingMails sweep when neither fired. Returns false if
+ * the mail was already queued, so callers can stay quiet about it.
+ */
+export async function queueJobPostingConfirmation(
+  client: GraphQLClient,
+  posting: NonNullable<PostingForWebhook['JobPosting_by_pk']>,
+  expiresAt: Date | null,
+  invoice: InvoiceMailData,
+  pdfUrl: string | null
+): Promise<boolean> {
+  if (!posting.ContactUser?.email) return false;
+  if (await hasQueuedJobPostingMail(client, 'JOB_POSTING_PUBLISHED', posting.id)) return false;
+
+  const paymentDescription = `${formatAmount(invoice.grossTotal, invoice.currency)} (${
+    invoice.paid ? 'bezahlt' : 'Zahlung ausstehend'
+  })`;
+  const vars = buildMailVars(posting, expiresAt, paymentDescription, invoice);
+  // InvoicePdf and InvoiceLink are separate from Invoice on purpose: the
+  // section must not claim a PDF is attached when the sweep had to send without
+  // one. InvoicePending covers the case where neither exists yet.
+  const flags = {
+    Invoice: true,
+    InvoicePdf: Boolean(pdfUrl),
+    InvoiceLink: Boolean(invoice.hostedUrl),
+    InvoicePending: !pdfUrl && !invoice.hostedUrl,
+    TermsAccepted: Boolean(posting.termsAcceptedAt),
+  };
+  const attachments = pdfUrl
+    ? [
+        {
+          url: pdfUrl,
+          filename: `rechnung-${invoice.number.replace(/[^A-Za-z0-9._-]+/g, '-')}.pdf`,
+          contentType: 'application/pdf',
+        },
+      ]
+    : null;
+
+  await queueMail(
+    client,
+    'JOB_POSTING_PUBLISHED',
+    posting.ContactUser.email,
+    vars,
+    flags,
+    attachments,
+    posting.id
+  );
+  return true;
 }
 
 /**
@@ -259,33 +498,34 @@ export async function handleJobPostingCheckoutCompleted(
     { sessionId: session.id }
   );
   const invoiceCreated = existing.length === 0;
+
+  // With an exclusive tax rate: amount_subtotal = net, amount_total = gross.
+  const grossTotal = session.amount_total ?? 0;
+  const netTotal = session.amount_subtotal ?? grossTotal;
+  const vatTotal = session.total_details?.amount_tax ?? grossTotal - netTotal;
+  const currency = (session.currency || 'eur').toUpperCase();
+  const paid = session.payment_status === 'paid';
+  const paymentIntentId =
+    typeof session.payment_intent === 'string'
+      ? session.payment_intent
+      : session.payment_intent?.id ?? null;
+
+  // Resolved before the insert branch because the confirmation mail below needs
+  // the same document, and re-reading it there would cost a second round trip.
+  // Read once, no waiting: Stripe finalizes invoice_creation invoices
+  // asynchronously, so the PDF may not exist yet. When it does not, the mail is
+  // left to the invoice.finalized handler rather than blocking the webhook.
+  const invoiceDoc = await resolveStripeInvoice(stripe, session.invoice);
+
+  // Our own record key, mirroring the course path. Deliberately not Stripe's
+  // number: that one is what is printed on the document the employer receives
+  // and is stored separately in stripeInvoiceNumber.
+  const invoiceNumber = generateInvoiceNumber('STUJO', session.id, paymentIntentId);
+
   if (invoiceCreated) {
     const buyerUserId = session.metadata?.userId;
     if (!buyerUserId) {
       throw new Error(`Session ${session.id} is missing userId metadata for the invoice`);
-    }
-    // With an exclusive tax rate: amount_subtotal = net, amount_total = gross.
-    const grossTotal = session.amount_total ?? 0;
-    const netTotal = session.amount_subtotal ?? grossTotal;
-    const vatTotal = session.total_details?.amount_tax ?? grossTotal - netTotal;
-    // The Stripe-generated invoice document (invoice_creation) carries the
-    // legally required sequential number and VAT breakdown.
-    let stripeInvoiceId: string | null = null;
-    let stripeHostedInvoiceUrl: string | null = null;
-    let stripeInvoicePdfUrl: string | null = null;
-    if (session.invoice) {
-      try {
-        const invoiceDoc =
-          typeof session.invoice === 'string'
-            ? await stripe.invoices.retrieve(session.invoice)
-            : session.invoice;
-        stripeInvoiceId = invoiceDoc.id ?? null;
-        stripeHostedInvoiceUrl = invoiceDoc.hosted_invoice_url ?? null;
-        stripeInvoicePdfUrl = invoiceDoc.invoice_pdf ?? null;
-      } catch (err) {
-        console.warn('Could not resolve Stripe invoice for job posting:', err);
-        stripeInvoiceId = typeof session.invoice === 'string' ? session.invoice : null;
-      }
     }
     // The platform (not the employer) is the selling organization.
     const sellerOrganizationId = Number.parseInt(
@@ -298,42 +538,79 @@ export async function handleJobPostingCheckoutCompleted(
         : posting.organizationId,
       userId: buyerUserId,
       jobPostingId: posting.id,
-      invoiceNumber: `STUJO-${session.id}`,
+      invoiceNumber,
       // Card payments are settled at completion; SEPA settles later
       // (async_payment_succeeded flips the invoice to PAID).
-      status: session.payment_status === 'paid' ? 'PAID' : 'ISSUED',
+      status: paid ? 'PAID' : 'ISSUED',
       netTotal,
       vatTotal,
       grossTotal,
-      currency: (session.currency || 'eur').toUpperCase(),
+      currency,
       stripeCheckoutSessionId: session.id,
-      stripePaymentIntentId:
-        typeof session.payment_intent === 'string'
-          ? session.payment_intent
-          : session.payment_intent?.id ?? null,
-      stripeInvoiceId,
-      stripeHostedInvoiceUrl,
-      stripeInvoicePdfUrl,
+      stripePaymentIntentId: paymentIntentId,
+      stripeInvoiceId: invoiceDoc.id,
+      stripeInvoiceNumber: invoiceDoc.number,
+      stripeHostedInvoiceUrl: invoiceDoc.hostedUrl,
+      stripeInvoicePdfUrl: invoiceDoc.pdfUrl,
     });
   }
 
-  // Mails: employer confirmation + admin post-hoc moderation notice. Gate on
-  // the invoice-creation branch so Stripe redeliveries (posting already
-  // PUBLISHED, invoice already present) don't enqueue duplicate sends. Fall
-  // back to the posting's stored expiresAt when this delivery didn't publish.
-  if (invoiceCreated) {
-    const mailExpiresAt =
-      expiresAt ?? (posting.expiresAt ? new Date(posting.expiresAt) : null);
-    const paymentDescription = `${((session.amount_total ?? 0) / 100).toFixed(2)} € (${
-      session.payment_status === 'paid' ? 'bezahlt' : 'Zahlung ausstehend'
-    })`;
-    const vars = buildMailVars(posting, mailExpiresAt, paymentDescription);
-    if (posting.ContactUser?.email) {
-      await queueMail(client, 'JOB_POSTING_PUBLISHED', posting.ContactUser.email, vars);
+  const mailExpiresAt = expiresAt ?? (posting.expiresAt ? new Date(posting.expiresAt) : null);
+  const invoice: InvoiceMailData = {
+    // The document number is what the employer sees on the attached PDF; fall
+    // back to our own key while Stripe has not finalized the invoice yet.
+    number: invoiceDoc.number ?? invoiceNumber,
+    hostedUrl: invoiceDoc.hostedUrl,
+    netTotal,
+    vatTotal,
+    grossTotal,
+    currency,
+    paid,
+  };
+
+  // The employer's copy carries the PDF, so it only goes out once the document
+  // exists. When Stripe has not finalized yet, invoice.finalized sends it (and
+  // the sendPendingJobPostingMails sweep is the backstop for that). Dedup is on
+  // MailLog.metadata rather than the invoiceCreated branch, because the mail
+  // can legitimately be queued by a later delivery than the one that inserted
+  // the invoice row.
+  if (posting.ContactUser?.email) {
+    if (invoiceDoc.pdfUrl) {
+      await queueJobPostingConfirmation(client, posting, mailExpiresAt, invoice, invoiceDoc.pdfUrl);
+    } else {
+      console.info('Stripe invoice not finalized yet, deferring the confirmation mail', {
+        jobPostingId: posting.id,
+        sessionId: session.id,
+        invoiceStatus: invoiceDoc.status,
+      });
     }
-    if (process.env.STUJO_ADMIN_EMAIL) {
-      await queueMail(client, 'JOB_POSTING_ADMIN_NOTICE', process.env.STUJO_ADMIN_EMAIL, vars);
-    }
+  }
+
+  // The admin notice carries no invoice figures, so it never has to wait.
+  if (
+    process.env.STUJO_ADMIN_EMAIL &&
+    !(await hasQueuedJobPostingMail(client, 'JOB_POSTING_ADMIN_NOTICE', posting.id))
+  ) {
+    await queueMail(
+      client,
+      'JOB_POSTING_ADMIN_NOTICE',
+      process.env.STUJO_ADMIN_EMAIL,
+      buildMailVars(
+        posting,
+        mailExpiresAt,
+        `${formatAmount(grossTotal, currency)} (${paid ? 'bezahlt' : 'Zahlung ausstehend'})`,
+        invoice
+      ),
+      {
+        Invoice: true,
+        InvoicePdf: false,
+        InvoiceLink: Boolean(invoiceDoc.hostedUrl),
+        InvoicePending: !invoiceDoc.hostedUrl,
+        TermsAccepted: Boolean(posting.termsAcceptedAt),
+      },
+      null,
+      posting.id
+    );
   }
 
   console.log('Job posting published via Stripe webhook', {
@@ -386,7 +663,14 @@ export async function handleJobPostingAsyncPaymentFailed(
       client,
       'JOB_POSTING_PAYMENT_FAILED',
       posting.ContactUser.email,
-      buildMailVars(posting, null, 'fehlgeschlagen')
+      buildMailVars(posting, null, 'fehlgeschlagen'),
+      {
+        Invoice: false,
+        InvoicePdf: false,
+        InvoiceLink: false,
+        InvoicePending: false,
+        TermsAccepted: Boolean(posting.termsAcceptedAt),
+      }
     );
   }
   console.warn('Job posting payment failed, posting taken offline', {
@@ -406,4 +690,78 @@ export async function handleJobPostingCheckoutExpired(
   if (data.JobPosting_by_pk?.status === 'PENDING_PAYMENT') {
     await client.request(SET_POSTING_STATUS_DRAFT, { id: jobPostingId });
   }
+}
+
+/**
+ * invoice.finalized: the document now has a number and a PDF.
+ *
+ * Stripe finalizes invoice_creation invoices asynchronously, so this is the
+ * supported signal that the attachment exists -- rather than polling inside
+ * checkout.session.completed, which cannot outrun a finalization that Stripe
+ * may delay by an hour, or by up to 72 hours while deliveries are failing.
+ *
+ * Backfills the document columns and, if the confirmation has not gone out yet,
+ * sends it now. Safe to receive more than once: the send is deduped on
+ * MailLog.metadata and the backfill is an idempotent _set.
+ */
+export async function handleJobPostingInvoiceFinalized(
+  client: GraphQLClient,
+  invoiceDoc: Stripe.Invoice
+): Promise<void> {
+  if (!invoiceDoc.id) return;
+
+  const { Invoice: rows } = await client.request<{
+    Invoice: Array<{
+      id: number;
+      jobPostingId: number | null;
+      invoiceNumber: string;
+      netTotal: number;
+      vatTotal: number;
+      grossTotal: number;
+      currency: string;
+      status: string;
+    }>;
+  }>(GET_INVOICE_BY_STRIPE_ID, { stripeInvoiceId: invoiceDoc.id });
+
+  const row = rows[0];
+  // Not ours, or a course invoice: nothing to do beyond the backfill below.
+  if (!row) return;
+
+  await client.request(BACKFILL_INVOICE_DOCUMENT, {
+    id: row.id,
+    stripeInvoiceNumber: invoiceDoc.number ?? null,
+    stripeHostedInvoiceUrl: invoiceDoc.hosted_invoice_url ?? null,
+    stripeInvoicePdfUrl: invoiceDoc.invoice_pdf ?? null,
+  });
+
+  if (!row.jobPostingId) return;
+
+  const data = await client.request<PostingForWebhook>(GET_POSTING_FOR_WEBHOOK, {
+    id: row.jobPostingId,
+  });
+  const posting = data.JobPosting_by_pk;
+  if (!posting) return;
+
+  const sent = await queueJobPostingConfirmation(
+    client,
+    posting,
+    posting.expiresAt ? new Date(posting.expiresAt) : null,
+    {
+      number: invoiceDoc.number ?? row.invoiceNumber,
+      hostedUrl: invoiceDoc.hosted_invoice_url ?? null,
+      netTotal: row.netTotal,
+      vatTotal: row.vatTotal,
+      grossTotal: row.grossTotal,
+      currency: row.currency,
+      paid: row.status === 'PAID',
+    },
+    invoiceDoc.invoice_pdf ?? null
+  );
+
+  console.log('Job posting invoice finalized', {
+    jobPostingId: row.jobPostingId,
+    stripeInvoiceId: invoiceDoc.id,
+    stripeInvoiceNumber: invoiceDoc.number,
+    confirmationQueuedNow: sent,
+  });
 }

--- a/frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts
+++ b/frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts
@@ -404,7 +404,8 @@ function buildMailVars(
     '[Invoice:GrossTotal]': invoice ? formatAmount(invoice.grossTotal, invoice.currency) : '',
     '[Invoice:HostedUrl]': invoice?.hostedUrl || '',
     '[Invoice:PaymentStatus]': invoice ? (invoice.paid ? 'bezahlt' : 'Zahlung ausstehend') : '',
-    '[Legal:TermsUrl]': process.env.STUJO_TERMS_URL || 'https://www.stujo.net/agb',
+    // Absolute: this is read in an email, where a relative path is dead.
+    '[Legal:TermsUrl]': process.env.STUJO_TERMS_URL || `${frontendUrl}/agb`,
   };
 }
 

--- a/frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts
+++ b/frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts
@@ -140,6 +140,7 @@ const GET_INVOICE_BY_STRIPE_ID = gql`
       id
       jobPostingId
       invoiceNumber
+      invoiceDate
       netTotal
       vatTotal
       grossTotal
@@ -267,6 +268,9 @@ function formatDate(date: Date): string {
 /** Invoice figures the confirmation mail renders; null on free/credit postings. */
 type InvoiceMailData = {
   number: string;
+  /** When the invoice was raised -- not when this mail is sent. The two differ
+   *  on the invoice.finalized and sweep paths, and the PDF shows this one. */
+  date: Date;
   hostedUrl: string | null;
   netTotal: number;
   vatTotal: number;
@@ -334,6 +338,12 @@ export async function hasQueuedJobPostingMail(
   return MailLog.length > 0;
 }
 
+/** True for a violation of MailLog_job_posting_mail_unique. */
+function isDuplicateMailError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.includes('MailLog_job_posting_mail_unique');
+}
+
 async function queueMail(
   client: GraphQLClient,
   templateType: string,
@@ -363,6 +373,13 @@ async function queueMail(
       metadata: jobPostingId === null ? null : { type: templateType, jobPostingId },
     });
   } catch (error) {
+    // The unique index on the job posting dedup key is the real guard against
+    // two deliveries racing past hasQueuedJobPostingMail. Losing that race is
+    // the mechanism working, not a failure.
+    if (isDuplicateMailError(error)) {
+      console.info(`${templateType} already queued for job posting ${jobPostingId}`);
+      return;
+    }
     // Mails must never fail the webhook.
     console.error(`Failed to queue ${templateType} mail:`, error);
   }
@@ -381,6 +398,10 @@ function buildMailVars(
   invoice: InvoiceMailData | null = null
 ): Record<string, string> {
   const frontendUrl = process.env.STUJO_FRONTEND_URL || process.env.FRONTEND_URL || '';
+  // The job board admin UI lives in the edu-hub app, not the stujo app, and the
+  // page is pages/manage/settings/jobboerse.tsx. Must match the AdminUrl built
+  // in publishJobPosting/index.js.
+  const adminAppUrl = process.env.FRONTEND_URL || frontendUrl;
   const vatRate =
     invoice && invoice.netTotal > 0 ? String(Math.round((invoice.vatTotal / invoice.netTotal) * 100)) : '';
   return {
@@ -393,11 +414,11 @@ function buildMailVars(
       : '',
     '[JobPosting:DashboardUrl]': `${frontendUrl}/mein-stujo`,
     '[JobPosting:RepostUrl]': `${frontendUrl}/mein-stujo?repost=${posting.id}`,
-    '[JobPosting:AdminUrl]': `${frontendUrl}/manage/jobboerse?posting=${posting.id}`,
+    '[JobPosting:AdminUrl]': `${adminAppUrl}/manage/settings/jobboerse?posting=${posting.id}`,
     '[Organization:Name]': posting.Organization?.name || '',
     '[JobPosting:Payment]': paymentDescription,
     '[Invoice:Number]': invoice?.number || '',
-    '[Invoice:Date]': invoice ? formatDate(new Date()) : '',
+    '[Invoice:Date]': invoice?.date ? formatDate(invoice.date) : '',
     '[Invoice:NetTotal]': invoice ? formatAmount(invoice.netTotal, invoice.currency) : '',
     '[Invoice:VatRate]': vatRate,
     '[Invoice:VatTotal]': invoice ? formatAmount(invoice.vatTotal, invoice.currency) : '',
@@ -561,6 +582,7 @@ export async function handleJobPostingCheckoutCompleted(
     // The document number is what the employer sees on the attached PDF; fall
     // back to our own key while Stripe has not finalized the invoice yet.
     number: invoiceDoc.number ?? invoiceNumber,
+    date: new Date(),
     hostedUrl: invoiceDoc.hostedUrl,
     netTotal,
     vatTotal,
@@ -716,6 +738,7 @@ export async function handleJobPostingInvoiceFinalized(
       id: number;
       jobPostingId: number | null;
       invoiceNumber: string;
+      invoiceDate: string | null;
       netTotal: number;
       vatTotal: number;
       grossTotal: number;
@@ -749,6 +772,7 @@ export async function handleJobPostingInvoiceFinalized(
     posting.expiresAt ? new Date(posting.expiresAt) : null,
     {
       number: invoiceDoc.number ?? row.invoiceNumber,
+      date: row.invoiceDate ? new Date(row.invoiceDate) : new Date(),
       hostedUrl: invoiceDoc.hosted_invoice_url ?? null,
       netTotal: row.netTotal,
       vatTotal: row.vatTotal,

--- a/frontend-nx/apps/edu-hub/locales/de.json
+++ b/frontend-nx/apps/edu-hub/locales/de.json
@@ -2622,7 +2622,12 @@
       "PROJECT_DEADLINE_REMINDER": "Erinnerung Projektabgabe",
       "SESSION_RESCHEDULED": "Termin verschoben",
       "PAYMENT_RECEIPT": "Zahlungsbestätigung",
-      "COURSE_CONTINUATION_INQUIRY": "Nachfrage zur Kursfortsetzung"
+      "COURSE_CONTINUATION_INQUIRY": "Nachfrage zur Kursfortsetzung",
+      "JOB_POSTING_PUBLISHED": "Stellenanzeige veröffentlicht",
+      "JOB_POSTING_EXPIRED": "Stellenanzeige abgelaufen",
+      "JOB_POSTING_ADMIN_NOTICE": "Stellenanzeige: Hinweis an Admins",
+      "JOB_POSTING_PAYMENT_FAILED": "Stellenanzeige: Zahlung fehlgeschlagen",
+      "JOB_ALERT": "Job-Benachrichtigung"
     },
     "placeholders": {
       "subject": "E-Mail-Betreff eingeben...",
@@ -2670,7 +2675,12 @@
       "PROJECT_DEADLINE_REMINDER": "Gesendet 48 Stunden vor dem Abgabetermin eines Projekts",
       "SESSION_RESCHEDULED": "Gesendet an Teilnehmende, wenn sich Datum oder Zeit eines Termins ändert",
       "PAYMENT_RECEIPT": "Gesendet, wenn eine Rechnung für eine Kurs- oder Event-Anmeldung bezahlt wurde",
-      "COURSE_CONTINUATION_INQUIRY": "Gesendet, wenn Teilnehmende so viele Termine versäumt haben, wie für den Kurs maximal erlaubt sind – mit der Bitte, keine weiteren Termine zu verpassen oder kurz Bescheid zu geben, falls sie nicht mehr teilnehmen möchten"
+      "COURSE_CONTINUATION_INQUIRY": "Gesendet, wenn Teilnehmende so viele Termine versäumt haben, wie für den Kurs maximal erlaubt sind – mit der Bitte, keine weiteren Termine zu verpassen oder kurz Bescheid zu geben, falls sie nicht mehr teilnehmen möchten",
+      "JOB_POSTING_PUBLISHED": "Geht an den Arbeitgeber, sobald die Anzeige online ist. Enthält den Zahlungsbeleg, die Rechnungsnummer und die Rechnung als PDF-Anhang. Der Abschnitt zwischen [#if:Invoice] und [/if:Invoice] entfällt bei kostenlosen und über Kontingent bezahlten Anzeigen; [#if:InvoicePdf] nur, wenn das PDF wirklich anhängt.",
+      "JOB_POSTING_EXPIRED": "Geht an den Arbeitgeber, wenn die Laufzeit der Anzeige endet, mit Link zum erneuten Schalten",
+      "JOB_POSTING_ADMIN_NOTICE": "Geht an die Plattform-Admins, wenn eine Anzeige veröffentlicht wurde (Prüfung im Nachhinein)",
+      "JOB_POSTING_PAYMENT_FAILED": "Geht an den Arbeitgeber, wenn eine verzögerte Zahlung (SEPA) fehlschlägt und die Anzeige offline genommen wird",
+      "JOB_ALERT": "Geht an Abonnenten mit neuen Anzeigen, die zu ihrem Suchprofil passen"
     },
     "delete_confirmation": "Bist du sicher, dass du die E-Mail-Vorlage „{title}“ löschen möchtest?",
     "unknown_trigger": "Unbekannter Auslöser-Typ",
@@ -2680,7 +2690,8 @@
       "projects": "Projekt-Benachrichtigungen",
       "sessions": "Termin-Erinnerungen",
       "system": "System-E-Mails",
-      "other": "Sonstige"
+      "other": "Sonstige",
+      "jobboard": "Stellenbörse"
     },
     "category_coming_soon": "Bald",
     "categories_coming_soon_explanation": {}

--- a/frontend-nx/apps/edu-hub/locales/en.json
+++ b/frontend-nx/apps/edu-hub/locales/en.json
@@ -2637,7 +2637,12 @@
       "PROJECT_DEADLINE_REMINDER": "Project Deadline Reminder",
       "SESSION_RESCHEDULED": "Session Rescheduled",
       "PAYMENT_RECEIPT": "Payment Receipt",
-      "COURSE_CONTINUATION_INQUIRY": "Course Continuation Inquiry"
+      "COURSE_CONTINUATION_INQUIRY": "Course Continuation Inquiry",
+      "JOB_POSTING_PUBLISHED": "Job posting published",
+      "JOB_POSTING_EXPIRED": "Job posting expired",
+      "JOB_POSTING_ADMIN_NOTICE": "Job posting: admin notice",
+      "JOB_POSTING_PAYMENT_FAILED": "Job posting: payment failed",
+      "JOB_ALERT": "Job alert"
     },
     "placeholders": {
       "subject": "Enter email subject...",
@@ -2685,7 +2690,12 @@
       "PROJECT_DEADLINE_REMINDER": "Sent 48 hours before a project's submission deadline",
       "SESSION_RESCHEDULED": "Sent to participants when a session's date or time changes",
       "PAYMENT_RECEIPT": "Sent when an invoice for a course or event enrollment is paid",
-      "COURSE_CONTINUATION_INQUIRY": "Sent when a participant reaches the course's limit of missed sessions, asking them not to miss further sessions or to let the team know if they want to stop"
+      "COURSE_CONTINUATION_INQUIRY": "Sent when a participant reaches the course's limit of missed sessions, asking them not to miss further sessions or to let the team know if they want to stop",
+      "JOB_POSTING_PUBLISHED": "Sent to the employer once the posting is live. Carries the payment receipt, the invoice number and the invoice PDF as an attachment. The block between [#if:Invoice] and [/if:Invoice] is dropped for free and credit-funded postings; [#if:InvoicePdf] only renders when the PDF is actually attached.",
+      "JOB_POSTING_EXPIRED": "Sent to the employer when the posting run ends, with a link to post it again",
+      "JOB_POSTING_ADMIN_NOTICE": "Sent to the platform admins when a posting is published (post-hoc moderation)",
+      "JOB_POSTING_PAYMENT_FAILED": "Sent to the employer when a delayed payment (SEPA) fails and the posting is taken offline",
+      "JOB_ALERT": "Sent to subscribers with new postings matching their search profile"
     },
     "delete_confirmation": "Are you sure you want to delete the email template \"{title}\"?",
     "unknown_trigger": "Unknown trigger type",
@@ -2695,7 +2705,8 @@
       "projects": "Project notifications",
       "sessions": "Session reminders",
       "system": "System emails",
-      "other": "Other"
+      "other": "Other",
+      "jobboard": "Job board"
     },
     "category_coming_soon": "Soon",
     "categories_coming_soon_explanation": {}

--- a/frontend-nx/apps/edu-hub/pages/api/webhooks/stripe.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/webhooks/stripe.ts
@@ -1,5 +1,4 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
-import { randomUUID } from 'node:crypto';
 import { GraphQLClient, gql } from 'graphql-request';
 import Stripe from 'stripe';
 import getRawBody from 'raw-body';
@@ -10,7 +9,9 @@ import {
   handleJobPostingAsyncPaymentFailed,
   handleJobPostingCheckoutExpired,
   parseJobPostingId,
+  handleJobPostingInvoiceFinalized,
 } from '../../../lib/stripeJobPosting';
+import { generateInvoiceNumber, resolveStripeInvoice } from '../../../lib/stripeInvoice';
 
 // Disable body parsing - we need raw body for signature verification
 export const config = {
@@ -87,6 +88,7 @@ const INSERT_INVOICE = gql`
     $stripeCheckoutSessionId: String
     $stripePaymentIntentId: String
     $stripeInvoiceId: String
+    $stripeInvoiceNumber: String
     $stripeHostedInvoiceUrl: String
     $stripeInvoicePdfUrl: String
   ) {
@@ -104,6 +106,7 @@ const INSERT_INVOICE = gql`
         stripeCheckoutSessionId: $stripeCheckoutSessionId
         stripePaymentIntentId: $stripePaymentIntentId
         stripeInvoiceId: $stripeInvoiceId
+        stripeInvoiceNumber: $stripeInvoiceNumber
         stripeHostedInvoiceUrl: $stripeHostedInvoiceUrl
         stripeInvoicePdfUrl: $stripeInvoicePdfUrl
       }
@@ -153,20 +156,6 @@ function parseAndValidateEnrollmentId(enrollmentId: string): number | null {
   }
 
   return parsed;
-}
-
-/**
- * Generates a unique invoice number for Stripe Checkout payments.
- * Uses session/payment intent ID as unique suffix when available.
- * Falls back to crypto.randomUUID() when both are absent to avoid collisions.
- */
-function generateInvoiceNumber(
-  prefix: string,
-  sessionId?: string | null,
-  paymentIntentId?: string | null
-): string {
-  const suffix = sessionId || paymentIntentId || `web-${randomUUID()}`;
-  return `${prefix}-${suffix}`;
 }
 
 /**
@@ -278,36 +267,6 @@ const handleStripeWebhook = async (
     }
   );
 
-  /**
-   * Resolves the Stripe-generated invoice document (invoice_creation) so
-   * the Invoice row carries the legally required document references.
-   */
-  const resolveStripeInvoice = async (
-    invoiceRef: string | Stripe.Invoice | null | undefined
-  ): Promise<{ id: string | null; hostedUrl: string | null; pdfUrl: string | null }> => {
-    if (!invoiceRef) {
-      return { id: null, hostedUrl: null, pdfUrl: null };
-    }
-    try {
-      const invoice =
-        typeof invoiceRef === 'string'
-          ? await stripe.invoices.retrieve(invoiceRef)
-          : invoiceRef;
-      return {
-        id: invoice.id ?? null,
-        hostedUrl: invoice.hosted_invoice_url ?? null,
-        pdfUrl: invoice.invoice_pdf ?? null,
-      };
-    } catch (err) {
-      console.warn('Could not resolve Stripe invoice document:', err);
-      return {
-        id: typeof invoiceRef === 'string' ? invoiceRef : null,
-        hostedUrl: null,
-        pdfUrl: null,
-      };
-    }
-  };
-
   const createInvoiceForEnrollment = async (
     enrollmentId: number,
     session: {
@@ -357,7 +316,7 @@ const handleStripeWebhook = async (
       session.stripePaymentIntentId
     );
 
-    const stripeInvoice = await resolveStripeInvoice(session.stripeInvoice);
+    const stripeInvoice = await resolveStripeInvoice(stripe, session.stripeInvoice);
 
     await client.request(INSERT_INVOICE, {
       organizationId,
@@ -372,6 +331,7 @@ const handleStripeWebhook = async (
       stripeCheckoutSessionId: session.stripeCheckoutSessionId,
       stripePaymentIntentId: session.stripePaymentIntentId,
       stripeInvoiceId: stripeInvoice.id,
+      stripeInvoiceNumber: stripeInvoice.number,
       stripeHostedInvoiceUrl: stripeInvoice.hostedUrl,
       stripeInvoicePdfUrl: stripeInvoice.pdfUrl,
     });
@@ -519,6 +479,18 @@ const handleStripeWebhook = async (
           }
         }
 
+        return res.status(200).json({ received: true });
+      }
+
+      // Stripe finalizes invoice_creation invoices asynchronously, so this is
+      // where the document number and the PDF first exist. For job postings it
+      // is also what releases the confirmation mail, which carries the PDF.
+      //
+      // NOTE: this event must be enabled on the endpoint in the Stripe
+      // Dashboard (sandbox and live) -- see docs/STRIPE_INTEGRATION.md. Without
+      // it the mail falls through to the sendPendingJobPostingMails sweep.
+      case 'invoice.finalized': {
+        await handleJobPostingInvoiceFinalized(client, event.data.object as Stripe.Invoice);
         return res.status(200).json({ received: true });
       }
 

--- a/frontend-nx/apps/stujo/components/Layout.tsx
+++ b/frontend-nx/apps/stujo/components/Layout.tsx
@@ -77,6 +77,7 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
   // the live stujo.net pages unless the portal configures its own URLs.
   const imprintUrl = portal.imprintUrl || 'https://www.stujo.net/impressum';
   const privacyUrl = portal.privacyUrl || 'https://www.stujo.net/datenschutz';
+  const termsUrl = portal.termsUrl || 'https://www.stujo.net/agb';
   const isGerman = router.locale === 'de';
   const otherLocale = isGerman ? 'en' : 'de';
 
@@ -192,7 +193,7 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
           </div>
           <div className="stujo-footer-links">
             <h3>{t('footerLinksHead')}</h3>
-            <a href="https://www.stujo.net/agb">AGB</a>
+            <a href={termsUrl}>AGB</a>
             <Link href="/fuer-arbeitgeber">{t('footerPrices')}</Link>
             <a href="https://www.stujo.net/faq">FAQ</a>
             <a href={imprintUrl}>Impressum</a>

--- a/frontend-nx/apps/stujo/components/Layout.tsx
+++ b/frontend-nx/apps/stujo/components/Layout.tsx
@@ -77,7 +77,7 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
   // the live stujo.net pages unless the portal configures its own URLs.
   const imprintUrl = portal.imprintUrl || 'https://www.stujo.net/impressum';
   const privacyUrl = portal.privacyUrl || 'https://www.stujo.net/datenschutz';
-  const termsUrl = portal.termsUrl || 'https://www.stujo.net/agb';
+  const termsUrl = portal.termsUrl || '/agb';
   const isGerman = router.locale === 'de';
   const otherLocale = isGerman ? 'en' : 'de';
 

--- a/frontend-nx/apps/stujo/lib/employer.ts
+++ b/frontend-nx/apps/stujo/lib/employer.ts
@@ -140,8 +140,8 @@ export const DELETE_DRAFT_POSTING = gql`
 `;
 
 export const PUBLISH_JOB_POSTING_ACTION = gql`
-  mutation PublishJobPostingAction($jobPostingId: Int!) {
-    publishJobPosting(jobPostingId: $jobPostingId) {
+  mutation PublishJobPostingAction($jobPostingId: Int!, $acceptTerms: Boolean) {
+    publishJobPosting(jobPostingId: $jobPostingId, acceptTerms: $acceptTerms) {
       success
       published
       checkoutUrl

--- a/frontend-nx/apps/stujo/lib/portal.ts
+++ b/frontend-nx/apps/stujo/lib/portal.ts
@@ -29,6 +29,7 @@ export type PortalBranding = {
   secondaryColor: string | null;
   imprintUrl: string | null;
   privacyUrl: string | null;
+  termsUrl: string | null;
 };
 
 const PORTAL_QUERY = /* GraphQL */ `
@@ -49,6 +50,7 @@ const PORTAL_QUERY = /* GraphQL */ `
       secondaryColor
       imprintUrl
       privacyUrl
+      termsUrl
     }
   }
 `;
@@ -83,6 +85,7 @@ type PortalQueryResult = {
     secondaryColor: string | null;
     imprintUrl: string | null;
     privacyUrl: string | null;
+    termsUrl: string | null;
   }[];
 };
 
@@ -150,5 +153,6 @@ export async function resolvePortal(host: string | undefined): Promise<PortalBra
     secondaryColor: settings?.secondaryColor ?? null,
     imprintUrl: settings?.imprintUrl ?? null,
     privacyUrl: settings?.privacyUrl ?? null,
+    termsUrl: settings?.termsUrl ?? null,
   };
 }

--- a/frontend-nx/apps/stujo/locales/de.json
+++ b/frontend-nx/apps/stujo/locales/de.json
@@ -87,7 +87,14 @@
     "publishNetworkError": "Veröffentlichen fehlgeschlagen: Netzwerkfehler.",
     "archiveFailed": "Archivieren fehlgeschlagen: {error}",
     "archiveNetworkError": "Archivieren fehlgeschlagen: Netzwerkfehler.",
-    "unknownError": "Unbekannter Fehler"
+    "unknownError": "Unbekannter Fehler",
+    "acceptTermsPrefix": "Ich habe die",
+    "acceptTermsLink": "Allgemeinen Geschäftsbedingungen",
+    "acceptTermsSuffix": "gelesen und akzeptiere sie.",
+    "acceptTermsRequired": "Bitte akzeptiere die AGB, um Dein Angebot zu veröffentlichen.",
+    "consentPromptPrefix": "Für die kostenpflichtige Veröffentlichung gelten unsere",
+    "consentPromptSuffix": ".",
+    "consentAcceptAndPublish": "AGB akzeptieren und veröffentlichen"
   },
   "jobType": {
     "MINIJOB": "Minijobs",

--- a/frontend-nx/apps/stujo/locales/en.json
+++ b/frontend-nx/apps/stujo/locales/en.json
@@ -87,7 +87,14 @@
     "publishNetworkError": "Publishing failed: network error.",
     "archiveFailed": "Archiving failed: {error}",
     "archiveNetworkError": "Archiving failed: network error.",
-    "unknownError": "Unknown error"
+    "unknownError": "Unknown error",
+    "acceptTermsPrefix": "I have read the",
+    "acceptTermsLink": "terms and conditions",
+    "acceptTermsSuffix": "and accept them.",
+    "acceptTermsRequired": "Please accept the terms to publish your posting.",
+    "consentPromptPrefix": "Publishing a paid posting is subject to our",
+    "consentPromptSuffix": ".",
+    "consentAcceptAndPublish": "Accept terms and publish"
   },
   "jobType": {
     "MINIJOB": "Mini jobs",

--- a/frontend-nx/apps/stujo/pages/agb.tsx
+++ b/frontend-nx/apps/stujo/pages/agb.tsx
@@ -1,0 +1,150 @@
+import Head from 'next/head';
+import { FC } from 'react';
+import { GetServerSideProps } from 'next';
+
+import Layout from '../components/Layout';
+import { resolvePortal, PortalBranding } from '../lib/portal';
+
+type Props = { portal: PortalBranding };
+
+/**
+ * Terms and conditions for the StuJo job board.
+ *
+ * In-repo rather than on the marketing site so that the consent recorded in
+ * JobPosting.termsAcceptedAt is provable: the process in
+ * docs/LEGAL_DOCUMENTS.md recovers the accepted version with
+ * `git log --until=<timestamp> -- <this file>`, which only works while the
+ * document lives in git. Update the "Stand" date whenever the text changes.
+ */
+const Agb: FC<Props> = ({ portal }) => (
+  <Layout portal={portal}>
+    <Head>
+      <title>AGB | {portal.title}</title>
+    </Head>
+
+    <div className="stujo-legal">
+      <h1>Allgemeine Geschäftsbedingungen</h1>
+
+      <h2>§ 1 Geltungsbereich</h2>
+      <p>
+        Diese Allgemeinen Geschäftsbedingungen gelten für die Schaltung von Stellen-, Projekt- und
+        Veranstaltungsangeboten (nachfolgend „Anzeigen“) auf dem Karrierenetzwerk StuJo, betrieben
+        vom Campus Business Box e.V. (nachfolgend „CBB“).
+      </p>
+      <p>
+        Inserenten können ausschließlich Unternehmer im Sinne des § 14 BGB, juristische Personen des
+        öffentlichen Rechts oder öffentlich-rechtliche Sondervermögen sein. Ein Verbrauchervertrag im
+        Sinne des § 310 Abs. 3 BGB kommt nicht zustande. Die Vorschriften über Fernabsatzverträge mit
+        Verbrauchern, insbesondere das Widerrufsrecht nach § 312g BGB, finden keine Anwendung.
+      </p>
+
+      <h2>§ 2 Vertragsgegenstand</h2>
+      <p>
+        CBB stellt Inserenten die technische Infrastruktur zur Veröffentlichung von Anzeigen zur
+        Verfügung. CBB wird nicht vermittelnd tätig und schuldet keinen Vermittlungserfolg,
+        insbesondere nicht das Zustandekommen eines Arbeits-, Praktikums- oder Projektverhältnisses.
+      </p>
+
+      <h2>§ 3 Vertragsschluss</h2>
+      <p>
+        Der Inserent gibt die Anzeige selbstständig über das Online-Formular ein. Mit dem Absenden
+        einer kostenpflichtigen Anzeige gibt er ein verbindliches Angebot auf Abschluss eines
+        Schaltungsvertrages ab. Der Vertrag kommt mit erfolgreichem Abschluss des Zahlungsvorgangs
+        zustande.
+      </p>
+
+      <h2>§ 4 Preise, Fälligkeit und Zahlungsweise</h2>
+      <p>
+        Es gelten die im Bestellvorgang angezeigten Preise. Alle Preise verstehen sich zuzüglich der
+        gesetzlichen Umsatzsteuer.
+      </p>
+      <p>
+        Kostenpflichtige Anzeigen werden im Wege der Vorkasse abgerechnet. Die Zahlungsabwicklung
+        erfolgt über den Zahlungsdienstleister Stripe (Stripe Payments Europe, Ltd.). Zur Verfügung
+        stehen die im Bestellvorgang angezeigten Zahlungsarten.
+      </p>
+      <p>
+        Bei Zahlungsarten mit verzögerter Gutschrift, etwa SEPA-Lastschrift, wird die Anzeige bereits
+        vor Zahlungseingang veröffentlicht. Scheitert der Einzug, ist CBB berechtigt, die Anzeige
+        unverzüglich offline zu nehmen.
+      </p>
+
+      <h2>§ 5 Elektronische Rechnungsstellung</h2>
+      <p>
+        Die Rechnungsstellung erfolgt elektronisch. Der Inserent stimmt zu, dass ihm Rechnungen
+        ausschließlich in elektronischer Form übermittelt werden, insbesondere als PDF-Datei per
+        E-Mail an die im Nutzerkonto hinterlegte Kontakt-E-Mail-Adresse sowie ergänzend über einen
+        Zugriffslink auf das Rechnungsdokument.
+      </p>
+      <p>
+        Der Inserent stellt sicher, dass die hinterlegte E-Mail-Adresse zutreffend und empfangsbereit
+        ist. Ein Anspruch auf Übermittlung einer Papierrechnung besteht nicht. Die Zustimmung kann
+        mit Wirkung für die Zukunft widerrufen werden.
+      </p>
+
+      <h2>§ 6 Laufzeit und Veröffentlichung</h2>
+      <p>
+        Anzeigen werden nach Vertragsschluss veröffentlicht und sind, soweit im Bestellvorgang nicht
+        anders angegeben, acht Wochen sichtbar. Danach werden sie archiviert.
+      </p>
+      <p>
+        Der Inserent kann seine Anzeige jederzeit vorzeitig über den Unternehmenszugang löschen. Ein
+        Anspruch auf Erstattung für die verbleibende Laufzeit besteht in diesem Fall nicht.
+      </p>
+
+      <h2>§ 7 Pflichten des Inserenten</h2>
+      <p>
+        Der Inserent ist für den Inhalt seiner Anzeige verantwortlich. Er sichert zu, dass die Anzeige
+        nicht gegen geltendes Recht verstößt, insbesondere nicht gegen das Allgemeine
+        Gleichbehandlungsgesetz, und keine Rechte Dritter verletzt.
+      </p>
+      <p>
+        CBB behält sich vor, Anzeigen ohne Angabe von Gründen abzulehnen oder zu entfernen. Ein
+        Anspruch auf Veröffentlichung besteht nicht.
+      </p>
+
+      <h2>§ 8 Haftung</h2>
+      <p>
+        CBB übernimmt keine Haftung für den Inhalt der Anzeigen. Die Haftung ist auf Vorsatz und grobe
+        Fahrlässigkeit beschränkt. Hiervon unberührt bleibt die Haftung für Schäden aus der Verletzung
+        des Lebens, des Körpers oder der Gesundheit sowie die Haftung nach dem Produkthaftungsgesetz.
+      </p>
+
+      <h2>§ 9 Urheberrecht</h2>
+      <p>
+        Die Inhalte des Karrierenetzwerks sind urheberrechtlich geschützt. Eine Vervielfältigung oder
+        Verwendung, insbesondere das systematische Auslesen von Anzeigen, bedarf der vorherigen
+        schriftlichen Zustimmung von CBB.
+      </p>
+
+      <h2>§ 10 Datenschutz</h2>
+      <p>
+        Die vom Inserenten übermittelten Daten werden ausschließlich zur Abwicklung des Vertrages und
+        zur Administration des Karrierenetzwerks verarbeitet und gespeichert. Einzelheiten regelt die
+        Datenschutzerklärung.
+      </p>
+
+      <h2>§ 11 Externe Verweise</h2>
+      <p>
+        Für die Inhalte verlinkter externer Websites ist ausschließlich deren jeweiliger Anbieter
+        verantwortlich.
+      </p>
+
+      <h2>§ 12 Schlussbestimmungen</h2>
+      <p>Erfüllungsort und Gerichtsstand ist Kiel.</p>
+      <p>
+        Sollten einzelne Bestimmungen unwirksam sein, bleibt die Wirksamkeit der übrigen Regelungen
+        unberührt.
+      </p>
+
+      <p className="stujo-legal-date">Stand: 1. September 2026</p>
+    </div>
+  </Layout>
+);
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ req }) => {
+  const portal = await resolvePortal(req.headers.host);
+  return { props: { portal } };
+};
+
+export default Agb;

--- a/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
@@ -207,7 +207,7 @@ const MeinStujo: FC<Props> = ({ portal }) => {
             <span>
               Für die kostenpflichtige Veröffentlichung gelten unsere{' '}
               <a
-                href={portal.termsUrl || 'https://www.stujo.net/agb'}
+                href={portal.termsUrl || '/agb'}
                 target="_blank"
                 rel="noreferrer"
               >

--- a/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
@@ -205,22 +205,18 @@ const MeinStujo: FC<Props> = ({ portal }) => {
         <div className="stujo-notice">
           <label className="stujo-consent">
             <span>
-              Für die kostenpflichtige Veröffentlichung gelten unsere{' '}
-              <a
-                href={portal.termsUrl || '/agb'}
-                target="_blank"
-                rel="noreferrer"
-              >
-                Allgemeinen Geschäftsbedingungen
+              {t('consentPromptPrefix')}{' '}
+              <a href={portal.termsUrl || '/agb'} target="_blank" rel="noreferrer">
+                {t('acceptTermsLink')}
               </a>
-              .
+              {t('consentPromptSuffix')}
             </span>
           </label>
           <button
             className="stujo-btn stujo-btn--accent"
             onClick={() => handlePublish(consentNeededFor, true)}
           >
-            AGB akzeptieren und veröffentlichen
+            {t('consentAcceptAndPublish')}
           </button>
         </div>
       )}

--- a/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
@@ -48,6 +48,7 @@ const MeinStujo: FC<Props> = ({ portal }) => {
   const router = useRouter();
   const { status: sessionStatus } = useSession();
   const [notice, setNotice] = useState<string | null>(null);
+  const [consentNeededFor, setConsentNeededFor] = useState<number | null>(null);
 
   const employerRole = useEmployerRoleContext();
   const {
@@ -99,18 +100,23 @@ const MeinStujo: FC<Props> = ({ portal }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [router.query.repost, data]);
 
-  const handlePublish = async (jobPostingId: number) => {
+  const handlePublish = async (jobPostingId: number, acceptTerms = false) => {
     setNotice(null);
     try {
-      const result = await publishPosting({ variables: { jobPostingId } });
+      const result = await publishPosting({ variables: { jobPostingId, acceptTerms } });
       const payload = result.data?.publishJobPosting;
       if (payload?.checkoutUrl) {
         window.location.href = payload.checkoutUrl;
         return;
       }
       if (payload?.success) {
+        setConsentNeededFor(null);
         setNotice(payload.usedCredit ? t('noticePublishedCredit') : t('noticePublished'));
         await refetch();
+      } else if (payload?.messageKey === 'TERMS_NOT_ACCEPTED') {
+        // A posting published before consent was recorded, or reposted from an
+        // expiry mail. Ask here rather than failing the action.
+        setConsentNeededFor(jobPostingId);
       } else {
         setNotice(t('publishFailed', { error: payload?.error ?? t('unknownError') }));
       }
@@ -194,6 +200,30 @@ const MeinStujo: FC<Props> = ({ portal }) => {
       </div>
 
       {notice && <div className="stujo-notice">{notice}</div>}
+
+      {consentNeededFor !== null && (
+        <div className="stujo-notice">
+          <label className="stujo-consent">
+            <span>
+              Für die kostenpflichtige Veröffentlichung gelten unsere{' '}
+              <a
+                href={portal.termsUrl || 'https://www.stujo.net/agb'}
+                target="_blank"
+                rel="noreferrer"
+              >
+                Allgemeinen Geschäftsbedingungen
+              </a>
+              .
+            </span>
+          </label>
+          <button
+            className="stujo-btn stujo-btn--accent"
+            onClick={() => handlePublish(consentNeededFor, true)}
+          >
+            AGB akzeptieren und veröffentlichen
+          </button>
+        </div>
+      )}
 
       <div className="stujo-stats">
         {[

--- a/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
@@ -256,7 +256,7 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
   const publish = async () => {
     setErrorMessage(null);
     if (requiresConsent && !acceptTerms) {
-      setErrorMessage('Bitte akzeptiere die AGB, um Dein Angebot zu veröffentlichen.');
+      setErrorMessage(t('acceptTermsRequired'));
       return;
     }
     const id = savedId ?? (await saveDraft());
@@ -511,11 +511,11 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
                 onChange={(event) => setAcceptTerms(event.target.checked)}
               />
               <span>
-                Ich habe die{' '}
+                {t('acceptTermsPrefix')}{' '}
                 <a href={termsUrl} target="_blank" rel="noreferrer">
-                  Allgemeinen Geschäftsbedingungen
+                  {t('acceptTermsLink')}
                 </a>{' '}
-                gelesen und akzeptiere sie.
+                {t('acceptTermsSuffix')}
               </span>
             </label>
           )}

--- a/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
@@ -288,7 +288,7 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
   // the same rule the course registration modal applies via
   // `config.requiresPayment && !acceptTerms`.
   const requiresConsent = netPrice > 0 && credits === 0;
-  const termsUrl = portal.termsUrl || 'https://www.stujo.net/agb';
+  const termsUrl = portal.termsUrl || '/agb';
 
   const field = (
     label: string,

--- a/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/neu.tsx
@@ -83,6 +83,7 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
   // and the preview once a draft exists.
   const [draftOrganizationId, setDraftOrganizationId] = useState<number | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [acceptTerms, setAcceptTerms] = useState(false);
   // The offer PDF is the centerpiece of a StuJo posting (embedded on the
   // detail page like in the Rails app). Uploaded after the draft exists.
   const [pdfFile, setPdfFile] = useState<File | null>(null);
@@ -254,9 +255,15 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
 
   const publish = async () => {
     setErrorMessage(null);
+    if (requiresConsent && !acceptTerms) {
+      setErrorMessage('Bitte akzeptiere die AGB, um Dein Angebot zu veröffentlichen.');
+      return;
+    }
     const id = savedId ?? (await saveDraft());
     if (!id) return;
-    const result = await publishPosting({ variables: { jobPostingId: id } });
+    const result = await publishPosting({
+      variables: { jobPostingId: id, acceptTerms },
+    });
     const payload = result.data?.publishJobPosting;
     if (payload?.checkoutUrl) {
       window.location.href = payload.checkoutUrl;
@@ -277,6 +284,11 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
     0
   );
   const busy = creating || updating || publishing || uploadingPdf;
+  // Only a paid publish concludes a contract, so only that asks for consent --
+  // the same rule the course registration modal applies via
+  // `config.requiresPayment && !acceptTerms`.
+  const requiresConsent = netPrice > 0 && credits === 0;
+  const termsUrl = portal.termsUrl || 'https://www.stujo.net/agb';
 
   const field = (
     label: string,
@@ -490,6 +502,23 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
             )}
           </div>
           )}
+          {!isLive && requiresConsent && (
+            <label className="stujo-consent">
+              <input
+                type="checkbox"
+                checked={acceptTerms}
+                disabled={busy}
+                onChange={(event) => setAcceptTerms(event.target.checked)}
+              />
+              <span>
+                Ich habe die{' '}
+                <a href={termsUrl} target="_blank" rel="noreferrer">
+                  Allgemeinen Geschäftsbedingungen
+                </a>{' '}
+                gelesen und akzeptiere sie.
+              </span>
+            </label>
+          )}
           <div className="stujo-form-actions">
             <button className="stujo-btn stujo-btn--ghost" disabled={busy} onClick={() => setStep(1)}>
               ← Zurück
@@ -506,7 +535,11 @@ const NeuesAngebot: FC<Props> = ({ portal }) => {
                 Änderungen speichern
               </button>
             ) : (
-              <button className="stujo-btn stujo-btn--accent" disabled={busy} onClick={publish}>
+              <button
+                className="stujo-btn stujo-btn--accent"
+                disabled={busy || (requiresConsent && !acceptTerms)}
+                onClick={publish}
+              >
                 {netPrice === 0 || credits > 0
                   ? 'Jetzt veröffentlichen'
                   : `Kostenpflichtig veröffentlichen · ${(grossPrice / 100).toFixed(2).replace('.', ',')} €`}

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -681,6 +681,25 @@ a:focus {
   margin-top: 0.5rem;
 }
 
+/* Consent checkbox at the point of purchase. Not .stujo-field: that is a
+   column layout and forces bold labels. */
+.stujo-consent {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+  margin: 1rem 0 0;
+  max-width: 30rem;
+  font-size: 0.9em;
+  line-height: 1.4;
+}
+
+.stujo-consent input[type='checkbox'] {
+  margin-top: 0.2rem;
+  flex-shrink: 0;
+  width: 1rem;
+  height: 1rem;
+}
+
 .stujo-order-box {
   border: 2px solid var(--stujo-border);
   padding: 1.25rem;

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -683,6 +683,29 @@ a:focus {
 
 /* Consent checkbox at the point of purchase. Not .stujo-field: that is a
    column layout and forces bold labels. */
+/* Legal documents (AGB). Narrow measure and generous spacing so long clauses
+   stay readable. */
+.stujo-legal {
+  max-width: 46em;
+  line-height: 1.6;
+}
+
+.stujo-legal h2 {
+  margin-top: 2em;
+  margin-bottom: 0.4em;
+  font-size: 1.1rem;
+}
+
+.stujo-legal p {
+  margin: 0 0 0.9em;
+}
+
+.stujo-legal-date {
+  margin-top: 3em;
+  font-size: 0.85em;
+  opacity: 0.7;
+}
+
 .stujo-consent {
   display: flex;
   align-items: flex-start;

--- a/functions/callNodeFunction/EMAIL_TEMPLATE_VARIABLES.md
+++ b/functions/callNodeFunction/EMAIL_TEMPLATE_VARIABLES.md
@@ -115,6 +115,61 @@ The email template variable system is centralized in `emailTemplateVariables.js`
   - Example: `https://edu.opencampus.sh`
   - Available in: user creation emails
 
+### StuJo Job Board Variables
+*Available in: job posting emails (employer-facing)*
+
+> **These do not go through `createVariableReplacer`.** The job board mails are
+> substituted by their own replacers, in
+> `frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts` (`buildMailVars`) and
+> `functions/callNodeFunction/publishJobPosting/index.js`
+> (`buildJobPostingMailVars`). A test asserts the two key sets are identical,
+> because the replacers only substitute keys they are handed -- a variable added
+> to one path but not the other reaches the employer as literal
+> `[Invoice:Number]` text. Adding a variable therefore means editing both
+> replacers as well as the registry.
+
+- **`[JobPosting:Title]`**: Job posting title
+  - Example: `Werkstudent:in Frontend`
+- **`[JobPosting:Type]`**: Posting category as a display label, not the raw enum
+  - Example: `Studentenjob`
+- **`[JobPosting:PublishedAt]`** / **`[JobPosting:ExpiresAt]`**: Run dates
+  - Example: `29. August 2026`
+- **`[JobPosting:Payment]`**: How the posting was paid for
+  - Example: `59,50 € (bezahlt)`, `kostenlos`, `Kontingent`
+- **`[JobPosting:DashboardUrl]`** / **`[JobPosting:RepostUrl]`** / **`[JobPosting:AdminUrl]`**: Links
+- **`[JobPosting:TermsAcceptedAt]`**: When the employer accepted the terms; empty if never recorded
+- **`[Organization:Name]`**: Employer organisation name
+- **`[Legal:TermsUrl]`**: Terms URL for the mail footer
+
+### Invoice Variables
+*Available in: job posting emails*
+
+Empty on free and credit-funded postings, which have no `Invoice` row.
+
+- **`[Invoice:Number]`**: The number printed on the Stripe invoice document, falling
+  back to our own record key while Stripe has not finalized it
+  - Example: `VGD1VIPO-0001`
+- **`[Invoice:Date]`**, **`[Invoice:NetTotal]`**, **`[Invoice:VatRate]`**,
+  **`[Invoice:VatTotal]`**, **`[Invoice:GrossTotal]`**, **`[Invoice:PaymentStatus]`**
+- **`[Invoice:HostedUrl]`**: Stripe hosted invoice page
+
+### Conditional Blocks
+
+Job board templates support `[#if:Flag] ... [/if:Flag]`, dropped when the flag is
+falsy. This is what lets one template serve paid, free and credit-funded
+postings. Blocks may nest.
+
+| Flag | True when |
+| --- | --- |
+| `Invoice` | The posting was paid for and has an invoice |
+| `InvoicePdf` | The invoice PDF is actually attached to this mail |
+| `InvoiceLink` | A hosted invoice URL exists |
+| `InvoicePending` | Neither PDF nor link exists yet, so the document follows separately |
+| `TermsAccepted` | A consent timestamp was recorded |
+
+`InvoicePdf` is deliberately separate from `Invoice`: the mail must not claim a
+PDF is attached when the fallback sweep had to send without one.
+
 ## Date Formatting
 
 All date variables are automatically formatted based on the app's timezone setting:

--- a/functions/callNodeFunction/__tests__/jobPostingMailTemplating.test.js
+++ b/functions/callNodeFunction/__tests__/jobPostingMailTemplating.test.js
@@ -1,0 +1,64 @@
+import {
+  applyConditionalBlocks,
+  escapeHtml,
+  replaceJobPostingVariables,
+} from '../publishJobPosting/index.js';
+
+describe('applyConditionalBlocks', () => {
+  it('keeps the body and strips the markers when the flag is set', () => {
+    expect(applyConditionalBlocks('a[#if:Invoice]b[/if:Invoice]c', { Invoice: true })).toBe('abc');
+  });
+
+  it('drops the whole section when the flag is falsy', () => {
+    expect(applyConditionalBlocks('a[#if:Invoice]b[/if:Invoice]c', { Invoice: false })).toBe('ac');
+    expect(applyConditionalBlocks('a[#if:Invoice]b[/if:Invoice]c', {})).toBe('ac');
+  });
+
+  it('resolves a nested block, which a single replace pass cannot', () => {
+    const template = 'x[#if:Invoice]A[#if:InvoiceLink]L[/if:InvoiceLink]B[/if:Invoice]y';
+    expect(applyConditionalBlocks(template, { Invoice: true, InvoiceLink: true })).toBe('xALBy');
+    expect(applyConditionalBlocks(template, { Invoice: true, InvoiceLink: false })).toBe('xABy');
+    expect(applyConditionalBlocks(template, { Invoice: false, InvoiceLink: true })).toBe('xy');
+  });
+
+  it('leaves an unclosed marker untouched rather than eating the rest of the mail', () => {
+    expect(applyConditionalBlocks('a[#if:Invoice]b', { Invoice: true })).toBe('a[#if:Invoice]b');
+  });
+
+  it('handles empty and missing input', () => {
+    expect(applyConditionalBlocks('', {})).toBe('');
+    expect(applyConditionalBlocks(undefined, {})).toBe('');
+  });
+});
+
+describe('escapeHtml', () => {
+  it('neutralises markup in employer-controlled values', () => {
+    expect(escapeHtml('<script>alert("x")</script>')).toBe(
+      '&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;'
+    );
+  });
+
+  it('escapes ampersands first so entities are not double-broken', () => {
+    expect(escapeHtml('A & B < C')).toBe('A &amp; B &lt; C');
+  });
+});
+
+describe('replaceJobPostingVariables', () => {
+  const vars = { '[JobPosting:Title]': 'Werkstudent <IT> & Co' };
+
+  it('escapes substituted values in HTML bodies', () => {
+    expect(replaceJobPostingVariables('<p>[JobPosting:Title]</p>', vars)).toBe(
+      '<p>Werkstudent &lt;IT&gt; &amp; Co</p>'
+    );
+  });
+
+  it('does not escape in subjects, which are plain text', () => {
+    expect(replaceJobPostingVariables('[JobPosting:Title]', vars, { html: false })).toBe(
+      'Werkstudent <IT> & Co'
+    );
+  });
+
+  it('substitutes an empty string for null values', () => {
+    expect(replaceJobPostingVariables('x[Invoice:Number]y', { '[Invoice:Number]': null })).toBe('xy');
+  });
+});

--- a/functions/callNodeFunction/__tests__/jobPostingMailVars.test.js
+++ b/functions/callNodeFunction/__tests__/jobPostingMailVars.test.js
@@ -10,6 +10,7 @@ const posting = {
 
 const paidInvoice = {
   number: 'VGD1VIPO-0001',
+  date: new Date('2026-08-29'),
   hostedUrl: 'https://invoice.stripe.com/i/x',
   netTotal: 50,
   vatTotal: 10,
@@ -58,6 +59,39 @@ describe('buildJobPostingMailVars', () => {
     expect(paid['[Invoice:VatRate]']).toBe('20');
     expect(paid['[Invoice:GrossTotal]']).toBe('0,60 €');
     expect(paid['[Invoice:PaymentStatus]']).toBe('bezahlt');
+  });
+
+  it('renders the invoice date, not the moment the mail is sent', () => {
+    // On the invoice.finalized and sweep paths the mail is queued minutes to
+    // days after the invoice was raised, and the PDF shows the invoice date.
+    const vars = buildJobPostingMailVars(posting, {
+      expiresAt: null,
+      publishedAt: null,
+      paymentDescription: '',
+      invoice: { ...paidInvoice, date: new Date('2026-01-15') },
+    });
+    expect(vars['[Invoice:Date]']).toBe('15. Januar 2026');
+  });
+
+  it('leaves the invoice date empty rather than throwing when it is missing', () => {
+    // This runs inside the publish action; a throw here would fail the publish.
+    const { date, ...noDate } = paidInvoice;
+    expect(() =>
+      buildJobPostingMailVars(posting, {
+        expiresAt: null,
+        publishedAt: null,
+        paymentDescription: '',
+        invoice: noDate,
+      })
+    ).not.toThrow();
+    const vars = buildJobPostingMailVars(posting, {
+      expiresAt: null,
+      publishedAt: null,
+      paymentDescription: '',
+      invoice: noDate,
+    });
+    expect(vars['[Invoice:Date]']).toBe('');
+    expect(vars['[Invoice:Number]']).toBe('VGD1VIPO-0001');
   });
 
   it('never divides by zero when the net total is zero', () => {

--- a/functions/callNodeFunction/__tests__/jobPostingMailVars.test.js
+++ b/functions/callNodeFunction/__tests__/jobPostingMailVars.test.js
@@ -1,0 +1,100 @@
+import { buildJobPostingMailVars, formatJobPostingAmount } from '../publishJobPosting/index.js';
+
+const posting = {
+  id: 42,
+  title: 'Werkstudent Frontend',
+  type: 'WORKING_STUDENT',
+  termsAcceptedAt: null,
+  Organization: { name: 'Coding Werkstatt' },
+};
+
+const paidInvoice = {
+  number: 'VGD1VIPO-0001',
+  hostedUrl: 'https://invoice.stripe.com/i/x',
+  netTotal: 50,
+  vatTotal: 10,
+  grossTotal: 60,
+  currency: 'EUR',
+  paid: true,
+};
+
+describe('buildJobPostingMailVars', () => {
+  it('produces the same key set with and without an invoice', () => {
+    // The replacer only substitutes keys it is handed, so a key present on the
+    // paid path but missing on the free path would reach the employer as a
+    // literal "[Invoice:Number]".
+    const free = buildJobPostingMailVars(posting, {
+      expiresAt: new Date('2026-10-23'),
+      publishedAt: new Date('2026-08-29'),
+      paymentDescription: 'kostenlos',
+    });
+    const paid = buildJobPostingMailVars(posting, {
+      expiresAt: new Date('2026-10-23'),
+      publishedAt: new Date('2026-08-29'),
+      paymentDescription: '0,60 € (bezahlt)',
+      invoice: paidInvoice,
+    });
+    expect(Object.keys(free).sort()).toEqual(Object.keys(paid).sort());
+  });
+
+  it('leaves every invoice variable empty on the free path', () => {
+    const free = buildJobPostingMailVars(posting, {
+      expiresAt: new Date('2026-10-23'),
+      publishedAt: new Date('2026-08-29'),
+      paymentDescription: 'kostenlos',
+    });
+    for (const [key, value] of Object.entries(free)) {
+      if (key.startsWith('[Invoice:')) expect(value).toBe('');
+    }
+  });
+
+  it('derives the VAT rate from the amounts', () => {
+    const paid = buildJobPostingMailVars(posting, {
+      expiresAt: null,
+      publishedAt: null,
+      paymentDescription: '',
+      invoice: paidInvoice,
+    });
+    expect(paid['[Invoice:VatRate]']).toBe('20');
+    expect(paid['[Invoice:GrossTotal]']).toBe('0,60 €');
+    expect(paid['[Invoice:PaymentStatus]']).toBe('bezahlt');
+  });
+
+  it('never divides by zero when the net total is zero', () => {
+    const vars = buildJobPostingMailVars(posting, {
+      expiresAt: null,
+      publishedAt: null,
+      paymentDescription: '',
+      invoice: { ...paidInvoice, netTotal: 0, vatTotal: 0 },
+    });
+    expect(vars['[Invoice:VatRate]']).toBe('');
+  });
+
+  it('renders the human label for the posting type, not the raw enum', () => {
+    const vars = buildJobPostingMailVars(posting, {
+      expiresAt: null,
+      publishedAt: null,
+      paymentDescription: '',
+    });
+    expect(vars['[JobPosting:Type]']).toBe('Studentenjob');
+  });
+
+  it('falls back to the raw value for an unknown type', () => {
+    const vars = buildJobPostingMailVars(
+      { ...posting, type: 'SOMETHING_NEW' },
+      { expiresAt: null, publishedAt: null, paymentDescription: '' }
+    );
+    expect(vars['[JobPosting:Type]']).toBe('SOMETHING_NEW');
+  });
+});
+
+describe('formatJobPostingAmount', () => {
+  it('formats euro cents in German notation', () => {
+    expect(formatJobPostingAmount(60, 'EUR')).toBe('0,60 €');
+    expect(formatJobPostingAmount(123456, 'EUR')).toBe('1234,56 €');
+  });
+
+  it('falls back to the currency code for non-euro', () => {
+    expect(formatJobPostingAmount(100, 'chf')).toBe('1,00 CHF');
+  });
+});

--- a/functions/callNodeFunction/__tests__/jobPostingTemplateRender.test.js
+++ b/functions/callNodeFunction/__tests__/jobPostingTemplateRender.test.js
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  applyConditionalBlocks,
+  buildJobPostingMailVars,
+  replaceJobPostingVariables,
+} from '../publishJobPosting/index.js';
+
+/**
+ * Renders the shipped JOB_POSTING_PUBLISHED template out of its migration.
+ *
+ * The template is data, not code, so these are the only tests that can catch a
+ * conditional block that was left unbalanced or a claim that contradicts what
+ * was actually sent.
+ */
+const MIGRATION = path.join(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../backend/migrations/default',
+  '1788200000001_update_job_posting_published_mail_template/up.sql'
+);
+
+const sql = fs.readFileSync(MIGRATION, 'utf8');
+const template = sql.slice(sql.indexOf('"content" = \'') + 13, sql.lastIndexOf("'\nWHERE"));
+
+const posting = {
+  id: 42,
+  title: 'Werkstudent Frontend',
+  type: 'WORKING_STUDENT',
+  termsAcceptedAt: '2026-08-29T10:00:00Z',
+  Organization: { name: 'Coding Werkstatt' },
+};
+
+const invoiceWith = (hostedUrl) => ({
+  number: 'VGD1VIPO-0001',
+  hostedUrl,
+  netTotal: 50,
+  vatTotal: 10,
+  grossTotal: 60,
+  currency: 'EUR',
+  paid: true,
+});
+
+function render(flags, invoice) {
+  const vars = buildJobPostingMailVars(posting, {
+    expiresAt: new Date('2026-10-23'),
+    publishedAt: new Date('2026-08-29'),
+    paymentDescription: invoice ? '0,60 € (bezahlt)' : 'kostenlos',
+    invoice,
+  });
+  return replaceJobPostingVariables(applyConditionalBlocks(template, flags), vars);
+}
+
+const SCENARIOS = [
+  ['paid, PDF attached and link', { Invoice: true, InvoicePdf: true, InvoiceLink: true, InvoicePending: false, TermsAccepted: true }, invoiceWith('https://invoice.stripe.com/i/x')],
+  ['sweep, link but no PDF', { Invoice: true, InvoicePdf: false, InvoiceLink: true, InvoicePending: false, TermsAccepted: true }, invoiceWith('https://invoice.stripe.com/i/x')],
+  ['sweep, neither PDF nor link', { Invoice: true, InvoicePdf: false, InvoiceLink: false, InvoicePending: true, TermsAccepted: true }, invoiceWith(null)],
+  ['free / credit', { Invoice: false, InvoicePdf: false, InvoiceLink: false, InvoicePending: false, TermsAccepted: false }, null],
+];
+
+describe('JOB_POSTING_PUBLISHED template', () => {
+  it.each(SCENARIOS)('leaves no unresolved placeholder or marker: %s', (_label, flags, invoice) => {
+    const html = render(flags, invoice);
+    expect(html).not.toMatch(/\[#if:/);
+    expect(html).not.toMatch(/\[\/if:/);
+    expect(html).not.toMatch(/\[[A-Za-z]+:[A-Za-z]+\]/);
+  });
+
+  it.each(SCENARIOS)('only promises an attached PDF when one is attached: %s', (_label, flags, invoice) => {
+    const html = render(flags, invoice);
+    expect(/liegt dieser E-Mail als PDF bei/.test(html)).toBe(flags.InvoicePdf);
+  });
+
+  it('tells the employer the document follows when neither PDF nor link exists', () => {
+    const html = render(SCENARIOS[2][1], SCENARIOS[2][2]);
+    expect(html).toMatch(/in Kürze separat/);
+  });
+
+  it('omits the whole invoice section for free and credit postings', () => {
+    const html = render(SCENARIOS[3][1], SCENARIOS[3][2]);
+    expect(html).not.toMatch(/Rechnung/);
+    expect(html).toMatch(/kostenlos/);
+  });
+
+  it('names the terms, and the acceptance date only when one is recorded', () => {
+    expect(render(SCENARIOS[0][1], SCENARIOS[0][2])).toMatch(/29\. August 2026 bei der Veröffentlichung zugestimmt/);
+    const free = render(SCENARIOS[3][1], SCENARIOS[3][2]);
+    expect(free).toMatch(/Allgemeinen Geschäftsbedingungen/);
+    expect(free).not.toMatch(/zugestimmt/);
+  });
+});

--- a/functions/callNodeFunction/__tests__/jobPostingTemplateRender.test.js
+++ b/functions/callNodeFunction/__tests__/jobPostingTemplateRender.test.js
@@ -34,6 +34,7 @@ const posting = {
 
 const invoiceWith = (hostedUrl) => ({
   number: 'VGD1VIPO-0001',
+  date: new Date('2026-08-29'),
   hostedUrl,
   netTotal: 50,
   vatTotal: 10,

--- a/functions/callNodeFunction/__tests__/sendMailAttachments.test.js
+++ b/functions/callNodeFunction/__tests__/sendMailAttachments.test.js
@@ -1,0 +1,152 @@
+import { jest } from '@jest/globals';
+import { createRequire } from 'node:module';
+
+// sendMail is CommonJS and lives in a sibling function package; callNodeFunction
+// is the only place in functions/ with a test runner.
+const require = createRequire(import.meta.url);
+const { isAllowedAttachmentUrl, safeAttachmentFilename, resolveAttachments } = require('../../sendMail/index.js');
+
+describe('isAllowedAttachmentUrl', () => {
+  it('accepts Stripe invoice documents over https', () => {
+    expect(isAllowedAttachmentUrl('https://invoice.stripe.com/i/acct_1/inv_2/pdf')).toBe(true);
+    expect(isAllowedAttachmentUrl('https://files.stripe.com/x.pdf')).toBe(true);
+    expect(isAllowedAttachmentUrl('https://stripe.com/x.pdf')).toBe(true);
+  });
+
+  it('rejects plaintext http even on an allowed host', () => {
+    expect(isAllowedAttachmentUrl('http://files.stripe.com/x.pdf')).toBe(false);
+  });
+
+  it('rejects a look-alike host that merely contains the allowed domain', () => {
+    // The bug a naive `includes`/`startsWith` check would introduce.
+    expect(isAllowedAttachmentUrl('https://x.stripe.com.evil.net/x.pdf')).toBe(false);
+    expect(isAllowedAttachmentUrl('https://notstripe.com/x.pdf')).toBe(false);
+    expect(isAllowedAttachmentUrl('https://evil.com/x.pdf')).toBe(false);
+  });
+
+  it('rejects malformed and missing URLs rather than throwing', () => {
+    expect(isAllowedAttachmentUrl('not a url')).toBe(false);
+    expect(isAllowedAttachmentUrl(undefined)).toBe(false);
+    expect(isAllowedAttachmentUrl(null)).toBe(false);
+  });
+
+  it('does not widen the allowlist when the bucket env var is malformed', () => {
+    const previous = process.env.STORAGE_BUCKET_PUBLIC_URL;
+    process.env.STORAGE_BUCKET_PUBLIC_URL = 'not a url';
+    try {
+      expect(isAllowedAttachmentUrl('https://evil.com/x.pdf')).toBe(false);
+    } finally {
+      if (previous === undefined) delete process.env.STORAGE_BUCKET_PUBLIC_URL;
+      else process.env.STORAGE_BUCKET_PUBLIC_URL = previous;
+    }
+  });
+});
+
+describe('safeAttachmentFilename', () => {
+  it('strips path traversal and separators', () => {
+    expect(safeAttachmentFilename('../../etc/passwd', 'fallback')).toBe('etc_passwd');
+  });
+
+  it('keeps a normal invoice filename intact', () => {
+    expect(safeAttachmentFilename('rechnung-VGD1VIPO-0001.pdf', 'fallback')).toBe(
+      'rechnung-VGD1VIPO-0001.pdf'
+    );
+  });
+
+  it('falls back when nothing usable remains', () => {
+    expect(safeAttachmentFilename('///', 'anhang-1')).toBe('anhang-1');
+    expect(safeAttachmentFilename('', 'anhang-1')).toBe('anhang-1');
+    expect(safeAttachmentFilename(null, 'anhang-1')).toBe('anhang-1');
+  });
+});
+
+describe('resolveAttachments', () => {
+  const originalFetch = global.fetch;
+  let errorSpy;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    errorSpy.mockRestore();
+  });
+
+  const pdfResponse = (bytes, declaredLength) => ({
+    ok: true,
+    headers: { get: () => (declaredLength === undefined ? null : String(declaredLength)) },
+    arrayBuffer: async () => new Uint8Array(bytes).buffer,
+  });
+
+  it('returns an empty list for missing or empty input', async () => {
+    await expect(resolveAttachments(null, 1)).resolves.toEqual([]);
+    await expect(resolveAttachments([], 1)).resolves.toEqual([]);
+    await expect(resolveAttachments(undefined, 1)).resolves.toEqual([]);
+  });
+
+  it('downloads an allowed descriptor into a Mailgun CustomFile', async () => {
+    global.fetch = jest.fn().mockResolvedValue(pdfResponse([1, 2, 3], 3));
+    const files = await resolveAttachments(
+      [{ url: 'https://files.stripe.com/a.pdf', filename: 'rechnung.pdf', contentType: 'application/pdf' }],
+      7
+    );
+    expect(files).toHaveLength(1);
+    expect(files[0].filename).toBe('rechnung.pdf');
+    expect(files[0].contentType).toBe('application/pdf');
+    expect(Buffer.isBuffer(files[0].data)).toBe(true);
+    expect(files[0].data.length).toBe(3);
+  });
+
+  it('skips a disallowed host without fetching it', async () => {
+    global.fetch = jest.fn();
+    await expect(resolveAttachments([{ url: 'https://evil.com/a.pdf' }], 7)).resolves.toEqual([]);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('rejects an oversize attachment declared via content-length before buffering', async () => {
+    global.fetch = jest.fn().mockResolvedValue(pdfResponse([1], 9 * 1024 * 1024));
+    await expect(
+      resolveAttachments([{ url: 'https://files.stripe.com/big.pdf' }], 7)
+    ).resolves.toEqual([]);
+  });
+
+  it('rejects an oversize body even when the server declares no length', async () => {
+    const big = new Uint8Array(9 * 1024 * 1024);
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      headers: { get: () => null },
+      arrayBuffer: async () => big.buffer,
+    });
+    await expect(
+      resolveAttachments([{ url: 'https://files.stripe.com/big.pdf' }], 7)
+    ).resolves.toEqual([]);
+  });
+
+  it('retries once and then gives up, returning no attachment rather than throwing', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('ECONNRESET'));
+    await expect(
+      resolveAttachments([{ url: 'https://files.stripe.com/a.pdf' }], 7)
+    ).resolves.toEqual([]);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('succeeds on the second attempt after a transient failure', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('transient'))
+      .mockResolvedValueOnce(pdfResponse([9], 1));
+    const files = await resolveAttachments([{ url: 'https://files.stripe.com/a.pdf' }], 7);
+    expect(files).toHaveLength(1);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats a non-2xx response as a failure', async () => {
+    global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 404, headers: { get: () => null } });
+    await expect(
+      resolveAttachments([{ url: 'https://files.stripe.com/a.pdf' }], 7)
+    ).resolves.toEqual([]);
+  });
+});

--- a/functions/callNodeFunction/emailTemplateVariables.js
+++ b/functions/callNodeFunction/emailTemplateVariables.js
@@ -205,6 +205,46 @@ export const EMAIL_VARIABLES = {
       example: 'https://edu.opencampus.sh',
       categories: ['general']
     }
+  },
+
+  // StuJo job board variables.
+  //
+  // Documentation and discoverability only: the job board mails do NOT go
+  // through createVariableReplacer below. They are substituted by their own
+  // replacers, which must stay in step with this list --
+  //   frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts  (buildMailVars)
+  //   functions/callNodeFunction/publishJobPosting/index.js  (buildJobPostingMailVars)
+  // whose key sets are asserted identical by a test. Unifying the three is a
+  // separate piece of work; until then, adding a variable means adding it in
+  // both replacers as well as here.
+  JOB_POSTING: {
+    '[JobPosting:Title]': { description: 'Job posting title', example: 'Werkstudent:in Frontend', categories: ['jobposting'] },
+    '[JobPosting:Type]': { description: 'Posting category, as a display label rather than the raw enum', example: 'Studentenjob', categories: ['jobposting'] },
+    '[JobPosting:PublishedAt]': { description: 'Date the posting went live', example: '29. August 2026', categories: ['jobposting'] },
+    '[JobPosting:ExpiresAt]': { description: 'Date the posting comes off the board', example: '24. Oktober 2026', categories: ['jobposting'] },
+    '[JobPosting:Payment]': { description: 'How the posting was paid for', example: '59,50 \u20ac (bezahlt)', categories: ['jobposting'] },
+    '[JobPosting:DashboardUrl]': { description: 'Employer dashboard link', example: 'https://stujo.opencampus.sh/mein-stujo', categories: ['jobposting'] },
+    '[JobPosting:RepostUrl]': { description: 'Link that republishes an expired posting', example: 'https://stujo.opencampus.sh/mein-stujo?repost=1', categories: ['jobposting'] },
+    '[JobPosting:AdminUrl]': { description: 'Admin moderation link', example: 'https://edu.opencampus.sh/manage/settings/jobboerse', categories: ['jobposting'] },
+    '[JobPosting:TermsAcceptedAt]': { description: 'When the employer accepted the terms; empty if never recorded', example: '29. August 2026', categories: ['jobposting'] },
+    '[Organization:Name]': { description: 'Employer organisation name', example: 'Beispiel GmbH', categories: ['jobposting'] }
+  },
+
+  // Invoice variables. Empty on free and credit-funded postings, which have no
+  // Invoice row -- the [#if:Invoice] block is dropped for those.
+  INVOICE: {
+    '[Invoice:Number]': { description: 'Number printed on the Stripe invoice document, falling back to our record key while Stripe has not finalized it', example: 'VGD1VIPO-0001', categories: ['jobposting'] },
+    '[Invoice:Date]': { description: 'Invoice date', example: '29. August 2026', categories: ['jobposting'] },
+    '[Invoice:NetTotal]': { description: 'Net amount', example: '50,00 \u20ac', categories: ['jobposting'] },
+    '[Invoice:VatRate]': { description: 'VAT percentage, derived from the amounts', example: '19', categories: ['jobposting'] },
+    '[Invoice:VatTotal]': { description: 'VAT amount', example: '9,50 \u20ac', categories: ['jobposting'] },
+    '[Invoice:GrossTotal]': { description: 'Gross amount', example: '59,50 \u20ac', categories: ['jobposting'] },
+    '[Invoice:HostedUrl]': { description: 'Stripe hosted invoice page', example: 'https://invoice.stripe.com/i/example', categories: ['jobposting'] },
+    '[Invoice:PaymentStatus]': { description: 'Whether the invoice is settled', example: 'bezahlt', categories: ['jobposting'] }
+  },
+
+  LEGAL: {
+    '[Legal:TermsUrl]': { description: 'Terms and conditions URL used in the mail footer', example: 'https://www.stujo.net/agb', categories: ['jobposting'] }
   }
 };
 

--- a/functions/callNodeFunction/index.js
+++ b/functions/callNodeFunction/index.js
@@ -22,6 +22,7 @@ import createStripeBasePrice from "./createStripeBasePrice/index.js";
 import createStripeAddonPrices from "./createStripeAddonPrices/index.js";
 import createStripeJobPostingPrices from "./createStripeJobPostingPrices/index.js";
 import publishJobPosting from "./publishJobPosting/index.js";
+import sendPendingJobPostingMails from "./sendPendingJobPostingMails/index.js";
 import archiveJobPosting from "./archiveJobPosting/index.js";
 import createEnrollmentWithAddons from "./createEnrollmentWithAddons/index.js";
 import syncGhostNewsletterSubscription from "./syncGhostNewsletterSubscription/index.js";
@@ -87,6 +88,7 @@ const functionMap = {
   createStripeAddonPrices,
   createStripeJobPostingPrices,
   publishJobPosting,
+  sendPendingJobPostingMails,
   archiveJobPosting,
   createEnrollmentWithAddons,
   createMatrixRoom,

--- a/functions/callNodeFunction/publishJobPosting/index.js
+++ b/functions/callNodeFunction/publishJobPosting/index.js
@@ -250,6 +250,12 @@ export async function sendJobPostingMail(
       attachments,
     });
   } catch (error) {
+    // Losing the race against the unique dedup index means the mail is already
+    // queued -- that is the guard working, not a failure.
+    if (String(error?.message ?? error).includes('MailLog_job_posting_mail_unique')) {
+      logger.info(`${templateType} already queued for job posting ${jobPostingId}`);
+      return;
+    }
     // Mails must never break the publish flow.
     logger.error(`Failed to queue ${templateType} mail`, { error: error.message });
   }
@@ -298,7 +304,7 @@ export function buildJobPostingMailVars(posting, { expiresAt, publishedAt, payme
     '[Organization:Name]': posting.Organization?.name || '',
     '[JobPosting:Payment]': paymentDescription || '',
     '[Invoice:Number]': invoice?.number || '',
-    '[Invoice:Date]': invoice ? formatJobPostingDate(new Date()) : '',
+    '[Invoice:Date]': invoice?.date ? formatJobPostingDate(invoice.date) : '',
     '[Invoice:NetTotal]': invoice ? formatJobPostingAmount(invoice.netTotal, invoice.currency) : '',
     '[Invoice:VatRate]': vatRate,
     '[Invoice:VatTotal]': invoice ? formatJobPostingAmount(invoice.vatTotal, invoice.currency) : '',

--- a/functions/callNodeFunction/publishJobPosting/index.js
+++ b/functions/callNodeFunction/publishJobPosting/index.js
@@ -105,6 +105,14 @@ const SET_PENDING_PAYMENT = gql`
   }
 `;
 
+const SET_TERMS_ACCEPTED = gql`
+  mutation SetJobPostingTermsAccepted($id: Int!, $at: timestamptz!) {
+    update_JobPosting_by_pk(pk_columns: { id: $id }, _set: { termsAcceptedAt: $at }) {
+      id
+    }
+  }
+`;
+
 const GET_MAIL_TEMPLATE = gql`
   query GetJobMailTemplate($type: MailTemplateType_enum!) {
     MailTemplate(where: { type: { _eq: $type }, courseId: { _is_null: true } }, limit: 1) {
@@ -357,7 +365,7 @@ export default async function publishJobPosting(req, logger) {
   try {
     const sessionUserId = req.body?.session_variables?.['x-hasura-user-id'];
     const sessionRole = req.body?.session_variables?.['x-hasura-role'];
-    const { jobPostingId } = req.body.input || req.body;
+    const { jobPostingId, acceptTerms } = req.body.input || req.body;
 
     if (!jobPostingId) {
       return { success: false, error: 'jobPostingId is required', messageKey: 'MISSING_JOB_POSTING_ID' };
@@ -391,6 +399,18 @@ export default async function publishJobPosting(req, logger) {
         error: `Posting in status ${posting.status} cannot be published`,
         messageKey: 'INVALID_STATUS',
       };
+    }
+
+    // Consent is server-controlled: the client may say it was given, but only
+    // this function writes the timestamp, and only once. A client-writable
+    // column could be backdated or forged, which would defeat the point of
+    // recording it at all.
+    if (acceptTerms === true && !posting.termsAcceptedAt) {
+      await client.request(SET_TERMS_ACCEPTED, {
+        id: posting.id,
+        at: new Date().toISOString(),
+      });
+      posting.termsAcceptedAt = new Date().toISOString();
     }
 
     const priceRow = data.JobPostingPrice.find((p) => p.jobPostingType === posting.type);
@@ -432,6 +452,18 @@ export default async function publishJobPosting(req, logger) {
     }
 
     // 3. Stripe checkout.
+    // Only the paid path is gated: this is where a contract is concluded, and
+    // it mirrors `config.requiresPayment && !acceptTerms` in the course
+    // registration modal. A repost of a posting that already carries consent
+    // passes without asking again.
+    if (!posting.termsAcceptedAt) {
+      return {
+        success: false,
+        error: 'Terms must be accepted before publishing a paid posting',
+        messageKey: 'TERMS_NOT_ACCEPTED',
+      };
+    }
+
     const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
     if (!stripeSecretKey) {
       return { success: false, error: 'Stripe secret key not configured', messageKey: 'STRIPE_NOT_CONFIGURED' };

--- a/functions/callNodeFunction/publishJobPosting/index.js
+++ b/functions/callNodeFunction/publishJobPosting/index.js
@@ -33,6 +33,7 @@ const GET_POSTING = gql`
       status
       organizationId
       contactUserId
+      termsAcceptedAt
       ContactUser {
         email
       }
@@ -124,6 +125,8 @@ const INSERT_MAIL_LOG = gql`
     $to: String!
     $bcc: String
     $status: String!
+    $metadata: jsonb
+    $attachments: jsonb
   ) {
     insert_MailLog_one(
       object: {
@@ -133,6 +136,8 @@ const INSERT_MAIL_LOG = gql`
         to: $to
         bcc: $bcc
         status: $status
+        metadata: $metadata
+        attachments: $attachments
       }
     ) {
       id
@@ -144,15 +149,76 @@ const INSERT_MAIL_LOG = gql`
 // price row is missing a duration.
 const DEFAULT_DURATION_DAYS = 56;
 
-export function replaceJobPostingVariables(text, vars) {
+/**
+ * Display labels for JobPostingType. The enum table deliberately keeps labels
+ * in the frontend i18n files, which the mail pipeline cannot reach. Keep in
+ * sync with the identical map in
+ * frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts.
+ */
+const JOB_POSTING_TYPE_LABELS = {
+  MINIJOB: 'Minijob',
+  WORKING_STUDENT: 'Studentenjob',
+  INTERNSHIP: 'Praktikum',
+  STATE_RECOGNITION_INTERNSHIP: 'Anerkennungspraktikum',
+  THESIS: 'Abschlussarbeit',
+  TRAINEE: 'Trainee-Stelle',
+  PERMANENT: 'Festanstellung',
+};
+
+export function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Drops [#if:Flag] ... [/if:Flag] sections whose flag is falsy and unwraps the
+ * rest, so one template can serve paid, free and credit-funded postings.
+ *
+ * Loops because String.replace does not rescan replaced regions, and the
+ * invoice block nests an inner [#if:InvoiceLink].
+ */
+export function applyConditionalBlocks(text, flags = {}) {
+  const pattern = /\[#if:([A-Za-z]+)\]([\s\S]*?)\[\/if:\1\]/g;
   let result = text || '';
-  for (const [key, value] of Object.entries(vars)) {
-    result = result.split(key).join(value ?? '');
+  for (let pass = 0; pass < 5; pass += 1) {
+    const next = result.replace(pattern, (_match, key, body) => (flags[key] ? body : ''));
+    if (next === result) return next;
+    result = next;
   }
   return result;
 }
 
-export async function sendJobPostingMail(client, logger, templateType, to, vars, bcc = null) {
+/**
+ * Substitutes [Entity:Field] placeholders. Values are HTML-escaped by default
+ * because they are employer-controlled and the result is sent as HTML -- the
+ * admin notice carries the same values into a staff inbox. Subjects are plain
+ * text, so they pass { html: false }.
+ */
+export function replaceJobPostingVariables(text, vars, options = {}) {
+  const { html = true } = options;
+  let result = text || '';
+  for (const [key, value] of Object.entries(vars)) {
+    const replacement = value ?? '';
+    result = result.split(key).join(html ? escapeHtml(replacement) : replacement);
+  }
+  return result;
+}
+
+export async function sendJobPostingMail(
+  client,
+  logger,
+  templateType,
+  to,
+  vars,
+  bcc = null,
+  flags = {},
+  jobPostingId = null,
+  attachments = null
+) {
   try {
     const templateData = await client.request(GET_MAIL_TEMPLATE, { type: templateType });
     const template = templateData?.MailTemplate?.[0];
@@ -161,17 +227,78 @@ export async function sendJobPostingMail(client, logger, templateType, to, vars,
       return;
     }
     await client.request(INSERT_MAIL_LOG, {
-      subject: replaceJobPostingVariables(template.subject, vars),
-      content: replaceJobPostingVariables(template.content, vars),
+      subject: replaceJobPostingVariables(applyConditionalBlocks(template.subject, flags), vars, {
+        html: false,
+      }),
+      content: replaceJobPostingVariables(applyConditionalBlocks(template.content, flags), vars),
       from: template.from || 'noreply@stujo.net',
       to,
       bcc: bcc || template.bcc || null,
       status: 'READY_TO_SEND',
+      // Dedup key for the sweep and the invoice.finalized handler, which can
+      // both queue this same mail later. See hasQueuedJobPostingMail in
+      // frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts.
+      metadata: jobPostingId === null ? null : { type: templateType, jobPostingId },
+      attachments,
     });
   } catch (error) {
     // Mails must never break the publish flow.
     logger.error(`Failed to queue ${templateType} mail`, { error: error.message });
   }
+}
+
+export const formatJobPostingDate = (date) =>
+  date.toLocaleDateString('de-DE', { year: 'numeric', month: 'long', day: 'numeric' });
+
+export function formatJobPostingAmount(cents, currency) {
+  const symbol = String(currency).toUpperCase() === 'EUR' ? '\u20ac' : String(currency).toUpperCase();
+  return `${(cents / 100).toFixed(2).replace('.', ',')} ${symbol}`;
+}
+
+/**
+ * Builds the mail variables for a job posting.
+ *
+ * The key set must stay identical to buildMailVars in
+ * frontend-nx/apps/edu-hub/lib/stripeJobPosting.ts: the replacer only
+ * substitutes keys it is handed, so a key missing on one path would reach the
+ * employer as literal "[Invoice:Number]" text. There is a parity test for this.
+ *
+ * `invoice` is null for free and credit-funded postings, which have no Invoice
+ * row at all; every [Invoice:*] key is then present but empty and the
+ * [#if:Invoice] block is dropped.
+ */
+export function buildJobPostingMailVars(posting, { expiresAt, publishedAt, paymentDescription, invoice = null }) {
+  const frontendUrl = process.env.STUJO_FRONTEND_URL || process.env.FRONTEND_URL || '';
+  // The job board admin UI lives in the edu-hub app, not the stujo app.
+  const adminAppUrl = process.env.FRONTEND_URL || frontendUrl;
+  const vatRate =
+    invoice && invoice.netTotal > 0
+      ? String(Math.round((invoice.vatTotal / invoice.netTotal) * 100))
+      : '';
+
+  return {
+    '[JobPosting:Title]': posting.title,
+    '[JobPosting:Type]': JOB_POSTING_TYPE_LABELS[posting.type] || posting.type,
+    '[JobPosting:ExpiresAt]': expiresAt ? formatJobPostingDate(expiresAt) : '',
+    '[JobPosting:PublishedAt]': publishedAt ? formatJobPostingDate(publishedAt) : '',
+    '[JobPosting:TermsAcceptedAt]': posting.termsAcceptedAt
+      ? formatJobPostingDate(new Date(posting.termsAcceptedAt))
+      : '',
+    '[JobPosting:DashboardUrl]': `${frontendUrl}/mein-stujo`,
+    '[JobPosting:RepostUrl]': `${frontendUrl}/mein-stujo?repost=${posting.id}`,
+    '[JobPosting:AdminUrl]': `${adminAppUrl}/manage/settings/jobboerse?posting=${posting.id}`,
+    '[Organization:Name]': posting.Organization?.name || '',
+    '[JobPosting:Payment]': paymentDescription || '',
+    '[Invoice:Number]': invoice?.number || '',
+    '[Invoice:Date]': invoice ? formatJobPostingDate(new Date()) : '',
+    '[Invoice:NetTotal]': invoice ? formatJobPostingAmount(invoice.netTotal, invoice.currency) : '',
+    '[Invoice:VatRate]': vatRate,
+    '[Invoice:VatTotal]': invoice ? formatJobPostingAmount(invoice.vatTotal, invoice.currency) : '',
+    '[Invoice:GrossTotal]': invoice ? formatJobPostingAmount(invoice.grossTotal, invoice.currency) : '',
+    '[Invoice:HostedUrl]': invoice?.hostedUrl || '',
+    '[Invoice:PaymentStatus]': invoice ? (invoice.paid ? 'bezahlt' : 'Zahlung ausstehend') : '',
+    '[Legal:TermsUrl]': process.env.STUJO_TERMS_URL || 'https://www.stujo.net/agb',
+  };
 }
 
 export async function publishAndNotify(client, logger, posting, durationDays) {
@@ -183,30 +310,43 @@ export async function publishAndNotify(client, logger, posting, durationDays) {
     expiresAt: expiresAt.toISOString(),
   });
 
-  const frontendUrl = process.env.STUJO_FRONTEND_URL || process.env.FRONTEND_URL || '';
-  // The job board admin UI lives in the edu-hub app, not the stujo app.
-  const adminAppUrl = process.env.FRONTEND_URL || frontendUrl;
-  const vars = {
-    '[JobPosting:Title]': posting.title,
-    '[JobPosting:Type]': posting.type,
-    '[JobPosting:ExpiresAt]': expiresAt.toLocaleDateString('de-DE', {
-      year: 'numeric',
-      month: 'long',
-      day: 'numeric',
-    }),
-    '[JobPosting:DashboardUrl]': `${frontendUrl}/mein-stujo`,
-    '[JobPosting:RepostUrl]': `${frontendUrl}/mein-stujo?repost=${posting.id}`,
-    '[JobPosting:AdminUrl]': `${adminAppUrl}/manage/settings/jobboerse?posting=${posting.id}`,
-    '[Organization:Name]': posting.Organization?.name || '',
-    '[JobPosting:Payment]': posting.paymentDescription || '',
+  const vars = buildJobPostingMailVars(posting, {
+    expiresAt,
+    publishedAt,
+    paymentDescription: posting.paymentDescription || '',
+  });
+  const flags = {
+    Invoice: false,
+    InvoicePdf: false,
+    InvoiceLink: false,
+    InvoicePending: false,
+    TermsAccepted: Boolean(posting.termsAcceptedAt),
   };
 
   if (posting.ContactUser?.email) {
-    await sendJobPostingMail(client, logger, 'JOB_POSTING_PUBLISHED', posting.ContactUser.email, vars);
+    await sendJobPostingMail(
+      client,
+      logger,
+      'JOB_POSTING_PUBLISHED',
+      posting.ContactUser.email,
+      vars,
+      null,
+      flags,
+      posting.id
+    );
   }
   const adminMail = process.env.STUJO_ADMIN_EMAIL;
   if (adminMail) {
-    await sendJobPostingMail(client, logger, 'JOB_POSTING_ADMIN_NOTICE', adminMail, vars);
+    await sendJobPostingMail(
+      client,
+      logger,
+      'JOB_POSTING_ADMIN_NOTICE',
+      adminMail,
+      vars,
+      null,
+      flags,
+      posting.id
+    );
   }
   return { publishedAt, expiresAt };
 }

--- a/functions/callNodeFunction/publishJobPosting/index.js
+++ b/functions/callNodeFunction/publishJobPosting/index.js
@@ -305,7 +305,8 @@ export function buildJobPostingMailVars(posting, { expiresAt, publishedAt, payme
     '[Invoice:GrossTotal]': invoice ? formatJobPostingAmount(invoice.grossTotal, invoice.currency) : '',
     '[Invoice:HostedUrl]': invoice?.hostedUrl || '',
     '[Invoice:PaymentStatus]': invoice ? (invoice.paid ? 'bezahlt' : 'Zahlung ausstehend') : '',
-    '[Legal:TermsUrl]': process.env.STUJO_TERMS_URL || 'https://www.stujo.net/agb',
+    // Absolute: this is read in an email, where a relative path is dead.
+    '[Legal:TermsUrl]': process.env.STUJO_TERMS_URL || `${frontendUrl}/agb`,
   };
 }
 

--- a/functions/callNodeFunction/sendPendingJobPostingMails/index.js
+++ b/functions/callNodeFunction/sendPendingJobPostingMails/index.js
@@ -27,25 +27,53 @@ import {
 // paths. Combined with the cron interval the worst-case delay is ~30 minutes.
 const MIN_AGE_MINUTES = 15;
 
+// Upper bound on how far back to look. Invoices keep their ISSUED/PAID status
+// forever, so without a window the oldest handled rows would fill every page
+// and a genuinely stuck posting would never be reached -- the sweep would go
+// quietly dead. Anything older than this has missed all three chances and needs
+// a human, not another retry.
+const MAX_AGE_HOURS = 72;
+const PAGE_SIZE = 200;
+
+const GET_ALREADY_MAILED = gql`
+  query GetJobPostingsAlreadyMailed($since: timestamptz!) {
+    MailLog(
+      where: {
+        created_at: { _gte: $since }
+        metadata: { _contains: { type: "JOB_POSTING_PUBLISHED" } }
+      }
+    ) {
+      metadata
+    }
+  }
+`;
+
 const GET_PENDING = gql`
-  query GetJobPostingInvoicesAwaitingMail($before: timestamptz!) {
+  query GetJobPostingInvoicesAwaitingMail(
+    $before: timestamptz!
+    $after: timestamptz!
+    $excluded: [Int!]
+    $limit: Int!
+  ) {
     Invoice(
       where: {
-        jobPostingId: { _is_null: false }
-        created_at: { _lte: $before }
+        jobPostingId: { _is_null: false, _nin: $excluded }
+        created_at: { _lte: $before, _gte: $after }
         status: { _in: [ISSUED, PAID] }
       }
       order_by: { created_at: asc }
-      limit: 50
+      limit: $limit
     ) {
       id
       jobPostingId
       invoiceNumber
+      invoiceDate
       netTotal
       vatTotal
       grossTotal
       currency
       status
+      created_at
       stripeInvoiceId
       stripeInvoicePdfUrl
       stripeHostedInvoiceUrl
@@ -105,7 +133,26 @@ export default async function sendPendingJobPostingMails(req, logger) {
   });
 
   const before = new Date(Date.now() - MIN_AGE_MINUTES * 60 * 1000).toISOString();
-  const { Invoice: candidates } = await client.request(GET_PENDING, { before });
+  const after = new Date(Date.now() - MAX_AGE_HOURS * 60 * 60 * 1000).toISOString();
+
+  // Exclude postings already mailed, in the query rather than in the loop.
+  // Filtering afterwards would let handled rows consume every page slot, which
+  // is exactly how a backstop stops backstopping.
+  const { MailLog: mailed } = await client.request(GET_ALREADY_MAILED, { since: after });
+  const excluded = [
+    ...new Set(
+      mailed
+        .map((row) => Number(row.metadata?.jobPostingId))
+        .filter((id) => Number.isInteger(id))
+    ),
+  ];
+
+  const { Invoice: candidates } = await client.request(GET_PENDING, {
+    before,
+    after,
+    excluded,
+    limit: PAGE_SIZE,
+  });
 
   const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
   const stripe = stripeSecretKey ? new Stripe(stripeSecretKey) : null;
@@ -163,6 +210,7 @@ export default async function sendPendingJobPostingMails(req, logger) {
       })`,
       invoice: {
         number,
+        date: invoice.invoiceDate ? new Date(invoice.invoiceDate) : new Date(invoice.created_at),
         hostedUrl,
         netTotal: invoice.netTotal,
         vatTotal: invoice.vatTotal,
@@ -211,8 +259,15 @@ export default async function sendPendingJobPostingMails(req, logger) {
     sent += 1;
   }
 
+  // A full page means the window may hold more than one run can handle; the
+  // next run picks up the rest, since everything sent here is now excluded.
+  if (candidates.length === PAGE_SIZE) {
+    logger.warn('Sweep filled a full page, more candidates may remain', { pageSize: PAGE_SIZE });
+  }
+
   logger.info('Pending job posting mail sweep finished', {
     candidates: candidates.length,
+    excluded: excluded.length,
     sent,
     sentWithoutPdf,
   });

--- a/functions/callNodeFunction/sendPendingJobPostingMails/index.js
+++ b/functions/callNodeFunction/sendPendingJobPostingMails/index.js
@@ -1,0 +1,220 @@
+import Stripe from 'stripe';
+import { GraphQLClient, gql } from 'graphql-request';
+
+import {
+  buildJobPostingMailVars,
+  formatJobPostingAmount,
+  sendJobPostingMail,
+} from '../publishJobPosting/index.js';
+
+/**
+ * Backstop for the StuJo job posting confirmation mail.
+ *
+ * The mail carries the invoice PDF, so it is only sent once Stripe has
+ * finalized the invoice. Normally that happens at checkout.session.completed
+ * (fast path) or on invoice.finalized. This sweep exists for when neither
+ * fired -- most plausibly because invoice.finalized is not enabled on the
+ * webhook endpoint in the Stripe Dashboard, but also for a Stripe backlog or a
+ * dropped delivery. Without it an employer could pay and never hear anything.
+ *
+ * Runs from a Hasura cron trigger (send_pending_job_posting_mails). It is in
+ * Node rather than the usual Python cron style because it needs the Stripe SDK,
+ * which callPythonFunction does not have, and the mail templating helpers that
+ * already live in publishJobPosting.
+ */
+
+// Grace period before the sweep takes over, so it never races the two faster
+// paths. Combined with the cron interval the worst-case delay is ~30 minutes.
+const MIN_AGE_MINUTES = 15;
+
+const GET_PENDING = gql`
+  query GetJobPostingInvoicesAwaitingMail($before: timestamptz!) {
+    Invoice(
+      where: {
+        jobPostingId: { _is_null: false }
+        created_at: { _lte: $before }
+        status: { _in: [ISSUED, PAID] }
+      }
+      order_by: { created_at: asc }
+      limit: 50
+    ) {
+      id
+      jobPostingId
+      invoiceNumber
+      netTotal
+      vatTotal
+      grossTotal
+      currency
+      status
+      stripeInvoiceId
+      stripeInvoicePdfUrl
+      stripeHostedInvoiceUrl
+      stripeInvoiceNumber
+      JobPosting {
+        id
+        title
+        type
+        status
+        expiresAt
+        publishedAt
+        termsAcceptedAt
+        ContactUser {
+          email
+        }
+        Organization {
+          name
+        }
+      }
+    }
+  }
+`;
+
+const GET_QUEUED_MAIL = gql`
+  query GetQueuedJobPostingMailSweep($contains: jsonb!) {
+    MailLog(where: { metadata: { _contains: $contains } }, limit: 1) {
+      id
+    }
+  }
+`;
+
+const BACKFILL_INVOICE_DOCUMENT = gql`
+  mutation SweepBackfillJobInvoiceDocument(
+    $id: Int!
+    $stripeInvoiceNumber: String
+    $stripeHostedInvoiceUrl: String
+    $stripeInvoicePdfUrl: String
+  ) {
+    update_Invoice_by_pk(
+      pk_columns: { id: $id }
+      _set: {
+        stripeInvoiceNumber: $stripeInvoiceNumber
+        stripeHostedInvoiceUrl: $stripeHostedInvoiceUrl
+        stripeInvoicePdfUrl: $stripeInvoicePdfUrl
+      }
+    ) {
+      id
+    }
+  }
+`;
+
+export default async function sendPendingJobPostingMails(req, logger) {
+  logger.info('########## Send Pending Job Posting Mails ##########');
+
+  const client = new GraphQLClient(process.env.HASURA_ENDPOINT, {
+    headers: { 'x-hasura-admin-secret': process.env.HASURA_ADMIN_SECRET },
+  });
+
+  const before = new Date(Date.now() - MIN_AGE_MINUTES * 60 * 1000).toISOString();
+  const { Invoice: candidates } = await client.request(GET_PENDING, { before });
+
+  const stripeSecretKey = process.env.STRIPE_SECRET_KEY;
+  const stripe = stripeSecretKey ? new Stripe(stripeSecretKey) : null;
+  if (!stripe) {
+    logger.warn('STRIPE_SECRET_KEY not configured, sweep cannot resolve missing invoice PDFs');
+  }
+
+  let sent = 0;
+  let sentWithoutPdf = 0;
+
+  for (const invoice of candidates) {
+    const posting = invoice.JobPosting;
+    if (!posting?.ContactUser?.email) continue;
+
+    const { MailLog: already } = await client.request(GET_QUEUED_MAIL, {
+      contains: { type: 'JOB_POSTING_PUBLISHED', jobPostingId: invoice.jobPostingId },
+    });
+    if (already.length > 0) continue;
+
+    // One last look: the document may have been finalized since the row was
+    // written, we just never heard about it.
+    let pdfUrl = invoice.stripeInvoicePdfUrl;
+    let hostedUrl = invoice.stripeHostedInvoiceUrl;
+    let documentNumber = invoice.stripeInvoiceNumber;
+    if (!pdfUrl && stripe && invoice.stripeInvoiceId) {
+      try {
+        const doc = await stripe.invoices.retrieve(invoice.stripeInvoiceId);
+        pdfUrl = doc.invoice_pdf ?? null;
+        hostedUrl = doc.hosted_invoice_url ?? null;
+        documentNumber = doc.number ?? null;
+        if (pdfUrl || hostedUrl || documentNumber) {
+          await client.request(BACKFILL_INVOICE_DOCUMENT, {
+            id: invoice.id,
+            stripeInvoiceNumber: documentNumber,
+            stripeHostedInvoiceUrl: hostedUrl,
+            stripeInvoicePdfUrl: pdfUrl,
+          });
+        }
+      } catch (error) {
+        logger.error('Sweep could not resolve the Stripe invoice', {
+          invoiceId: invoice.id,
+          stripeInvoiceId: invoice.stripeInvoiceId,
+          error: error.message,
+        });
+      }
+    }
+
+    const paid = invoice.status === 'PAID';
+    const number = documentNumber || invoice.invoiceNumber;
+    const vars = buildJobPostingMailVars(posting, {
+      expiresAt: posting.expiresAt ? new Date(posting.expiresAt) : null,
+      publishedAt: posting.publishedAt ? new Date(posting.publishedAt) : null,
+      paymentDescription: `${formatJobPostingAmount(invoice.grossTotal, invoice.currency)} (${
+        paid ? 'bezahlt' : 'Zahlung ausstehend'
+      })`,
+      invoice: {
+        number,
+        hostedUrl,
+        netTotal: invoice.netTotal,
+        vatTotal: invoice.vatTotal,
+        grossTotal: invoice.grossTotal,
+        currency: invoice.currency,
+        paid,
+      },
+    });
+
+    if (!pdfUrl) {
+      // Deliberate: an email without the attachment beats no email at all. The
+      // employer still gets the invoice figures and, usually, the hosted link.
+      logger.error('Sending job posting confirmation without the invoice PDF', {
+        jobPostingId: posting.id,
+        invoiceId: invoice.id,
+        stripeInvoiceId: invoice.stripeInvoiceId,
+      });
+      sentWithoutPdf += 1;
+    }
+
+    await sendJobPostingMail(
+      client,
+      logger,
+      'JOB_POSTING_PUBLISHED',
+      posting.ContactUser.email,
+      vars,
+      null,
+      {
+        Invoice: true,
+        InvoicePdf: Boolean(pdfUrl),
+        InvoiceLink: Boolean(hostedUrl),
+        InvoicePending: !pdfUrl && !hostedUrl,
+        TermsAccepted: Boolean(posting.termsAcceptedAt),
+      },
+      posting.id,
+      pdfUrl
+        ? [
+            {
+              url: pdfUrl,
+              filename: `rechnung-${String(number).replace(/[^A-Za-z0-9._-]+/g, '-')}.pdf`,
+              contentType: 'application/pdf',
+            },
+          ]
+        : null
+    );
+    sent += 1;
+  }
+
+  logger.info('Pending job posting mail sweep finished', {
+    candidates: candidates.length,
+    sent,
+    sentWithoutPdf,
+  });
+  return { success: true, candidates: candidates.length, sent, sentWithoutPdf };
+}

--- a/functions/sendMail/index.js
+++ b/functions/sendMail/index.js
@@ -7,6 +7,128 @@ try {
   ({ secretsMatch } = require('../shared_libs/node/security.cjs'));
 }
 
+// Mailgun accepts up to 25 MB, but this function runs with 256M of memory and
+// form-data buffers a second multipart copy of every attachment. A Stripe
+// invoice PDF is ~30-60 KB, so 8 MB is generous; raising this needs a matching
+// available_memory bump in infrastructure/application/06_cloud-functions.tf.
+const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 15000;
+const RETRY_DELAY_MS = 250;
+// Only Stripe invoice documents today. MailLog is admin-write-only, so this is
+// defence in depth rather than a live hole -- but without it any future path
+// that lets a user-controlled URL reach the column would turn this function
+// into an SSRF proxy with its own egress.
+const ATTACHMENT_HOST_SUFFIXES = ['.stripe.com'];
+
+function isAllowedAttachmentUrl(rawUrl) {
+  let url;
+  try {
+    url = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'https:') return false;
+
+  // The public bucket is opt-in via env, so certificates and similar documents
+  // can be attached later without touching this list.
+  const bucketUrl = process.env.STORAGE_BUCKET_PUBLIC_URL;
+  if (bucketUrl) {
+    try {
+      if (new URL(bucketUrl).hostname === url.hostname) return true;
+    } catch {
+      // A malformed env var must never widen the allowlist.
+    }
+  }
+
+  // Match the bare host too, so 'stripe.com' passes while an attacker-owned
+  // 'x.stripe.com.evil.net' does not.
+  return ATTACHMENT_HOST_SUFFIXES.some(
+    (suffix) => url.hostname === suffix.slice(1) || url.hostname.endsWith(suffix)
+  );
+}
+
+function safeAttachmentFilename(name, fallback) {
+  const cleaned = String(name || '')
+    .replace(/[^A-Za-z0-9._-]+/g, '_')
+    .replace(/^[._]+/, '')
+    .slice(0, 120);
+  return cleaned || fallback;
+}
+
+/**
+ * Downloads the descriptors in MailLog.attachments into Mailgun CustomFile
+ * objects ({data, filename, contentType}).
+ *
+ * A descriptor that cannot be fetched is skipped, never thrown. The Hasura
+ * trigger retries 10x at 61-minute intervals, so failing here would delay the
+ * mail by up to ten hours or lose it entirely, and every template that carries
+ * an attachment also links the same document. Sending without the file is
+ * strictly better than not sending; the error log is the signal.
+ */
+async function resolveAttachments(descriptors, mailId) {
+  if (!Array.isArray(descriptors) || descriptors.length === 0) return [];
+
+  const files = [];
+  let totalBytes = 0;
+
+  for (const [index, descriptor] of descriptors.entries()) {
+    const url = descriptor && descriptor.url;
+    if (!isAllowedAttachmentUrl(url)) {
+      console.error('Attachment URL rejected', { mailId, index, url });
+      continue;
+    }
+
+    let lastError = null;
+    for (let attempt = 0; attempt < 2; attempt += 1) {
+      try {
+        const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+        // Cheap rejection before buffering, when the server declares a size.
+        const declared = Number(response.headers.get('content-length'));
+        if (Number.isFinite(declared) && declared > MAX_ATTACHMENT_BYTES) {
+          throw new Error(`declared size ${declared} exceeds ${MAX_ATTACHMENT_BYTES} bytes`);
+        }
+
+        const data = Buffer.from(await response.arrayBuffer());
+        if (data.length > MAX_ATTACHMENT_BYTES) {
+          throw new Error(`size ${data.length} exceeds ${MAX_ATTACHMENT_BYTES} bytes`);
+        }
+        if (totalBytes + data.length > MAX_ATTACHMENT_BYTES) {
+          throw new Error(`total attachment size would exceed ${MAX_ATTACHMENT_BYTES} bytes`);
+        }
+
+        totalBytes += data.length;
+        files.push({
+          data,
+          filename: safeAttachmentFilename(descriptor.filename, `anhang-${index + 1}`),
+          contentType: descriptor.contentType || 'application/octet-stream',
+        });
+        lastError = null;
+        break;
+      } catch (error) {
+        lastError = error;
+        // One cheap retry absorbs a transient blip without burning the Hasura
+        // retry budget, which is measured in hours.
+        if (attempt === 0) {
+          await new Promise((resolve) => setTimeout(resolve, RETRY_DELAY_MS));
+        }
+      }
+    }
+
+    if (lastError) {
+      console.error('Attachment fetch failed, sending mail without it', {
+        mailId,
+        index,
+        url,
+        error: lastError.message,
+      });
+    }
+  }
+
+  return files;
+}
+
 /**
  * Responds to any HTTP request to send emails via Mailgun.
  *
@@ -25,8 +147,8 @@ exports.sendMail = async (req, res) => {
   }
 
   // Extract email parameters from the Hasura event payload
-  const { subject, content, to, replyTo, cc, bcc } = req.body.event.data.new;
-  
+  const { id, subject, content, to, replyTo, cc, bcc, attachments } = req.body.event.data.new;
+
   // Get mail tag from headers or use default
   const mailTag = req.headers.mailTag || 'eduhub'; // default if not provided
 
@@ -48,6 +170,12 @@ exports.sendMail = async (req, res) => {
   if (bcc) msg.bcc = bcc;
 
   try {
+    // Resolved before the environment switch so local development -- which only
+    // logs -- still exercises the fetch, the allowlist and the size caps.
+    // Otherwise the attachment path would be untestable outside staging.
+    const attachmentFiles = await resolveAttachments(attachments, id);
+    if (attachmentFiles.length > 0) msg.attachment = attachmentFiles;
+
     switch (process.env.ENVIRONMENT) {
       case 'development':
         // Development mode: Log all email attempts without actually sending
@@ -58,7 +186,12 @@ exports.sendMail = async (req, res) => {
           text: msg.text,
           cc: msg.cc,
           bcc: msg.bcc,
-          replyTo: msg['h:Reply-To']
+          replyTo: msg['h:Reply-To'],
+          attachments: attachmentFiles.map((file) => ({
+            filename: file.filename,
+            contentType: file.contentType,
+            bytes: file.data.length
+          }))
         });
         break;
       case 'staging':
@@ -89,3 +222,8 @@ exports.sendMail = async (req, res) => {
     });
   }
 };
+
+// Exported for unit tests; not part of the cloud function contract.
+exports.resolveAttachments = resolveAttachments;
+exports.isAllowedAttachmentUrl = isAllowedAttachmentUrl;
+exports.safeAttachmentFilename = safeAttachmentFilename;

--- a/functions/sendMail/index.js
+++ b/functions/sendMail/index.js
@@ -47,6 +47,15 @@ function isAllowedAttachmentUrl(rawUrl) {
   );
 }
 
+/** Hostname of an attachment URL, for logs that must not carry the full URL. */
+function attachmentHost(rawUrl) {
+  try {
+    return new URL(rawUrl).hostname;
+  } catch {
+    return '(unparseable)';
+  }
+}
+
 function safeAttachmentFilename(name, fallback) {
   const cleaned = String(name || '')
     .replace(/[^A-Za-z0-9._-]+/g, '_')
@@ -74,7 +83,7 @@ async function resolveAttachments(descriptors, mailId) {
   for (const [index, descriptor] of descriptors.entries()) {
     const url = descriptor && descriptor.url;
     if (!isAllowedAttachmentUrl(url)) {
-      console.error('Attachment URL rejected', { mailId, index, url });
+      console.error('Attachment URL rejected', { mailId, index, host: attachmentHost(url) });
       continue;
     }
 
@@ -117,10 +126,12 @@ async function resolveAttachments(descriptors, mailId) {
     }
 
     if (lastError) {
+      // Host only: a Stripe invoice_pdf URL is unauthenticated and long-lived,
+      // so the full URL in a log line is a durable way to reach the document.
       console.error('Attachment fetch failed, sending mail without it', {
         mailId,
         index,
-        url,
+        host: attachmentHost(url),
         error: lastError.message,
       });
     }


### PR DESCRIPTION
Paying for a StuJo job posting produced a bare "your posting is online" mail. No invoice, no receipt, no terms — and nothing else delivered them either: Stripe was never asked to email anything, and no screen renders the invoice URLs we already store.

The employer now gets **one** mail carrying the posting details, the payment receipt, the invoice figures and the invoice **PDF as a real attachment**, plus a reference to the terms they accepted.

## Two defects this uncovered

**Stripe finalizes `invoice_creation` invoices asynchronously.** At `checkout.session.completed` the PDF and the document number are often still `null`. The old code stored those nulls and moved on, which is plausibly why no invoice has ever surfaced.

**Stripe's document number was persisted nowhere.** `Invoice.invoiceNumber` is our own key and `stripeInvoiceId` is the `in_…` reference; the number actually printed on the customer's invoice was stored in neither, so the database and the document disagreed.

## How delivery works

Waiting inside the webhook was the wrong answer — Stripe's guidance is acknowledge-first, and finalization timing is not something a wait can outrun (it can lag an hour, or up to 72 hours while deliveries are failing). So delivery is event-driven:

| Trigger | Behaviour |
| --- | --- |
| `checkout.session.completed` | Sends immediately **if** Stripe already finalized |
| `invoice.finalized` *(new)* | Backfills the document columns and sends otherwise |
| `send_pending_job_posting_mails` *(new cron, 15 min)* | Backstop when neither fired |

Exactly one mail goes out, deduplicated on `MailLog.metadata` containment — the same mechanism the Python reminder jobs use. The old `invoiceCreated` gate could not express this and silently prevented a mail sent without an attachment from ever being re-sent.

The sweep is in Node rather than the usual Python cron style because it needs the Stripe SDK, which `callPythonFunction` does not have.

## Attachments

New to the pipeline. `MailLog.attachments` holds URL descriptors that `sendMail` fetches at send time, restricted to an https host allowlist and capped at 8 MB (that function runs with 256M). A fetch failure sends the mail **without** the file rather than losing it to the event trigger's ten-hour retry schedule, and the template only claims a PDF is attached when one actually is.

## Terms

Publishing a paid posting concluded a contract without ever showing the terms. There is now a consent checkbox at the point of purchase, gated on the paid path only — mirroring `config.requiresPayment && !acceptTerms` in the course registration modal.

`JobPosting.termsAcceptedAt` is server-controlled: readable, but absent from every insert and update permission, so an organisation admin cannot forge or backdate the one field whose purpose is to evidence what happened.

The terms move into the repo, because the process in `docs/LEGAL_DOCUMENTS.md` recovers the accepted version from git history — which only works while the text lives in git.

## ⚠️ Before merging

- **Enable `invoice.finalized` on the Stripe endpoints (sandbox *and* live).** Nothing fails loudly if this is missed; every employer just falls through to the sweep and waits up to ~30 minutes.
- **The terms wording is newly drafted, not copied from the live page.** It should be read as a fresh document and reviewed. It resolves three things the published text left unsettled: Unternehmer-only with no right of withdrawal, prepayment via Stripe, and consent to electronic invoicing.
- `STUJO_SELLER_ORGANIZATION_ID` is still unset in production, so the invoice records the *employer* as seller and no footer reaches Stripe.

## Verification

Applied and exercised against a local stack, not just typechecked: the draft-invoice, finalized, redelivered, fast and sweep paths each behave as intended; the attachment fetch was driven in both its succeeding and failing forms; Hasura rejects a client-side attempt to backdate the consent field; and the rendered mail was read end to end for the paid, free and fallback variants.

457 tests pass (242 frontend, 215 functions), 60 of them new. The one failing suite, `matrixRoomUtils.test.js`, is pre-existing and untouched — it uses `node:test` rather than jest.

## Known gaps, deliberately not fixed

- `MailLog.from` is ignored, so StuJo templates' `noreply@stujo.net` is dead data. Fixing it naively would break DMARC alignment platform-wide; it needs a second verified Mailgun sending domain first.
- From 2028-01-01 domestic B2B invoices must be structured EN 16931 documents. Stripe's PDF will not qualify — worth tracking separately.
- Employers still cannot see past invoices in `/mein-stujo`; the Hasura permission already exists, so this is a pure UI gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added required terms-and-conditions consent before publishing paid job postings.
  * Added a dedicated terms page with configurable portal links.
  * Job-posting confirmation emails now include invoice details and, when available, PDF attachments.
  * Added job-board email templates, placeholders, conditional content, and German/English labels.
  * Added support for delayed payment events and automatic recovery of pending confirmation emails.

* **Improvements**
  * Enhanced invoice tracking with Stripe document numbers and payment status.
  * Email attachments are securely validated and gracefully skipped if unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->