### PR TITLE
ci(deps): run Dependabot triage twice weekly

### DIFF
--- a/.github/workflows/dependabot-triage.yml
+++ b/.github/workflows/dependabot-triage.yml
@@ -25,7 +25,7 @@ name: Dependabot triage
 on:
   schedule:
     # 05:00 UTC = 07:00 Europe/Berlin in summer (CEST), 06:00 in winter (CET).
-    - cron: "0 5 * * *"
+    - cron: "0 5 * * 2,4" # every Tuesday and Thursday at 05:00 UTC
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The daily schedule produced a triage run on most days with nothing
actionable to patch. Narrow the cron to Tuesdays and Thursdays at
05:00 UTC, which keeps alerts turning around within a few days while
cutting the number of no-op runs.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated dependency triage schedule to run every Tuesday and Thursday instead of daily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->