### PR TITLE
Fix data access control and deduplication bugs in StuJo migration

### DIFF
--- a/backend/metadata/databases/default/tables/public_Organization.yaml
+++ b/backend/metadata/databases/default/tables/public_Organization.yaml
@@ -5,6 +5,18 @@ object_relationships:
   - name: Country
     using:
       foreign_key_constraint_on: country
+  # The settings-admin-only columns (billing, tax, integration credentials) live in the
+  # OrganizationSettings view, whose own permission requires canManageSettings. Reading them
+  # through this relationship yields null for an admin without that capability.
+  - name: Settings
+    using:
+      manual_configuration:
+        column_mapping:
+          id: id
+        insertion_order: null
+        remote_table:
+          name: OrganizationSettings
+          schema: public
   - name: OrganizationType
     using:
       foreign_key_constraint_on: type
@@ -136,49 +148,40 @@ select_permissions:
         - city
       filter: {}
       allow_aggregations: true
-  # Org admins may read the full record of any organization they administer (regardless of which
-  # capability flags are set) so they have context for managing it. Editing settings additionally
-  # requires canManageSettings (see update_permissions). The `user` role only sees the public
-  # columns granted to `anonymous`.
+  # Org admins may read the working record of any organization they administer (regardless of which
+  # capability flags are set) so they have context for managing it.
+  #
+  # The banking, tax, register and invoicing columns and the integration credentials are NOT here:
+  # this filter is satisfied by any grant, so a job-board-only admin would read them too. They live
+  # in the OrganizationSettings view (relationship `Settings`), which requires canManageSettings —
+  # the same capability the update permission below requires to change them. The Ghost newsletter
+  # endpoint fields stay because `anonymous` may already read them; hiding them here would protect
+  # nothing. The `user` role only sees the public columns granted to `anonymous`.
   - role: org_admin_access
     permission:
       columns:
         - addressLine1
         - addressLine2
         - aliases
-        - bankName
         - city
         - country
         - created_at
-        - defaultTaxExemptionNote
-        - defaultVatRate
         - description
         - email
         - id
-        - invoiceFooterText
-        - invoiceNumberPrefix
-        - legalForm
-        - legalName
         - logo
-        - managingDirector
         - name
         - newsletterDescription
         - newsletterProvider
         - phone
         - postalCode
-        - registerCourt
-        - registerNumber
         - ghostNewsletterApiUrl
-        - ghostNewsletterApiKeyConfigured
         - ghostNewsletterListId
         - ghostNewsletterSlug
         - ghostNewsletterLabel
         - ghostNewsletterDoubleOptInEnabled
-        - apiKeyHash
-        - taxNumber
         - type
         - updated_at
-        - vatId
         - website
       filter:
         OrganizationAdmins:

--- a/backend/metadata/databases/default/tables/public_OrganizationSettings.yaml
+++ b/backend/metadata/databases/default/tables/public_OrganizationSettings.yaml
@@ -1,0 +1,54 @@
+table:
+  name: OrganizationSettings
+  schema: public
+object_relationships:
+  - name: Organization
+    using:
+      manual_configuration:
+        column_mapping:
+          id: id
+        insertion_order: null
+        remote_table:
+          name: Organization
+          schema: public
+array_relationships:
+  # Carries the permission filter below; the view has no foreign keys of its own.
+  - name: OrganizationAdmins
+    using:
+      manual_configuration:
+        column_mapping:
+          id: organizationId
+        insertion_order: null
+        remote_table:
+          name: OrganizationAdmin
+          schema: public
+select_permissions:
+  # The settings-admin-only half of an organization's record. Unlike the Organization select
+  # permission — which any admin of the organization satisfies, a job-board-only grant included —
+  # this one requires canManageSettings, the same capability the Organization update permission
+  # requires to change these values.
+  - role: org_admin_access
+    permission:
+      columns:
+        - id
+        - apiKeyHash
+        - ghostNewsletterApiKeyConfigured
+        - legalName
+        - legalForm
+        - managingDirector
+        - registerCourt
+        - registerNumber
+        - taxNumber
+        - vatId
+        - bankName
+        - invoiceFooterText
+        - invoiceNumberPrefix
+        - defaultVatRate
+        - defaultTaxExemptionNote
+      filter:
+        OrganizationAdmins:
+          _and:
+            - userId:
+                _eq: X-Hasura-User-Id
+            - canManageSettings:
+                _eq: true

--- a/backend/metadata/databases/default/tables/tables.yaml
+++ b/backend/metadata/databases/default/tables/tables.yaml
@@ -58,6 +58,7 @@
 - "!include public_Organization.yaml"
 - "!include public_OrganizationAdmin.yaml"
 - "!include public_OrganizationNewsletterSubscription.yaml"
+- "!include public_OrganizationSettings.yaml"
 - "!include public_OrganizationType.yaml"
 - "!include public_Program.yaml"
 - "!include public_ProgramType.yaml"

--- a/backend/migrations/default/1788510781014_create_view_public_OrganizationSettings/down.sql
+++ b/backend/migrations/default/1788510781014_create_view_public_OrganizationSettings/down.sql
@@ -1,0 +1,1 @@
+DROP VIEW IF EXISTS "public"."OrganizationSettings";

--- a/backend/migrations/default/1788510781014_create_view_public_OrganizationSettings/up.sql
+++ b/backend/migrations/default/1788510781014_create_view_public_OrganizationSettings/up.sql
@@ -1,0 +1,41 @@
+-- Split the settings-admin-only columns of "Organization" into their own
+-- selectable object.
+--
+-- Hasura allows exactly one select permission per role and table, so the
+-- org_admin_access read of "Organization" could not distinguish capabilities:
+-- ANY OrganizationAdmin row — a job-board grant with canManageJobs and nothing
+-- else included — could read the organization's banking, tax and register data,
+-- its invoicing configuration and its integration credentials. The StuJo
+-- migration made that concrete: employer contacts of a legacy company that
+-- name-matched an existing EduHub organization became job-only admins there and
+-- could read that organization's billing record.
+--
+-- These columns move to this view, whose permission requires canManageSettings.
+-- Writes are unaffected: they go to "Organization" and already require that
+-- same capability. Columns that are public on "Organization" (the Ghost
+-- newsletter endpoint fields, readable by `anonymous`) are deliberately NOT
+-- here — hiding them from org admins alone would protect nothing.
+CREATE VIEW "public"."OrganizationSettings" AS
+SELECT
+  o."id",
+  -- Integration credentials
+  o."apiKeyHash",
+  o."ghostNewsletterApiKeyConfigured",
+  -- Legal identity / commercial register
+  o."legalName",
+  o."legalForm",
+  o."managingDirector",
+  o."registerCourt",
+  o."registerNumber",
+  -- Tax and banking
+  o."taxNumber",
+  o."vatId",
+  o."bankName",
+  -- Invoicing configuration (seller side: what goes onto the Stripe invoice)
+  o."invoiceFooterText",
+  o."invoiceNumberPrefix",
+  o."defaultVatRate",
+  o."defaultTaxExemptionNote"
+FROM "public"."Organization" o;
+
+COMMENT ON VIEW "public"."OrganizationSettings" IS E'Settings-admin-only columns of Organization (integration credentials, legal/tax/banking identity, invoicing configuration). Readable via Hasura only by an OrganizationAdmin with canManageSettings; writes still go to Organization, which requires the same capability. "id" is the Organization id.';

--- a/frontend-nx/apps/edu-hub/components/pages/ManageOrganizationsContent/ApiKeyManager.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageOrganizationsContent/ApiKeyManager.tsx
@@ -58,7 +58,7 @@ export const ApiKeyManager: React.FC<Props> = ({ organization, onError }) => {
   const [generatedKey, setGeneratedKey] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isRegeneration, setIsRegeneration] = useState(false);
-  const [hasKey, setHasKey] = useState<boolean>(Boolean(organization.apiKeyHash));
+  const [hasKey, setHasKey] = useState<boolean>(Boolean(organization.Settings?.apiKeyHash));
   const [revokeOpen, setRevokeOpen] = useState(false);
 
   const [updateApiKeyHash] = useRoleMutation(UPDATE_ORGANIZATION_API_KEY_HASH);

--- a/frontend-nx/apps/edu-hub/components/pages/ManageOrganizationsContent/MergeOrganizationsDialog.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageOrganizationsContent/MergeOrganizationsDialog.tsx
@@ -131,9 +131,12 @@ export const MergeOrganizationsDialog: React.FC<MergeOrganizationsDialogProps> =
     const willChangeToUniversity = hasUniversityType && targetOrg.type !== 'UNIVERSITY';
 
     // Check for API keys - count organizations with apiKeyHash defined
+    // Settings is null unless the viewer may manage the organization's settings.
     const orgsWithApiKeys = [
-      ...orgsToMerge.filter((org: OrganizationList_Organization) => org.apiKeyHash != null && org.apiKeyHash !== ''),
-      ...(targetOrg.apiKeyHash != null && targetOrg.apiKeyHash !== '' ? [targetOrg] : []),
+      ...orgsToMerge.filter(
+        (org: OrganizationList_Organization) => org.Settings?.apiKeyHash != null && org.Settings.apiKeyHash !== ''
+      ),
+      ...(targetOrg.Settings?.apiKeyHash != null && targetOrg.Settings.apiKeyHash !== '' ? [targetOrg] : []),
     ];
     const hasMultipleApiKeys = orgsWithApiKeys.length > 1;
 

--- a/frontend-nx/apps/edu-hub/components/pages/ManageOrganizationsContent/index.tsx
+++ b/frontend-nx/apps/edu-hub/components/pages/ManageOrganizationsContent/index.tsx
@@ -167,7 +167,7 @@ const ExpandableOrganizationRow: React.FC<ExpandableRowProps> = ({ row, onError 
         />
         <GhostNewsletterCredentialManager
           organizationId={row.id}
-          initiallyConfigured={Boolean(row.ghostNewsletterApiKeyConfigured)}
+          initiallyConfigured={Boolean(row.Settings?.ghostNewsletterApiKeyConfigured)}
           onCredentialSaved={() => {
             void syncGhostNewsletterProvider();
           }}
@@ -480,8 +480,11 @@ const ManageOrganizationsContent: FC<ManageOrganizationsContentProps> = ({
         }
 
         // Check for API keys - if target doesn't have one but a merged org does, transfer it
-        const orgsWithApiKeys = orgsToMerge.filter((org) => org.apiKeyHash != null && org.apiKeyHash !== '');
-        const targetHasApiKey = targetOrg.apiKeyHash != null && targetOrg.apiKeyHash !== '';
+        // Settings is null for an admin without canManageSettings, who then sees no key to transfer.
+        const orgsWithApiKeys = orgsToMerge.filter(
+          (org) => org.Settings?.apiKeyHash != null && org.Settings.apiKeyHash !== ''
+        );
+        const targetHasApiKey = targetOrg.Settings?.apiKeyHash != null && targetOrg.Settings.apiKeyHash !== '';
         const shouldTransferApiKey = !targetHasApiKey && orgsWithApiKeys.length === 1;
 
         // Prepare updates - aliases first
@@ -503,7 +506,7 @@ const ManageOrganizationsContent: FC<ManageOrganizationsContentProps> = ({
             await updateOrganizationApiKeyHash({
               variables: {
                 id: parseInt(targetOrgId, 10),
-                apiKeyHash: orgsWithApiKeys[0].apiKeyHash,
+                apiKeyHash: orgsWithApiKeys[0].Settings?.apiKeyHash,
               },
             });
           } catch (apiKeyError) {

--- a/frontend-nx/apps/edu-hub/queries/__generated__/OrganizationList.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/OrganizationList.ts
@@ -9,6 +9,19 @@ import { Organization_bool_exp, Organization_order_by, OrganizationType_enum } f
 // GraphQL query operation: OrganizationList
 // ====================================================
 
+export interface OrganizationList_Organization_Settings {
+  __typename: "OrganizationSettings";
+  id: number | null;
+  /**
+   * SHA-256 hash of the organization API key for participant data access. Plain text keys are never stored.
+   */
+  apiKeyHash: string | null;
+  /**
+   * Flag indicating whether an encrypted Ghost newsletter API credential is configured.
+   */
+  ghostNewsletterApiKeyConfigured: boolean | null;
+}
+
 export interface OrganizationList_Organization_Users {
   __typename: "User";
   id: any;
@@ -26,10 +39,6 @@ export interface OrganizationList_Organization {
    */
   logo: string | null;
   /**
-   * SHA-256 hash of the organization API key for participant data access. Plain text keys are never stored.
-   */
-  apiKeyHash: string | null;
-  /**
    * Short organization newsletter description shown to participants in onboarding and profile preferences.
    */
   newsletterDescription: string | null;
@@ -41,10 +50,6 @@ export interface OrganizationList_Organization {
    * Ghost members API URL used to synchronize newsletter subscriptions.
    */
   ghostNewsletterApiUrl: string | null;
-  /**
-   * Flag indicating whether an encrypted Ghost newsletter API credential is configured.
-   */
-  ghostNewsletterApiKeyConfigured: boolean;
   /**
    * Optional Ghost newsletter list identifier.
    */
@@ -66,6 +71,10 @@ export interface OrganizationList_Organization {
   /**
    * An array relationship
    */
+  /**
+   * Settings-admin-only columns; null unless the caller holds canManageSettings for this organization.
+   */
+  Settings: OrganizationList_Organization_Settings | null;
   Users: OrganizationList_Organization_Users[];
 }
 

--- a/frontend-nx/apps/edu-hub/queries/__generated__/UpdateOrganizationApiKeyHash.ts
+++ b/frontend-nx/apps/edu-hub/queries/__generated__/UpdateOrganizationApiKeyHash.ts
@@ -10,10 +10,6 @@
 export interface UpdateOrganizationApiKeyHash_update_Organization_by_pk {
   __typename: "Organization";
   id: number;
-  /**
-   * SHA-256 hash of the organization API key for participant data access. Plain text keys are never stored.
-   */
-  apiKeyHash: string | null;
 }
 
 export interface UpdateOrganizationApiKeyHash {

--- a/frontend-nx/apps/edu-hub/queries/organization.ts
+++ b/frontend-nx/apps/edu-hub/queries/organization.ts
@@ -19,17 +19,22 @@ export const ORGANIZATION_LIST = gql`
       description
       aliases
       logo
-      apiKeyHash
       newsletterDescription
       newsletterProvider
       ghostNewsletterApiUrl
-      ghostNewsletterApiKeyConfigured
       ghostNewsletterListId
       ghostNewsletterSlug
       ghostNewsletterLabel
       ghostNewsletterDoubleOptInEnabled
       created_at
       updated_at
+      # Only populated for admins who may manage this organization's settings; null otherwise
+      # (the OrganizationSettings permission requires canManageSettings).
+      Settings {
+        id
+        apiKeyHash
+        ghostNewsletterApiKeyConfigured
+      }
       Users {
         id
       }
@@ -129,7 +134,6 @@ export const UPDATE_ORGANIZATION_API_KEY_HASH = gql`
       _set: { apiKeyHash: $apiKeyHash }
     ) {
       id
-      apiKeyHash
     }
   }
 `;

--- a/scripts/stujo_etl.py
+++ b/scripts/stujo_etl.py
@@ -143,10 +143,32 @@ def slugify(value: str) -> str:
 
 
 def normalize_company_name(name: str) -> str:
-    """Normalization for dedupe against existing EduHub organizations."""
+    """Normalization for dedupe against existing EduHub organizations.
+
+    Returns "" for a name that carries no dedupe signal at all — a punctuation-
+    only row ("-", "..."), or one that is nothing but a legal form ("e.V."),
+    since both the legal forms and every non-alphanumeric character are
+    stripped. Callers MUST NOT dedupe on an empty result: it matches every other
+    junk-named company, which is how a StuJo company merged into the placeholder
+    Organization "-" and made its contact an admin there.
+    """
     n = name.lower().strip()
     n = re.sub(r"\b(gmbh & co\.? kg|gmbh|ag|kg|e\.?v\.?|ug|se|ohg|mbh)\b", "", n)
     return re.sub(r"[^a-z0-9]+", "", n)
+
+
+_LIKE_WILDCARDS = re.compile(r"([\\%_])")
+
+
+def like_escape(value: str) -> str:
+    """Escape the LIKE/ILIKE wildcards in a value used as a pattern.
+
+    Legacy addresses regularly contain "_", which ILIKE reads as "any single
+    character": an unescaped lookup for `max_mustermann@x.de` also matches
+    `max.mustermann@x.de`, so a StuJo grant could land on a different person.
+    Postgres uses backslash as the default LIKE escape character.
+    """
+    return _LIKE_WILDCARDS.sub(r"\\\1", value)
 
 
 def mask_email(email: str | None) -> str:
@@ -553,17 +575,32 @@ def step_companies(hasura: HasuraClient, gcs_bucket, files_root, companies) -> d
     existing = hasura.query(
         """query { Organization { id name aliases logo } }"""
     )["Organization"]
-    by_norm = {normalize_company_name(o["name"]): o for o in existing}
+    # "" is deliberately not a key: a junk-named organization must not be a dedupe
+    # target for every other junk-named company (see normalize_company_name).
+    by_norm = {}
+    for o in existing:
+        norm_existing = normalize_company_name(o["name"])
+        if norm_existing:
+            by_norm[norm_existing] = o
     by_alias = {}
     for o in existing:
         for alias in o.get("aliases") or []:
             by_alias[alias] = o
 
+    existing_names = {o["name"] for o in existing}
+
     mapping = {}
     for c in companies:
         legacy_alias = f"stujo:{c['id']}-{slugify(c['name'])}"
         norm = normalize_company_name(c["name"])
-        org = by_alias.get(legacy_alias) or by_norm.get(norm)
+        # An empty normalization carries no identity (see normalize_company_name),
+        # so it must never dedupe: matching on it merged a junk-named StuJo company
+        # into the placeholder Organization "-" and made its contact an admin there.
+        # Such a company still migrates, as its own organization.
+        if not norm:
+            log.warning("company %s '%s' normalizes to nothing — not deduped, "
+                        "migrating as its own organization", c["id"], c["name"])
+        org = by_alias.get(legacy_alias) or (by_norm.get(norm) if norm else None)
         if org:
             # Duplicate company rows in the Rails DB (23 exist, e.g. two
             # 'terwixonse') merge into one Organization; record this row's
@@ -598,6 +635,14 @@ def step_companies(hasura: HasuraClient, gcs_bucket, files_root, companies) -> d
             log.info("company %s → existing Organization %s (%s)", c["id"], org["id"], org["name"])
             continue
 
+        # Organization.name is unique. Without the name dedupe above, a junk name can
+        # collide with an existing organization that carries it verbatim, which would
+        # abort the whole run — so those get the source row appended to stay distinct
+        # (and recognizable as imported junk in the UI).
+        org_name = c["name"]
+        if not norm and org_name in existing_names:
+            org_name = f"{org_name} (StuJo #{c['id']})"
+
         address_line = " ".join(filter(None, [c.get("street"), c.get("nr")])) or None
         result = hasura.mutate(
             """
@@ -607,7 +652,7 @@ def step_companies(hasura: HasuraClient, gcs_bucket, files_root, companies) -> d
             """,
             {
                 "obj": {
-                    "name": c["name"],
+                    "name": org_name,
                     "type": "CORPORATION",
                     "description": c.get("description"),
                     "website": normalize_website(c.get("url")),
@@ -628,10 +673,14 @@ def step_companies(hasura: HasuraClient, gcs_bucket, files_root, companies) -> d
             _set_org_logo(hasura, org_id, logo_path)
         # Register the new org in the dedupe maps so later duplicate rows
         # in the same run merge instead of violating Organization_name_key.
-        created = {"id": org_id, "name": c["name"], "aliases": [legacy_alias], "logo": logo_path}
-        by_norm[norm] = created
+        created = {"id": org_id, "name": org_name, "aliases": [legacy_alias], "logo": logo_path}
+        # Only a meaningful normalization may serve later rows; registering "" would
+        # re-introduce the junk collision within a single run.
+        if norm:
+            by_norm[norm] = created
         by_alias[legacy_alias] = created
-        log.info("company %s '%s' → new Organization %s", c["id"], c["name"], org_id)
+        existing_names.add(org_name)
+        log.info("company %s '%s' → new Organization %s", c["id"], org_name, org_id)
     return mapping
 
 
@@ -751,6 +800,33 @@ def _sync_job_tags(hasura: "HasuraClient", posting_id: int, tags: list) -> None:
         )
 
 
+def find_account_by_email(hasura: "HasuraClient", email: str):
+    """Look an EduHub account up by address — exactly, and case-insensitively.
+
+    Two traps this closes:
+      - ILIKE wildcards. Legacy addresses contain "_" (and occasionally "%"),
+        which ILIKE reads as a pattern: an unescaped lookup for
+        `max_mustermann@x.de` also matches `max.mustermann@x.de`, and the StuJo
+        grant would land on a different person. The address is escaped.
+      - GUEST rows are not accounts. User_email_non_guest_key exists precisely so
+        one address can carry a guest record *and* the account that later claims
+        it, so a guest row must not be mistaken for the account.
+
+    Returns (user_id, rows). user_id is None when nothing matched, and also when
+    several accounts share the address — picking one of them would silently give
+    the wrong person the grant, so the caller skips instead of guessing.
+    """
+    rows = hasura.query(
+        """
+        query ($pattern: String!) {
+          User(where: {email: {_ilike: $pattern}, status: {_neq: GUEST}}) { id email }
+        }
+        """,
+        {"pattern": like_escape(email)},
+    )["User"]
+    return (rows[0]["id"] if len(rows) == 1 else None), rows
+
+
 def step_users(hasura: HasuraClient, keycloak, contacts, org_mapping) -> dict:
     """Employer accounts → Keycloak (bcrypt import) + User + OrganizationAdmin.
 
@@ -771,14 +847,15 @@ def step_users(hasura: HasuraClient, keycloak, contacts, org_mapping) -> dict:
             continue
         org_id = org_mapping[c["company_id"]]
 
-        existing = hasura.query(
-            """query ($email: String!) { User(where: {email: {_ilike: $email}}) { id } }""",
-            {"email": email},
-        )["User"]
+        user_id, matches = find_account_by_email(hasura, email)
+        if user_id is None and matches:
+            log.warning("skipping contact %s (%s): %s accounts share this address — "
+                        "resolve the duplicate, then re-run (idempotent)",
+                        c["id"], mask_email(email), len(matches))
+            skipped += 1
+            continue
 
-        if existing:
-            user_id = existing[0]["id"]
-        else:
+        if user_id is None:
             if keycloak is None:
                 if not hasura.dry_run:
                     raise RuntimeError(
@@ -1043,13 +1120,15 @@ def step_students(hasura: HasuraClient, keycloak, students):
         if not email:
             continue
 
-        existing = hasura.query(
-            """query ($email: String!) { User(where: {email: {_ilike: $email}}) { id } }""",
-            {"email": email},
-        )["User"]
+        user_id, matches = find_account_by_email(hasura, email)
+        if user_id is None and matches:
+            log.warning("skipping student %s (%s): %s accounts share this address — "
+                        "resolve the duplicate, then re-run (idempotent)",
+                        s["student_id"], mask_email(email), len(matches))
+            skipped += 1
+            continue
 
-        if existing:
-            user_id = existing[0]["id"]
+        if user_id is not None:
             log.info("student %s (%s) → existing User %s",
                      s["student_id"], mask_email(email), user_id)
         else:


### PR DESCRIPTION
## Summary

This PR fixes critical security and data integrity issues discovered during the StuJo employer migration:

1. **Data access control vulnerability**: Organization settings (banking, tax, integration credentials) were readable by any organization admin, even those with only job-board permissions. These are now moved to a separate `OrganizationSettings` view that requires `canManageSettings` capability.

2. **Deduplication logic bug**: Company names that normalize to empty strings (punctuation-only or legal-form-only names) were incorrectly deduped against existing organizations, causing StuJo companies to merge into placeholder organizations like "-" and making their contacts admins there.

3. **Email lookup vulnerability**: ILIKE pattern matching on email addresses containing underscores could match unintended accounts, potentially assigning grants to the wrong person.

## Key Changes

**Backend - Security & Data Integrity:**
- Created `OrganizationSettings` view to isolate sensitive organization data (API keys, tax/banking info, invoicing config, integration credentials)
- Updated `Organization` select permission for `org_admin_access` role to exclude sensitive columns; they're now accessible only through the `Settings` relationship which requires `canManageSettings`
- Added `like_escape()` function to properly escape ILIKE wildcards in email lookups, preventing "_" from matching any character
- Added `find_account_by_email()` function that safely looks up accounts by email with proper escaping and duplicate detection
- Fixed `normalize_company_name()` to never dedupe on empty results; added validation to skip deduplication when normalization yields empty string
- Updated company creation logic to append "(StuJo #{id})" to junk-named organizations that would collide with existing names
- Updated user and student migration steps to use the new safe email lookup function

**Frontend - UI Updates:**
- Updated `OrganizationList` query to fetch sensitive fields through the new `Settings` relationship
- Updated all components accessing sensitive organization fields (`apiKeyHash`, `ghostNewsletterApiKeyConfigured`) to read from `Settings` instead of directly from `Organization`
- Updated `UPDATE_ORGANIZATION_API_KEY_HASH` mutation to not return the sensitive field (it's now write-only from the frontend perspective)

## Notable Implementation Details

- Empty normalization is deliberately excluded from deduplication maps to prevent junk-named companies from colliding with each other
- The `OrganizationSettings` view uses manual column mapping in Hasura to maintain the relationship without foreign key constraints
- Email lookups now properly handle the case where multiple accounts share an address (logs warning and skips rather than guessing)
- The fix is backward compatible: existing data access patterns continue to work, with sensitive fields simply returning null for admins without `canManageSettings`

https://claude.ai/code/session_01ScuLTKrGoTNAaRZx7GDATh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated organization settings view for banking, tax, legal, invoicing, and integration credentials.
  - Settings are available only to administrators with permission to manage organization settings.
  - Organization management now reads API key and newsletter credential status through the protected settings area.

- **Bug Fixes**
  - Improved organization deduplication to avoid merging records with empty or ambiguous normalized names.
  - Prevented migrations from selecting accounts when duplicate email matches exist.
  - Improved handling of special characters in organization-name matching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->