### PR TITLE
fix(stujo): grant the org_admin role before the post-claim re-login

### DIFF
--- a/frontend-nx/apps/stujo/lib/useEmployerOrganization.ts
+++ b/frontend-nx/apps/stujo/lib/useEmployerOrganization.ts
@@ -4,6 +4,7 @@ import { useSession } from 'next-auth/react';
 import { useCallback, useMemo } from 'react';
 
 import { useCurrentUserId } from '@eduhub/hooks/authentication';
+import { AuthRoles } from '@eduhub/types/enums';
 
 import { MY_JOB_ORGANIZATIONS, useEmployerRoleContext } from './employer';
 
@@ -64,10 +65,17 @@ export const useEmployerOrganization = (): EmployerOrganizationState => {
   const employerRole = useEmployerRoleContext();
   const currentUserId = useCurrentUserId();
 
+  // OrganizationAdmin is readable by org_admin_access and admin only, so under
+  // the plain `user` role this query does not fail gracefully — it fails schema
+  // validation. Skipping it keeps the "no company yet" state honest instead of
+  // hiding a permission error behind it; a user whose grant exists but whose
+  // token has not caught up recovers on /mein-stujo/unternehmen, which
+  // re-authenticates and verifies the role.
   const { data, loading } = useQuery(MY_JOB_ORGANIZATIONS, {
     context: employerRole,
     variables: { userId: currentUserId },
-    skip: sessionStatus !== 'authenticated' || !currentUserId,
+    skip:
+      sessionStatus !== 'authenticated' || !currentUserId || employerRole.role === AuthRoles.user,
   });
 
   const organizations = useMemo<EmployerOrganization[]>(

--- a/frontend-nx/apps/stujo/locales/de.json
+++ b/frontend-nx/apps/stujo/locales/de.json
@@ -128,6 +128,8 @@
     "claimAlreadyClaimedByName": "Die Stellenanzeigen von {organization} verwaltet bereits {name}. Wir können Dich fragen, ob Du dazukommen darfst.",
     "claimAlreadyClaimed": "Die Stellenanzeigen von {organization} verwaltet bereits jemand anderes. Wir können nachfragen, ob Du dazukommen darfst.",
     "claimRequestAccess": "Zugang anfragen",
+    "claimRoleRefreshFailed": "Deine Stellen-Verwaltung ist eingerichtet, aber Deine Anmeldung konnte nicht aktualisiert werden. Versuche es noch einmal – oder melde Dich ab und wieder an, dann ist der Zugang da.",
+    "claimRoleRefreshRetry": "Anmeldung aktualisieren",
     "claimContactFallback": "Du kommst nicht weiter? Schreib uns an {contact}.",
     "accessRequestSent": "Wir haben Deine Anfrage weitergeleitet. Du hörst direkt von den Kolleg:innen, die die Stellenanzeigen verwalten.",
     "accessRequestAlreadySent": "Für dieses Unternehmen läuft schon eine Anfrage von Dir. Bitte warte die Antwort ab.",

--- a/frontend-nx/apps/stujo/locales/en.json
+++ b/frontend-nx/apps/stujo/locales/en.json
@@ -128,6 +128,8 @@
     "claimAlreadyClaimedByName": "{name} already manages the job offers of {organization}. We can ask whether you may join.",
     "claimAlreadyClaimed": "Someone else already manages the job offers of {organization}. We can ask whether you may join.",
     "claimRequestAccess": "Request access",
+    "claimRoleRefreshFailed": "Your job management is set up, but your sign-in could not be refreshed. Please try again — or sign out and sign back in, then the access will be there.",
+    "claimRoleRefreshRetry": "Refresh sign-in",
     "claimContactFallback": "Stuck? Write to us at {contact}.",
     "accessRequestSent": "We have passed your request on. You will hear directly from the colleagues who manage the job offers.",
     "accessRequestAlreadySent": "You already have a pending request for this company. Please wait for a reply.",

--- a/frontend-nx/apps/stujo/pages/mein-stujo/unternehmen.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/unternehmen.tsx
@@ -3,10 +3,11 @@ import type { GetServerSideProps } from 'next';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { signIn, useSession } from 'next-auth/react';
-import { FC, useCallback, useMemo, useState } from 'react';
+import { FC, useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import DropDownSelector from '@eduhub/components/inputs/DropDownSelector';
+import { useIsAdmin, useIsOrgAdmin } from '@eduhub/hooks/authentication';
 
 import Layout from '../../components/Layout';
 import StuJoLegacyIcon from '../../components/StuJoLegacyIcon';
@@ -21,6 +22,26 @@ import { useEmployerOrganization } from '../../lib/useEmployerOrganization';
 import { resolvePortal, PortalBranding } from '../../lib/portal';
 
 type Props = { portal: PortalBranding };
+
+/**
+ * How many times to re-authenticate before giving up on picking the new role
+ * up silently. The first attempt is an SSO round trip; the second forces a
+ * fresh Keycloak authentication, which is what signing out and back in does.
+ */
+const MAX_ROLE_REFRESH_ATTEMPTS = 2;
+
+/**
+ * Keep `?next=` an in-app destination. It is echoed into a callbackUrl and into
+ * router.replace, so an absolute or protocol-relative value would turn this
+ * page — the one employers are sent to by link — into an open redirect.
+ */
+const safeNext = (value: unknown): string =>
+  typeof value === 'string' && value.startsWith('/') && !value.startsWith('//')
+    ? value
+    : '/mein-stujo/neu';
+
+/** Breathing room for the event trigger before a repeat attempt (ms). */
+const ROLE_REFRESH_BACKOFF_MS = 1500;
 
 type ClaimResult = {
   status?: string | null;
@@ -51,6 +72,14 @@ const Unternehmen: FC<Props> = ({ portal }) => {
   const { status: sessionStatus } = useSession();
   const employerRole = useEmployerRoleContext();
   const { organizations, loading: orgsLoading } = useEmployerOrganization();
+  // Whether this session's token can actually reach the employer screens. The
+  // grant lives in OrganizationAdmin, but Hasura only lets `org_admin` (or a
+  // super-admin's `admin`) read and write job offers, and that role reaches the
+  // token exclusively through Keycloak — so a committed claim is invisible until
+  // the token carries it.
+  const isOrgAdmin = useIsOrgAdmin();
+  const isSuperAdmin = useIsAdmin();
+  const canManageJobs = isOrgAdmin || isSuperAdmin;
 
   // What the picker currently holds, tracked as a tagged value rather than inferred from the
   // string: a company legitimately named "360" would otherwise be read back as organization id 360.
@@ -65,7 +94,12 @@ const Unternehmen: FC<Props> = ({ portal }) => {
 
   // Where to go once the claim succeeds. `?next=` lets the employer screens
   // send someone here and get them back to what they were doing.
-  const next = typeof router.query.next === 'string' ? router.query.next : '/mein-stujo/neu';
+  const next = safeNext(router.query.next);
+
+  // Set by the re-authentication round trip below so the page knows, on the way
+  // back, that it must verify the role instead of offering the form again.
+  const refreshing = router.query.refreshRole === '1';
+  const attempt = Number.parseInt(String(router.query.attempt ?? ''), 10) || 0;
 
   const {
     data: optionsData,
@@ -106,6 +140,47 @@ const Unternehmen: FC<Props> = ({ portal }) => {
     [portal.appName, router.asPath]
   );
 
+  /**
+   * Re-authenticate so the fresh token carries the org_admin role, and come back
+   * *here* rather than straight to the posting form: only this page knows a
+   * claim just happened, so only this page can tell "the refresh worked" from
+   * "you have no company yet" — the message the employer used to be dropped
+   * into, with no way out but signing out manually.
+   *
+   * Attempt 2 adds `prompt=login`, which makes Keycloak authenticate the user
+   * again instead of answering from the existing SSO session.
+   */
+  const refreshRole = useCallback(
+    (nextAttempt: number) =>
+      signIn(
+        'keycloak',
+        {
+          callbackUrl: `/mein-stujo/unternehmen?refreshRole=1&attempt=${nextAttempt}&next=${encodeURIComponent(
+            next
+          )}`,
+        },
+        {
+          stujo_portal: portal.appName,
+          ...(nextAttempt > 1 ? { prompt: 'login' } : {}),
+        }
+      ),
+    [next, portal.appName]
+  );
+
+  // Back from a re-authentication: hand the employer on if the role arrived,
+  // and otherwise try once more — the add_keycloak_org_admin_role event trigger
+  // can still be catching up if the action's synchronous grant did not land.
+  useEffect(() => {
+    if (!refreshing || sessionStatus !== 'authenticated') return;
+    if (canManageJobs) {
+      router.replace(next);
+      return;
+    }
+    if (attempt >= MAX_ROLE_REFRESH_ATTEMPTS) return;
+    const timer = setTimeout(() => refreshRole(attempt + 1), ROLE_REFRESH_BACKOFF_MS);
+    return () => clearTimeout(timer);
+  }, [refreshing, sessionStatus, canManageJobs, attempt, next, refreshRole, router]);
+
   const handleSubmit = async () => {
     setError(null);
     setNotice(null);
@@ -144,11 +219,11 @@ const Unternehmen: FC<Props> = ({ portal }) => {
       }
 
       // The grant is in the database, but this session's token predates it and
-      // still lacks the org_admin role, so every posting write would be
+      // still lacks the org_admin role, so every posting query and write would be
       // rejected. Re-authenticating is a silent redirect through the existing
       // Keycloak session and comes back with the role.
       setRedirecting(true);
-      await signIn('keycloak', { callbackUrl: next }, { stujo_portal: portal.appName });
+      await refreshRole(1);
     } catch (caught: any) {
       console.error('claimJobOrganization failed', caught);
       setError(t('claimNetworkError'));
@@ -207,10 +282,34 @@ const Unternehmen: FC<Props> = ({ portal }) => {
     );
   }
 
-  if (redirecting) {
+  if (redirecting || (refreshing && !canManageJobs && attempt < MAX_ROLE_REFRESH_ATTEMPTS)) {
     return (
       <Layout portal={portal}>
         <p className="stujo-muted">{t('claimSettingUpAccess')}</p>
+      </Layout>
+    );
+  }
+
+  // Every silent attempt is spent and the token still has no org_admin role.
+  // The access itself is granted — say so, and say what does fix it — rather
+  // than showing the picker again, which would only re-claim what they hold.
+  if (refreshing && !canManageJobs) {
+    return (
+      <Layout portal={portal}>
+        <h1>{t('claimTitle')}</h1>
+        <div className="stujo-notice stujo-notice--error">{t('claimRoleRefreshFailed')}</div>
+        <p className="stujo-form-actions">
+          <button
+            type="button"
+            className="stujo-btn stujo-btn--primary"
+            onClick={() => refreshRole(MAX_ROLE_REFRESH_ATTEMPTS)}
+          >
+            {t('claimRoleRefreshRetry')}
+          </button>
+        </p>
+        <p className="stujo-muted">
+          {t('claimContactFallback', { contact: portal.contactEmail || t('defaultContact') })}
+        </p>
       </Layout>
     );
   }

--- a/frontend-nx/apps/stujo/pages/mein-stujo/unternehmen.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/unternehmen.tsx
@@ -91,6 +91,11 @@ const Unternehmen: FC<Props> = ({ portal }) => {
   const [error, setError] = useState<string | null>(null);
   const [claim, setClaim] = useState<ClaimResult | null>(null);
   const [redirecting, setRedirecting] = useState(false);
+  // A re-authentication that never even got as far as leaving the page. signIn
+  // resolves by navigating away, so reaching its rejection path means the
+  // redirect did not happen — without this the employer watches "setting up
+  // your access" forever.
+  const [refreshFailed, setRefreshFailed] = useState(false);
 
   // Where to go once the claim succeeds. `?next=` lets the employer screens
   // send someone here and get them back to what they were doing.
@@ -98,8 +103,15 @@ const Unternehmen: FC<Props> = ({ portal }) => {
 
   // Set by the re-authentication round trip below so the page knows, on the way
   // back, that it must verify the role instead of offering the form again.
+  //
+  // The counter is clamped rather than trusted: it comes from the query string,
+  // and a crafted `attempt=-1000000` would otherwise stay below the ceiling for
+  // a million redirects — a self-inflicted loop through Keycloak.
   const refreshing = router.query.refreshRole === '1';
-  const attempt = Number.parseInt(String(router.query.attempt ?? ''), 10) || 0;
+  const attempt = Math.min(
+    Math.max(0, Number.parseInt(String(router.query.attempt ?? ''), 10) || 0),
+    MAX_ROLE_REFRESH_ATTEMPTS
+  );
 
   const {
     data: optionsData,
@@ -151,8 +163,9 @@ const Unternehmen: FC<Props> = ({ portal }) => {
    * again instead of answering from the existing SSO session.
    */
   const refreshRole = useCallback(
-    (nextAttempt: number) =>
-      signIn(
+    (nextAttempt: number) => {
+      setRefreshFailed(false);
+      return signIn(
         'keycloak',
         {
           callbackUrl: `/mein-stujo/unternehmen?refreshRole=1&attempt=${nextAttempt}&next=${encodeURIComponent(
@@ -163,7 +176,11 @@ const Unternehmen: FC<Props> = ({ portal }) => {
           stujo_portal: portal.appName,
           ...(nextAttempt > 1 ? { prompt: 'login' } : {}),
         }
-      ),
+      ).catch((caught) => {
+        console.error('role refresh sign-in failed', caught);
+        setRefreshFailed(true);
+      });
+    },
     [next, portal.appName]
   );
 
@@ -171,7 +188,7 @@ const Unternehmen: FC<Props> = ({ portal }) => {
   // and otherwise try once more — the add_keycloak_org_admin_role event trigger
   // can still be catching up if the action's synchronous grant did not land.
   useEffect(() => {
-    if (!refreshing || sessionStatus !== 'authenticated') return;
+    if (!refreshing || sessionStatus !== 'authenticated' || refreshFailed) return;
     if (canManageJobs) {
       router.replace(next);
       return;
@@ -179,7 +196,16 @@ const Unternehmen: FC<Props> = ({ portal }) => {
     if (attempt >= MAX_ROLE_REFRESH_ATTEMPTS) return;
     const timer = setTimeout(() => refreshRole(attempt + 1), ROLE_REFRESH_BACKOFF_MS);
     return () => clearTimeout(timer);
-  }, [refreshing, sessionStatus, canManageJobs, attempt, next, refreshRole, router]);
+  }, [
+    refreshing,
+    sessionStatus,
+    canManageJobs,
+    attempt,
+    next,
+    refreshFailed,
+    refreshRole,
+    router,
+  ]);
 
   const handleSubmit = async () => {
     setError(null);
@@ -226,6 +252,7 @@ const Unternehmen: FC<Props> = ({ portal }) => {
       await refreshRole(1);
     } catch (caught: any) {
       console.error('claimJobOrganization failed', caught);
+      setRedirecting(false);
       setError(t('claimNetworkError'));
     }
   };
@@ -282,7 +309,10 @@ const Unternehmen: FC<Props> = ({ portal }) => {
     );
   }
 
-  if (redirecting || (refreshing && !canManageJobs && attempt < MAX_ROLE_REFRESH_ATTEMPTS)) {
+  const waitingForRole =
+    redirecting || (refreshing && !canManageJobs && attempt < MAX_ROLE_REFRESH_ATTEMPTS);
+
+  if (waitingForRole && !refreshFailed) {
     return (
       <Layout portal={portal}>
         <p className="stujo-muted">{t('claimSettingUpAccess')}</p>
@@ -290,10 +320,11 @@ const Unternehmen: FC<Props> = ({ portal }) => {
     );
   }
 
-  // Every silent attempt is spent and the token still has no org_admin role.
-  // The access itself is granted — say so, and say what does fix it — rather
-  // than showing the picker again, which would only re-claim what they hold.
-  if (refreshing && !canManageJobs) {
+  // Every silent attempt is spent, or a redirect never happened, and the token
+  // still has no org_admin role. The access itself is granted — say so, and say
+  // what does fix it — rather than showing the picker again, which would only
+  // re-claim what they already hold.
+  if (!canManageJobs && (refreshFailed || refreshing)) {
     return (
       <Layout portal={portal}>
         <h1>{t('claimTitle')}</h1>

--- a/functions/callNodeFunction/claimJobOrganization/__tests__/claimJobOrganization.test.js
+++ b/functions/callNodeFunction/claimJobOrganization/__tests__/claimJobOrganization.test.js
@@ -61,12 +61,16 @@ describe('claimJobOrganization', () => {
   let claimJobOrganization;
   let queueEmailMock;
   let requestMock;
-  let fetchMock;
+  let addRoleMock;
 
   beforeAll(async () => {
     queueEmailMock = jest.fn(async () => ({ success: true, messageKey: 'EMAIL_QUEUED_SUCCESS' }));
+    addRoleMock = jest.fn(async () => ({ granted: true, reason: 'ADDED' }));
 
     jest.unstable_mockModule('../../lib/queueEmail.js', () => ({ queueEmail: queueEmailMock }));
+    jest.unstable_mockModule('../../lib/keycloakClientRole.js', () => ({
+      addKeycloakClientRole: addRoleMock,
+    }));
     jest.unstable_mockModule('graphql-request', () => {
       const actual = jest.requireActual('graphql-request');
       return {
@@ -84,13 +88,11 @@ describe('claimJobOrganization', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     queueEmailMock.mockResolvedValue({ success: true, messageKey: 'EMAIL_QUEUED_SUCCESS' });
+    addRoleMock.mockResolvedValue({ granted: true, reason: 'ADDED' });
     process.env.HASURA_ENDPOINT = 'https://test.hasura.app/v1/graphql';
     process.env.HASURA_ADMIN_SECRET = 'test-secret';
     process.env.FRONTEND_URL = 'https://edu.opencampus.sh';
     process.env.STUJO_ADMIN_EMAIL = 'stujo@opencampus.sh';
-    delete process.env.CLOUD_FUNCTION_LINK_ADD_KEYCLOAK_ROLE;
-    fetchMock = jest.fn(async () => ({ ok: true }));
-    global.fetch = fetchMock;
   });
 
   it('refuses a request without an authenticated session user', async () => {
@@ -432,6 +434,68 @@ describe('claimJobOrganization', () => {
 
     expect(result).toMatchObject({ success: true, status: 'GRANTED' });
     expect(queueEmailMock).not.toHaveBeenCalled();
+    expect(mockLogger.warn).toHaveBeenCalled();
+  });
+  // The bug this guards: the grant used to be handed to Keycloak only by the
+  // add_keycloak_org_admin_role event trigger, asynchronously, while the
+  // frontend re-authenticated the instant this action returned. The fresh token
+  // then still lacked org_admin and the employer was told they had no company
+  // until they signed out and back in.
+  it('grants the Keycloak org_admin role before returning a claimed organization', async () => {
+    requestMock = buildRequestMock({
+      organization: { id: 7, name: 'Beispiel GmbH', email: null, website: null, OrganizationAdmins: [] },
+    });
+
+    const result = await claimJobOrganization(claimInput({ organizationId: 7 }), mockLogger);
+
+    expect(result).toMatchObject({ success: true, status: 'GRANTED' });
+    expect(addRoleMock).toHaveBeenCalledTimes(1);
+    expect(addRoleMock.mock.calls[0].slice(0, 2)).toEqual([CLAIMER.id, 'org_admin']);
+  });
+
+  it('grants the Keycloak org_admin role for a newly created organization too', async () => {
+    requestMock = buildRequestMock({ candidates: [], created: { id: 21, name: 'Ganz Neu GmbH' } });
+
+    const result = await claimJobOrganization(
+      claimInput({ newOrganizationName: 'Ganz Neu GmbH' }),
+      mockLogger
+    );
+
+    expect(result).toMatchObject({ success: true, status: 'GRANTED', organizationId: 21 });
+    expect(addRoleMock).toHaveBeenCalledTimes(1);
+    expect(addRoleMock.mock.calls[0].slice(0, 2)).toEqual([CLAIMER.id, 'org_admin']);
+  });
+
+  it('does not touch Keycloak when no grant was made', async () => {
+    requestMock = buildRequestMock({
+      organization: {
+        id: 7,
+        name: 'Beispiel GmbH',
+        email: null,
+        website: null,
+        OrganizationAdmins: [
+          { id: 3, userId: 'someone-else', canManageJobs: true, User: { firstName: 'Bea', lastName: 'B' } },
+        ],
+      },
+    });
+
+    const result = await claimJobOrganization(claimInput({ organizationId: 7 }), mockLogger);
+
+    expect(result).toMatchObject({ status: 'ALREADY_CLAIMED' });
+    expect(addRoleMock).not.toHaveBeenCalled();
+  });
+
+  it('still reports the grant when Keycloak cannot be reached', async () => {
+    // The database access is already committed, so a Keycloak hiccup must not be
+    // reported as a failed claim — the event trigger retries the role.
+    addRoleMock.mockRejectedValue(new Error('Keycloak role grant timed out after 8000ms'));
+    requestMock = buildRequestMock({
+      organization: { id: 7, name: 'Beispiel GmbH', email: null, website: null, OrganizationAdmins: [] },
+    });
+
+    const result = await claimJobOrganization(claimInput({ organizationId: 7 }), mockLogger);
+
+    expect(result).toMatchObject({ success: true, status: 'GRANTED' });
     expect(mockLogger.warn).toHaveBeenCalled();
   });
 });

--- a/functions/callNodeFunction/claimJobOrganization/index.js
+++ b/functions/callNodeFunction/claimJobOrganization/index.js
@@ -1,5 +1,6 @@
 import { GraphQLClient, gql } from 'graphql-request';
 
+import { addKeycloakClientRole } from '../lib/keycloakClientRole.js';
 import { queueEmail } from '../lib/queueEmail.js';
 import { createOrganizationClaimVariableReplacer } from '../emailTemplateVariables.js';
 import {
@@ -36,7 +37,7 @@ import {
 const MAX_ORGANIZATION_NAME_LENGTH = 200;
 
 /** How long to wait for the synchronous Keycloak role grant before leaving it to the retry path. */
-const KEYCLOAK_ROLE_TIMEOUT_MS = 5000;
+const KEYCLOAK_ROLE_TIMEOUT_MS = 8000;
 
 const GET_CLAIMER = gql`
   query GetClaimerForOrganizationClaim($userId: uuid!) {
@@ -134,42 +135,31 @@ const INSERT_GRANT = gql`
  * The add_keycloak_org_admin_role event trigger on OrganizationAdmin does this
  * too, but asynchronously, and the frontend re-authenticates the moment this
  * action returns to pick the role up. Losing that race means the fresh token
- * still lacks org_admin and the first JobPosting insert is rejected. The
- * function is idempotent (an already-assigned role is no longer "available" to
- * add), so doing both is safe. A failure here is logged, not fatal: the event
- * trigger retries.
+ * still lacks org_admin, every JobPosting query and insert is rejected, and the
+ * employer is told they have no company until they sign out and in again.
+ *
+ * So the grant is made here, in-process, against the Keycloak admin API — not
+ * by calling the addKeycloakRole webhook, whose URL is only configured on
+ * Hasura and was therefore never set in this runtime, making the whole
+ * "synchronous" path a silent no-op. It is idempotent, so overlapping with the
+ * event trigger is safe.
+ *
+ * A failure is logged, not fatal: the access is already committed in the
+ * database and the event trigger retries the role.
  */
 async function addKeycloakOrgAdminRole(userId, logger) {
-  const url = process.env.CLOUD_FUNCTION_LINK_ADD_KEYCLOAK_ROLE;
-  const secret = process.env.HASURA_CLOUD_FUNCTION_SECRET;
-  if (!url || !secret) {
-    logger.warn('Keycloak role webhook not configured, relying on the event trigger');
-    return;
-  }
-  // Bounded, because by this point the grant is already committed: an endpoint that accepts the
-  // connection and never answers would otherwise hold the action until the platform timeout and
-  // report failure to somebody who does have access. The event trigger retries either way.
-  const controller = new AbortController();
-  const deadline = setTimeout(() => controller.abort(), KEYCLOAK_ROLE_TIMEOUT_MS);
-  try {
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', secret, role: 'org_admin' },
-      body: JSON.stringify({ event: { data: { new: { userId } } } }),
-      signal: controller.signal,
-    });
-    if (!response.ok) {
-      logger.warn('Synchronous Keycloak role grant failed, relying on the event trigger', {
-        status: response.status,
-      });
-    }
-  } catch (error) {
+  const result = await addKeycloakClientRole(userId, 'org_admin', logger, {
+    timeoutMs: KEYCLOAK_ROLE_TIMEOUT_MS,
+  }).catch((error) => ({ granted: false, reason: error.message }));
+
+  if (result.granted) {
+    logger.info('Keycloak org_admin role in place for the claimer', { reason: result.reason });
+  } else {
     logger.warn('Synchronous Keycloak role grant failed, relying on the event trigger', {
-      error: error.message,
+      reason: result.reason,
     });
-  } finally {
-    clearTimeout(deadline);
   }
+  return result.granted;
 }
 
 /**

--- a/functions/callNodeFunction/lib/keycloakClientRole.js
+++ b/functions/callNodeFunction/lib/keycloakClientRole.js
@@ -1,0 +1,102 @@
+import KcAdminClient from '@keycloak/keycloak-admin-client';
+
+/**
+ * Hand out a Keycloak `hasura` client role (admin, instructor, org_admin, ...)
+ * from inside a node function, without going through the addKeycloakRole
+ * webhook.
+ *
+ * Why not the webhook: CLOUD_FUNCTION_LINK_ADD_KEYCLOAK_ROLE is configured on
+ * Hasura (which owns the event triggers), not on the callNodeFunction runtime,
+ * so a handler that tried to POST there found no URL and silently skipped the
+ * grant. KEYCLOAK_URL/KEYCLOAK_USER/KEYCLOAK_PW, on the other hand, are already
+ * part of this runtime's environment (updateKeycloakUser uses them), so talking
+ * to the Keycloak admin API directly is both possible and one hop shorter.
+ *
+ * This matters where a caller re-authenticates immediately after the grant to
+ * pick the role up in a fresh token: only a synchronous grant is guaranteed to
+ * be in place by the time the new token is issued. The equivalent event trigger
+ * on the same table stays the retry safety net for everything else.
+ *
+ * Idempotent: a role the user already holds is no longer "available" to add, so
+ * a repeat call is a no-op rather than an error.
+ *
+ * @returns {Promise<{ granted: boolean, reason?: string }>} `granted` is true
+ *   only when the role is now on the user (freshly added or already there).
+ */
+export const addKeycloakClientRole = async (
+  userId,
+  role,
+  logger,
+  { timeoutMs = 8000, clientId = 'hasura', realmName = 'edu-hub' } = {}
+) => {
+  if (!userId || !role) {
+    return { granted: false, reason: 'MISSING_ARGUMENTS' };
+  }
+  if (!process.env.KEYCLOAK_URL || !process.env.KEYCLOAK_PW) {
+    logger?.warn('Keycloak admin credentials not configured, cannot grant role', { role });
+    return { granted: false, reason: 'KEYCLOAK_NOT_CONFIGURED' };
+  }
+
+  // Bounded, because callers grant the role after the database write has already
+  // committed: a Keycloak that accepts the connection and never answers must not
+  // hold the request until the platform timeout and report failure to somebody
+  // who does have the access.
+  let expire;
+  const timeout = new Promise((_, reject) => {
+    expire = setTimeout(() => reject(new Error(`Keycloak role grant timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+
+  try {
+    return await Promise.race([grant(userId, role, clientId, realmName), timeout]);
+  } finally {
+    clearTimeout(expire);
+  }
+};
+
+const grant = async (userId, role, clientId, realmName) => {
+  const kcAdminClient = new KcAdminClient({
+    baseUrl: process.env.KEYCLOAK_URL,
+    realmName: 'master',
+  });
+
+  await kcAdminClient.auth({
+    username: process.env.KEYCLOAK_USER || 'keycloak',
+    password: process.env.KEYCLOAK_PW,
+    grantType: 'password',
+    clientId: 'admin-cli',
+  });
+
+  kcAdminClient.setConfig({ realmName });
+
+  const clients = await kcAdminClient.clients.find({ clientId, first: 1 });
+  const clientUniqueId = clients?.[0]?.id;
+  if (!clientUniqueId) {
+    throw new Error(`Keycloak client '${clientId}' not found in realm '${realmName}'`);
+  }
+
+  const available = await kcAdminClient.users.listAvailableClientRoleMappings({
+    id: userId,
+    clientUniqueId,
+  });
+  const target = (available ?? []).find((candidate) => candidate.name === role);
+
+  // Not available means either "already assigned" or "no such role". Both are
+  // distinguished by asking what the user actually holds, so a typo in a role
+  // name is not reported as a successful grant.
+  if (!target) {
+    const assigned = await kcAdminClient.users.listClientRoleMappings({
+      id: userId,
+      clientUniqueId,
+    });
+    const held = (assigned ?? []).some((candidate) => candidate.name === role);
+    return held ? { granted: true, reason: 'ALREADY_ASSIGNED' } : { granted: false, reason: 'ROLE_UNKNOWN' };
+  }
+
+  await kcAdminClient.users.addClientRoleMappings({
+    id: userId,
+    clientUniqueId,
+    roles: [{ id: target.id, name: target.name }],
+  });
+
+  return { granted: true, reason: 'ADDED' };
+};

--- a/functions/callNodeFunction/lib/keycloakClientRole.js
+++ b/functions/callNodeFunction/lib/keycloakClientRole.js
@@ -20,6 +20,13 @@ import KcAdminClient from '@keycloak/keycloak-admin-client';
  * Idempotent: a role the user already holds is no longer "available" to add, so
  * a repeat call is a no-op rather than an error.
  *
+ * `timeoutMs` bounds this twice over, because the two bounds are not the same
+ * thing: the admin client's own `timeout` is per request (it puts an
+ * AbortSignal.timeout on each fetch, which actually cancels a stalled socket),
+ * while the race below bounds the whole four-request sequence — the caller runs
+ * inside a Hasura action whose default budget is 30s, so four independently
+ * bounded requests could still blow it.
+ *
  * @returns {Promise<{ granted: boolean, reason?: string }>} `granted` is true
  *   only when the role is now on the user (freshly added or already there).
  */
@@ -42,21 +49,22 @@ export const addKeycloakClientRole = async (
   // hold the request until the platform timeout and report failure to somebody
   // who does have the access.
   let expire;
-  const timeout = new Promise((_, reject) => {
+  const deadline = new Promise((_, reject) => {
     expire = setTimeout(() => reject(new Error(`Keycloak role grant timed out after ${timeoutMs}ms`)), timeoutMs);
   });
 
   try {
-    return await Promise.race([grant(userId, role, clientId, realmName), timeout]);
+    return await Promise.race([grant(userId, role, clientId, realmName, timeoutMs), deadline]);
   } finally {
     clearTimeout(expire);
   }
 };
 
-const grant = async (userId, role, clientId, realmName) => {
+const grant = async (userId, role, clientId, realmName, timeoutMs) => {
   const kcAdminClient = new KcAdminClient({
     baseUrl: process.env.KEYCLOAK_URL,
     realmName: 'master',
+    timeout: timeoutMs,
   });
 
   await kcAdminClient.auth({


### PR DESCRIPTION
## The bug

Claiming an organization in StuJo to post a job offer left the employer on
*"no company is assigned to your account"* until they signed out and back in
manually. The claim page's silent re-`signIn` never came back with the role.

## Root cause

`claimJobOrganization` **already** tried to hand out the Keycloak `org_admin`
role synchronously, precisely so the frontend's immediate re-`signIn` would pick
it up. It did that by POSTing to `CLOUD_FUNCTION_LINK_ADD_KEYCLOAK_ROLE` — and
that variable is only set on **Hasura** (`docker-compose.yml:195`,
`infrastructure/application/05_hasura.tf:89`), never on the node-functions
runtime. So the handler hit its own `if (!url || !secret)` guard, logged
*"webhook not configured"*, and returned. Every claim fell back to the async
`add_keycloak_org_admin_role` event trigger, which the OAuth round trip beat
every time.

The stale token then cascaded: `useManageRole()` fell back to `user`, and
`OrganizationAdmin` has no `user_access` select permission, so
`MY_JOB_ORGANIZATIONS` failed schema validation → zero organizations → the
"pick a company" screen the employer had just come from.

## Changes

- **`functions/callNodeFunction/lib/keycloakClientRole.js`** (new) — grants a
  `hasura` client role in-process via the Keycloak admin API, whose credentials
  this runtime already has (`updateKeycloakUser` uses them). Idempotent, bounded
  by a timeout, and distinguishes *already assigned* from *unknown role* instead
  of reporting both as success.
- **`claimJobOrganization/index.js`** — uses it instead of the unreachable
  webhook. Still non-fatal: the grant is committed either way and the event
  trigger stays the retry net.
- **`unternehmen.tsx`** — the re-auth now returns *to this page*
  (`?refreshRole=1&attempt=N`) and **verifies** the role arrived before
  forwarding to `next`. If it did not: one more attempt with `prompt=login`,
  then an explicit *"your access is set up, your sign-in wasn't refreshed"*
  message with a retry button — not the claim form again. `?next=` is sanitized
  on the way, since it feeds both a `callbackUrl` and `router.replace`.
- **`useEmployerOrganization.ts`** — skips the query the `user` role cannot run,
  so a permission error stops masquerading as "no company yet".
- Two locale keys (de/en, informal *Du*).

## Verification

**Unit:** 4 new tests pinning the synchronous grant (granted org, newly created
org, no grant → no Keycloak call, Keycloak failure → still `GRANTED`).
20/20 pass in `claimJobOrganization`. `tsc --noEmit` and `eslint apps/stujo`
clean.

**End-to-end on the local stack:** a real claim through Hasura as a seeded user
returned `GRANTED`, and the Keycloak user went from `['user']` to
`['org_admin', 'user']` *before the mutation returned*. A token issued at that
moment carried `"x-hasura-allowed-roles": ["org_admin", "user"]` in **both** the
access token and the id token — the id token is what NextAuth reads into
`session.profile`, so `useIsOrgAdmin()` is true on the way back. Probe grant and
role removed afterwards.

## Not affected: the admin table UI

Same mechanism, different situation — no fix needed there:

- **Capability flags** (`canManageJobs`, `canManageCourses`, …) are plain DB
  columns evaluated per request. Immediate, no token involved.
- **Super-admin toggle** goes through `updateAdminUser`, which already talks to
  Keycloak in-process — no race.
- **Org-admin add/remove** does use the async event trigger, but it changes
  *someone else's* rights, so nobody is racing their own token; the grantee
  picks the role up at their next sign-in.

The acute case only arises when you grant *yourself* and need it immediately,
i.e. the self-service claim. A super-admin self-granting is unaffected
(`useManageRole()` prefers `admin`), and reaching `AddAdminDialog` at all
requires an existing grant, which means `org_admin` is already in the token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved employer onboarding so company access is activated automatically after a successful claim.
  * Added automatic session refresh with retry handling when role activation is delayed.
  * Added a manual retry option and support guidance when session refresh fails.
  * Added English and German translations for new onboarding messages.

* **Bug Fixes**
  * Improved the “no company yet” state for users without employer permissions.
  * Improved handling of post-claim navigation to prevent unsafe redirects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->