### PR TITLE
fix(stujo): logout fallback and dashboard action layout

### DIFF
--- a/backend/seeds/README.md
+++ b/backend/seeds/README.md
@@ -16,6 +16,7 @@ The seed data includes the following users:
 - `admin@example.com`
 - `user@example.com`
 - `instructor@example.com`
+- `orgadmin@example.com` — organization admin with StuJo job-management access
 
 The password for all users is `dev`.
 

--- a/backend/seeds/default/initial_seeds.sql
+++ b/backend/seeds/default/initial_seeds.sql
@@ -3695,6 +3695,17 @@ INSERT INTO public."User" (id, "firstName", "lastName", email, picture, "externa
 INSERT INTO public."OrganizationAdmin" (id, "userId", "organizationId", "canManageCourses", "canManageEvents", "canManageDegrees", "canManageSettings", "canManageJobs", updated_at, created_at) VALUES
   (9100, 'dddddddd-dddd-dddd-dddd-dddddddddddd', 9100, false, true, false, true, true, now(), now());
 
+-- Draft visible in the dedicated employer dashboard at /mein-stujo. Keeping it
+-- unpublished prevents it from appearing on the public job board.
+INSERT INTO public."JobPosting"
+  (id, "organizationId", "contactUserId", type, status, region, occupation,
+   title, "shortDescription", location, featured, created_at, updated_at)
+VALUES
+  (9925, 9100, 'dddddddd-dddd-dddd-dddd-dddddddddddd', 'WORKING_STUDENT', 'DRAFT',
+   'KIEL', 'IT_TELECOMMUNICATIONS', 'StuJo employer dashboard test',
+   'Draft fixture for testing the authenticated Mein StuJo dashboard and logout flow.',
+   'Kiel', false, now(), now());
+
 -- Instructor of an existing course (id 4), which belongs to a different organization than the one
 -- this user administers, to confirm that instructor access is retained alongside the org_admin role.
 INSERT INTO public."CourseInstructor" (id, "courseId", "userId", created_at, updated_at) VALUES
@@ -3718,3 +3729,4 @@ SELECT pg_catalog.setval(pg_get_serial_sequence('public."Course"', 'id'), (SELEC
 SELECT pg_catalog.setval(pg_get_serial_sequence('public."Organization"', 'id'), (SELECT GREATEST(max(id), 500) FROM public."Organization"), true);
 SELECT pg_catalog.setval(pg_get_serial_sequence('public."OrganizationAdmin"', 'id'), (SELECT max(id) FROM public."OrganizationAdmin"), true);
 SELECT pg_catalog.setval(pg_get_serial_sequence('public."CourseInstructor"', 'id'), (SELECT max(id) FROM public."CourseInstructor"), true);
+SELECT pg_catalog.setval(pg_get_serial_sequence('public."JobPosting"', 'id'), (SELECT max(id) FROM public."JobPosting"), true);

--- a/frontend-nx/apps/edu-hub/hooks/logout.ts
+++ b/frontend-nx/apps/edu-hub/hooks/logout.ts
@@ -5,15 +5,23 @@ import { useRouter } from 'next/router';
 const useLogout = () => {
   const router = useRouter();
   return useCallback(async () => {
-    // Fetch Keycloak Logout URL
-    const res = await fetch('/api/auth/logout');
-    const jsonPayload = await res?.json();
-    const url = JSON.parse(jsonPayload).url;
+    let url = '/';
 
-    // Logging user out client side
+    try {
+      // Fetch the Keycloak end-session URL. The endpoint returns the app home
+      // URL when federated logout is unavailable.
+      const res = await fetch('/api/auth/logout');
+      if (res.ok) {
+        const payload = await res.json();
+        if (typeof payload?.url === 'string') url = payload.url;
+      }
+    } catch (error) {
+      console.error('Failed to prepare federated logout', error);
+    }
+
+    // Always clear the local session, even if Keycloak logout preparation
+    // failed, then return to a real application page.
     await signOut({ redirect: false });
-
-    // Logging user out on keycloak and redirecting back to app
     router.push(url);
   }, [router]);
 };

--- a/frontend-nx/apps/edu-hub/pages/api/auth/__tests__/logout.test.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/__tests__/logout.test.ts
@@ -1,0 +1,85 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from 'next-auth/jwt';
+
+import handler from '../logout';
+
+jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
+
+const mockedGetToken = getToken as jest.MockedFunction<typeof getToken>;
+
+const token = (idToken?: string) => ({
+  name: 'StuJo employer',
+  email: 'employer@example.com',
+  sub: 'user-1',
+  accessTokenExpired: 0,
+  refreshTokenExpired: 0,
+  idToken,
+});
+
+const response = () => {
+  const res = {
+    status: jest.fn(),
+    json: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  return res as unknown as NextApiResponse & {
+    status: jest.Mock;
+    json: jest.Mock;
+  };
+};
+
+describe('logout API', () => {
+  const originalEnv = process.env;
+  let warn: jest.SpyInstance;
+  let error: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      NEXTAUTH_URL: 'https://stujo.example',
+      NEXT_PUBLIC_AUTH_URL: 'https://login.example',
+    };
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    error = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    warn.mockRestore();
+    error.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it('returns the Keycloak end-session URL for a complete token', async () => {
+    mockedGetToken.mockResolvedValue(token('token-value'));
+    const res = response();
+
+    await handler({} as NextApiRequest, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      url:
+        'https://login.example/realms/edu-hub/protocol/openid-connect/logout?' +
+        'id_token_hint=token-value&post_logout_redirect_uri=https%3A%2F%2Fstujo.example',
+    });
+  });
+
+  it('falls back to the app when the token has no id_token', async () => {
+    mockedGetToken.mockResolvedValue(token());
+    const res = response();
+
+    await handler({} as NextApiRequest, res);
+
+    expect(res.json).toHaveBeenCalledWith({ url: 'https://stujo.example' });
+  });
+
+  it('falls back to the app when reading the token fails', async () => {
+    mockedGetToken.mockRejectedValue(new Error('invalid cookie'));
+    const res = response();
+
+    await handler({} as NextApiRequest, res);
+
+    expect(res.json).toHaveBeenCalledWith({ url: 'https://stujo.example' });
+  });
+});

--- a/frontend-nx/apps/edu-hub/pages/api/auth/__tests__/logout.test.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/__tests__/logout.test.ts
@@ -18,16 +18,21 @@ const token = (idToken?: string) => ({
 
 const response = () => {
   const res = {
+    setHeader: jest.fn(),
     status: jest.fn(),
     json: jest.fn(),
   };
   res.status.mockReturnValue(res);
   res.json.mockReturnValue(res);
   return res as unknown as NextApiResponse & {
+    setHeader: jest.Mock;
     status: jest.Mock;
     json: jest.Mock;
   };
 };
+
+const expectNoStore = (res: ReturnType<typeof response>) =>
+  expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
 
 describe('logout API', () => {
   const originalEnv = process.env;
@@ -57,6 +62,7 @@ describe('logout API', () => {
 
     await handler({} as NextApiRequest, res);
 
+    expectNoStore(res);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
       url:
@@ -71,6 +77,7 @@ describe('logout API', () => {
 
     await handler({} as NextApiRequest, res);
 
+    expectNoStore(res);
     expect(res.json).toHaveBeenCalledWith({ url: 'https://stujo.example' });
   });
 
@@ -80,6 +87,7 @@ describe('logout API', () => {
 
     await handler({} as NextApiRequest, res);
 
+    expectNoStore(res);
     expect(res.json).toHaveBeenCalledWith({ url: 'https://stujo.example' });
   });
 });

--- a/frontend-nx/apps/edu-hub/pages/api/auth/logout.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/logout.ts
@@ -4,35 +4,37 @@ import { getToken } from 'next-auth/jwt';
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   console.log('Calling logout handler!');
 
+  // Logging out locally must still work if the Keycloak session is already
+  // gone or the token does not contain an id_token. The clients use this URL
+  // as their safe fallback instead of being left on an unfinished API request.
+  const fallbackUrl = process.env.NEXTAUTH_URL || '/';
+
   try {
     const token = await getToken({ req });
 
-    if (!token && process.env.NEXTAUTH_URL) {
-      console.warn('No JWT token found when calling /logout endpoint,');
-      return res.redirect(307, process.env.NEXTAUTH_URL);
+    if (!token) {
+      console.warn('No JWT token found when calling /logout endpoint.');
+      return res.status(200).json({ url: fallbackUrl });
     }
-    if (token && !token.idToken) {
-      throw new Error(
-        "Without an id_token the user won't be redirected back from the IdP after logout."
-      );
+    if (!token.idToken) {
+      console.warn('No id_token found; skipping the Keycloak end-session redirect.');
+      return res.status(200).json({ url: fallbackUrl });
     }
 
-    if (token && token.idToken && process.env.NEXT_PUBLIC_AUTH_URL) {
+    if (process.env.NEXT_PUBLIC_AUTH_URL) {
       const endsessionURL = `${process.env.NEXT_PUBLIC_AUTH_URL}/realms/edu-hub/protocol/openid-connect/logout`;
       const endsessionParams = new URLSearchParams([
         ['id_token_hint', token.idToken],
-        [
-          'post_logout_redirect_uri',
-          process.env.NEXTAUTH_URL || 'http://localhost:5000',
-        ],
+        ['post_logout_redirect_uri', fallbackUrl],
       ]);
-      return res
-        .status(200)
-        .json(JSON.stringify({ url: `${endsessionURL}?${endsessionParams}` }));
+      return res.status(200).json({ url: `${endsessionURL}?${endsessionParams}` });
     }
-    throw new Error('Something went wrong - see logout');
+
+    console.warn('NEXT_PUBLIC_AUTH_URL is not configured; skipping Keycloak logout.');
+    return res.status(200).json({ url: fallbackUrl });
   } catch (error) {
     console.error(error);
+    return res.status(200).json({ url: fallbackUrl });
   }
 };
 

--- a/frontend-nx/apps/edu-hub/pages/api/auth/logout.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/logout.ts
@@ -4,6 +4,10 @@ import { getToken } from 'next-auth/jwt';
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   console.log('Calling logout handler!');
 
+  // The response may contain a per-session Keycloak URL with an id_token_hint.
+  // Never allow browsers or intermediaries to retain it.
+  res.setHeader('Cache-Control', 'no-store');
+
   // Logging out locally must still work if the Keycloak session is already
   // gone or the token does not contain an id_token. The clients use this URL
   // as their safe fallback instead of being left on an unfinished API request.

--- a/frontend-nx/apps/stujo/components/Layout.tsx
+++ b/frontend-nx/apps/stujo/components/Layout.tsx
@@ -30,9 +30,19 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
   // end-session URL, clear the NextAuth session, then redirect through
   // Keycloak back to the app.
   const logout = useCallback(async () => {
-    const res = await fetch('/api/auth/logout');
-    const jsonPayload = await res.json();
-    const url = JSON.parse(jsonPayload).url;
+    let url = '/';
+
+    try {
+      const res = await fetch('/api/auth/logout');
+      if (res.ok) {
+        const payload = await res.json();
+        if (typeof payload?.url === 'string') url = payload.url;
+      }
+    } catch (error) {
+      console.error('Failed to prepare federated logout', error);
+    }
+
+    // A stale/malformed token must not strand the user on the API route.
     await signOut({ redirect: false });
     router.push(url);
   }, [router]);
@@ -127,17 +137,14 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
             </Link>
           </span>
           {sessionStatus === 'authenticated' ? (
-            <a
-              href="/api/auth/logout"
-              onClick={(e) => {
-                e.preventDefault();
-                logout();
-              }}
+            <button
+              type="button"
+              onClick={logout}
               className="stujo-header-action stujo-header-action--uppercase"
             >
               <StuJoLegacyIcon name="unlocked" className="stujo-header-action-icon" />
               {t('logout')}
-            </a>
+            </button>
           ) : (
             <>
               <a

--- a/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
@@ -272,38 +272,40 @@ const MeinStujo: FC<Props> = ({ portal }) => {
                 <td className="stujo-muted">{posting.views}</td>
                 <td className="stujo-muted">{formatDate(posting.expiresAt)}</td>
                 <td style={{ whiteSpace: 'nowrap' }}>
-                  <Link
-                    href={`/mein-stujo/neu?id=${posting.id}`}
-                    className="stujo-button-pen"
-                    title={t('edit')}
-                    aria-label={t('edit')}
-                  />
-                  {(posting.status === 'DRAFT' || posting.status === 'PENDING_PAYMENT') && (
-                    <button
-                      className="stujo-btn stujo-btn--small"
-                      disabled={publishing}
-                      onClick={() => handlePublish(posting.id)}
-                    >
-                      {t('publish')}
-                    </button>
-                  )}
-                  {posting.status === 'EXPIRED' && (
-                    <button
-                      className="stujo-btn stujo-btn--small"
-                      disabled={publishing}
-                      onClick={() => handlePublish(posting.id)}
-                    >
-                      {t('repost')}
-                    </button>
-                  )}
-                  {posting.status === 'PUBLISHED' && (
-                    <button
-                      className="stujo-btn stujo-btn--small stujo-btn--ghost"
-                      onClick={() => handleArchive(posting.id)}
-                    >
-                      {t('archive')}
-                    </button>
-                  )}
+                  <div className="stujo-table-actions">
+                    <Link
+                      href={`/mein-stujo/neu?id=${posting.id}`}
+                      className="stujo-button-pen"
+                      title={t('edit')}
+                      aria-label={t('edit')}
+                    />
+                    {(posting.status === 'DRAFT' || posting.status === 'PENDING_PAYMENT') && (
+                      <button
+                        className="stujo-btn stujo-btn--small"
+                        disabled={publishing}
+                        onClick={() => handlePublish(posting.id)}
+                      >
+                        {t('publish')}
+                      </button>
+                    )}
+                    {posting.status === 'EXPIRED' && (
+                      <button
+                        className="stujo-btn stujo-btn--small"
+                        disabled={publishing}
+                        onClick={() => handlePublish(posting.id)}
+                      >
+                        {t('repost')}
+                      </button>
+                    )}
+                    {posting.status === 'PUBLISHED' && (
+                      <button
+                        className="stujo-btn stujo-btn--small stujo-btn--ghost"
+                        onClick={() => handleArchive(posting.id)}
+                      >
+                        {t('archive')}
+                      </button>
+                    )}
+                  </div>
                 </td>
               </tr>
             );

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -159,6 +159,19 @@ a:focus {
   gap: 0.35em;
 }
 
+button.stujo-header-action {
+  padding: 0;
+  border: 0;
+  color: #fff;
+  background: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+button.stujo-header-action:hover {
+  color: var(--stujo-secondary);
+}
+
 .stujo-header-action--uppercase {
   text-transform: uppercase;
 }

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -621,6 +621,12 @@ button.stujo-header-action:hover {
   color: var(--stujo-grey);
 }
 
+.stujo-table-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .stujo-chip {
   display: inline-block;
   border-radius: 999px;


### PR DESCRIPTION
## Summary

- Make federated logout resilient to missing, malformed, or expired tokens.
- Always clear the local session and redirect to a safe application URL.
- Add API coverage for successful and fallback logout responses.
- Improve StuJo dashboard action alignment and add an organization-admin job fixture.

## Testing

- Added Jest tests covering complete tokens, missing `id_token`, and token-read failures.
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logout handling with reliable session clearing and safe fallback navigation when authentication services are unavailable.
  * Logout responses now consistently provide a valid destination instead of redirecting unexpectedly.
* **Improvements**
  * Refined the authenticated header logout control for more consistent interaction and styling.
  * Improved spacing and alignment for job-posting actions in the Mein StuJo dashboard.
* **Seed Data**
  * Added a draft working-student job posting for testing in the employer dashboard.
  * Documented an additional default organization-admin account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->