### PR TITLE
Redesign StuJo login and shared account branding

### DIFF
--- a/backend/seeds/README.md
+++ b/backend/seeds/README.md
@@ -16,6 +16,7 @@ The seed data includes the following users:
 - `admin@example.com`
 - `user@example.com`
 - `instructor@example.com`
+- `orgadmin@example.com` — organization admin with StuJo job-management access
 
 The password for all users is `dev`.
 

--- a/backend/seeds/default/initial_seeds.sql
+++ b/backend/seeds/default/initial_seeds.sql
@@ -3695,6 +3695,17 @@ INSERT INTO public."User" (id, "firstName", "lastName", email, picture, "externa
 INSERT INTO public."OrganizationAdmin" (id, "userId", "organizationId", "canManageCourses", "canManageEvents", "canManageDegrees", "canManageSettings", "canManageJobs", updated_at, created_at) VALUES
   (9100, 'dddddddd-dddd-dddd-dddd-dddddddddddd', 9100, false, true, false, true, true, now(), now());
 
+-- Draft visible in the dedicated employer dashboard at /mein-stujo. Keeping it
+-- unpublished prevents it from appearing on the public job board.
+INSERT INTO public."JobPosting"
+  (id, "organizationId", "contactUserId", type, status, region, occupation,
+   title, "shortDescription", location, featured, created_at, updated_at)
+VALUES
+  (9925, 9100, 'dddddddd-dddd-dddd-dddd-dddddddddddd', 'WORKING_STUDENT', 'DRAFT',
+   'KIEL', 'IT_TELECOMMUNICATIONS', 'StuJo employer dashboard test',
+   'Draft fixture for testing the authenticated Mein StuJo dashboard and logout flow.',
+   'Kiel', false, now(), now());
+
 -- Instructor of an existing course (id 4), which belongs to a different organization than the one
 -- this user administers, to confirm that instructor access is retained alongside the org_admin role.
 INSERT INTO public."CourseInstructor" (id, "courseId", "userId", created_at, updated_at) VALUES
@@ -3718,3 +3729,4 @@ SELECT pg_catalog.setval(pg_get_serial_sequence('public."Course"', 'id'), (SELEC
 SELECT pg_catalog.setval(pg_get_serial_sequence('public."Organization"', 'id'), (SELECT GREATEST(max(id), 500) FROM public."Organization"), true);
 SELECT pg_catalog.setval(pg_get_serial_sequence('public."OrganizationAdmin"', 'id'), (SELECT max(id) FROM public."OrganizationAdmin"), true);
 SELECT pg_catalog.setval(pg_get_serial_sequence('public."CourseInstructor"', 'id'), (SELECT max(id) FROM public."CourseInstructor"), true);
+SELECT pg_catalog.setval(pg_get_serial_sequence('public."JobPosting"', 'id'), (SELECT max(id) FROM public."JobPosting"), true);

--- a/frontend-nx/apps/edu-hub/hooks/logout.ts
+++ b/frontend-nx/apps/edu-hub/hooks/logout.ts
@@ -5,15 +5,23 @@ import { useRouter } from 'next/router';
 const useLogout = () => {
   const router = useRouter();
   return useCallback(async () => {
-    // Fetch Keycloak Logout URL
-    const res = await fetch('/api/auth/logout');
-    const jsonPayload = await res?.json();
-    const url = JSON.parse(jsonPayload).url;
+    let url = '/';
 
-    // Logging user out client side
+    try {
+      // Fetch the Keycloak end-session URL. The endpoint returns the app home
+      // URL when federated logout is unavailable.
+      const res = await fetch('/api/auth/logout');
+      if (res.ok) {
+        const payload = await res.json();
+        if (typeof payload?.url === 'string') url = payload.url;
+      }
+    } catch (error) {
+      console.error('Failed to prepare federated logout', error);
+    }
+
+    // Always clear the local session, even if Keycloak logout preparation
+    // failed, then return to a real application page.
     await signOut({ redirect: false });
-
-    // Logging user out on keycloak and redirecting back to app
     router.push(url);
   }, [router]);
 };

--- a/frontend-nx/apps/edu-hub/pages/api/auth/__tests__/logout.test.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/__tests__/logout.test.ts
@@ -1,0 +1,85 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { getToken } from 'next-auth/jwt';
+
+import handler from '../logout';
+
+jest.mock('next-auth/jwt', () => ({ getToken: jest.fn() }));
+
+const mockedGetToken = getToken as jest.MockedFunction<typeof getToken>;
+
+const token = (idToken?: string) => ({
+  name: 'StuJo employer',
+  email: 'employer@example.com',
+  sub: 'user-1',
+  accessTokenExpired: 0,
+  refreshTokenExpired: 0,
+  idToken,
+});
+
+const response = () => {
+  const res = {
+    status: jest.fn(),
+    json: jest.fn(),
+  };
+  res.status.mockReturnValue(res);
+  res.json.mockReturnValue(res);
+  return res as unknown as NextApiResponse & {
+    status: jest.Mock;
+    json: jest.Mock;
+  };
+};
+
+describe('logout API', () => {
+  const originalEnv = process.env;
+  let warn: jest.SpyInstance;
+  let error: jest.SpyInstance;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      NEXTAUTH_URL: 'https://stujo.example',
+      NEXT_PUBLIC_AUTH_URL: 'https://login.example',
+    };
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+    error = jest.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    warn.mockRestore();
+    error.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  it('returns the Keycloak end-session URL for a complete token', async () => {
+    mockedGetToken.mockResolvedValue(token('token-value'));
+    const res = response();
+
+    await handler({} as NextApiRequest, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      url:
+        'https://login.example/realms/edu-hub/protocol/openid-connect/logout?' +
+        'id_token_hint=token-value&post_logout_redirect_uri=https%3A%2F%2Fstujo.example',
+    });
+  });
+
+  it('falls back to the app when the token has no id_token', async () => {
+    mockedGetToken.mockResolvedValue(token());
+    const res = response();
+
+    await handler({} as NextApiRequest, res);
+
+    expect(res.json).toHaveBeenCalledWith({ url: 'https://stujo.example' });
+  });
+
+  it('falls back to the app when reading the token fails', async () => {
+    mockedGetToken.mockRejectedValue(new Error('invalid cookie'));
+    const res = response();
+
+    await handler({} as NextApiRequest, res);
+
+    expect(res.json).toHaveBeenCalledWith({ url: 'https://stujo.example' });
+  });
+});

--- a/frontend-nx/apps/edu-hub/pages/api/auth/__tests__/logout.test.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/__tests__/logout.test.ts
@@ -18,16 +18,21 @@ const token = (idToken?: string) => ({
 
 const response = () => {
   const res = {
+    setHeader: jest.fn(),
     status: jest.fn(),
     json: jest.fn(),
   };
   res.status.mockReturnValue(res);
   res.json.mockReturnValue(res);
   return res as unknown as NextApiResponse & {
+    setHeader: jest.Mock;
     status: jest.Mock;
     json: jest.Mock;
   };
 };
+
+const expectNoStore = (res: ReturnType<typeof response>) =>
+  expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
 
 describe('logout API', () => {
   const originalEnv = process.env;
@@ -57,6 +62,7 @@ describe('logout API', () => {
 
     await handler({} as NextApiRequest, res);
 
+    expectNoStore(res);
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith({
       url:
@@ -71,6 +77,7 @@ describe('logout API', () => {
 
     await handler({} as NextApiRequest, res);
 
+    expectNoStore(res);
     expect(res.json).toHaveBeenCalledWith({ url: 'https://stujo.example' });
   });
 
@@ -80,6 +87,7 @@ describe('logout API', () => {
 
     await handler({} as NextApiRequest, res);
 
+    expectNoStore(res);
     expect(res.json).toHaveBeenCalledWith({ url: 'https://stujo.example' });
   });
 });

--- a/frontend-nx/apps/edu-hub/pages/api/auth/__tests__/logout.test.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/__tests__/logout.test.ts
@@ -90,4 +90,20 @@ describe('logout API', () => {
     expectNoStore(res);
     expect(res.json).toHaveBeenCalledWith({ url: 'https://stujo.example' });
   });
+
+  it.each([undefined, '/'])('skips Keycloak logout when NEXTAUTH_URL is %s', async (nextAuthUrl) => {
+    if (nextAuthUrl) {
+      process.env.NEXTAUTH_URL = nextAuthUrl;
+    } else {
+      delete process.env.NEXTAUTH_URL;
+    }
+    mockedGetToken.mockResolvedValue(token('token-value'));
+    const res = response();
+
+    await handler({} as NextApiRequest, res);
+
+    expectNoStore(res);
+    expect(res.json).toHaveBeenCalledWith({ url: '/' });
+    expect(warn).toHaveBeenCalledWith('NEXTAUTH_URL is not an absolute application URL; skipping Keycloak logout.');
+  });
 });

--- a/frontend-nx/apps/edu-hub/pages/api/auth/logout.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/logout.ts
@@ -4,35 +4,37 @@ import { getToken } from 'next-auth/jwt';
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   console.log('Calling logout handler!');
 
+  // Logging out locally must still work if the Keycloak session is already
+  // gone or the token does not contain an id_token. The clients use this URL
+  // as their safe fallback instead of being left on an unfinished API request.
+  const fallbackUrl = process.env.NEXTAUTH_URL || '/';
+
   try {
     const token = await getToken({ req });
 
-    if (!token && process.env.NEXTAUTH_URL) {
-      console.warn('No JWT token found when calling /logout endpoint,');
-      return res.redirect(307, process.env.NEXTAUTH_URL);
+    if (!token) {
+      console.warn('No JWT token found when calling /logout endpoint.');
+      return res.status(200).json({ url: fallbackUrl });
     }
-    if (token && !token.idToken) {
-      throw new Error(
-        "Without an id_token the user won't be redirected back from the IdP after logout."
-      );
+    if (!token.idToken) {
+      console.warn('No id_token found; skipping the Keycloak end-session redirect.');
+      return res.status(200).json({ url: fallbackUrl });
     }
 
-    if (token && token.idToken && process.env.NEXT_PUBLIC_AUTH_URL) {
+    if (process.env.NEXT_PUBLIC_AUTH_URL) {
       const endsessionURL = `${process.env.NEXT_PUBLIC_AUTH_URL}/realms/edu-hub/protocol/openid-connect/logout`;
       const endsessionParams = new URLSearchParams([
         ['id_token_hint', token.idToken],
-        [
-          'post_logout_redirect_uri',
-          process.env.NEXTAUTH_URL || 'http://localhost:5000',
-        ],
+        ['post_logout_redirect_uri', fallbackUrl],
       ]);
-      return res
-        .status(200)
-        .json(JSON.stringify({ url: `${endsessionURL}?${endsessionParams}` }));
+      return res.status(200).json({ url: `${endsessionURL}?${endsessionParams}` });
     }
-    throw new Error('Something went wrong - see logout');
+
+    console.warn('NEXT_PUBLIC_AUTH_URL is not configured; skipping Keycloak logout.');
+    return res.status(200).json({ url: fallbackUrl });
   } catch (error) {
     console.error(error);
+    return res.status(200).json({ url: fallbackUrl });
   }
 };
 

--- a/frontend-nx/apps/edu-hub/pages/api/auth/logout.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/logout.ts
@@ -1,6 +1,19 @@
 import { NextApiRequest, NextApiResponse } from 'next';
 import { getToken } from 'next-auth/jwt';
 
+const getApplicationUrl = () => {
+  const applicationUrl = process.env.NEXTAUTH_URL;
+
+  if (!applicationUrl || !/^https?:\/\//i.test(applicationUrl)) return undefined;
+
+  try {
+    new URL(applicationUrl);
+    return applicationUrl;
+  } catch {
+    return undefined;
+  }
+};
+
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   console.log('Calling logout handler!');
 
@@ -11,7 +24,8 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   // Logging out locally must still work if the Keycloak session is already
   // gone or the token does not contain an id_token. The clients use this URL
   // as their safe fallback instead of being left on an unfinished API request.
-  const fallbackUrl = process.env.NEXTAUTH_URL || '/';
+  const applicationUrl = getApplicationUrl();
+  const fallbackUrl = applicationUrl || '/';
 
   try {
     const token = await getToken({ req });
@@ -25,13 +39,18 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       return res.status(200).json({ url: fallbackUrl });
     }
 
-    if (process.env.NEXT_PUBLIC_AUTH_URL) {
+    if (process.env.NEXT_PUBLIC_AUTH_URL && applicationUrl) {
       const endsessionURL = `${process.env.NEXT_PUBLIC_AUTH_URL}/realms/edu-hub/protocol/openid-connect/logout`;
       const endsessionParams = new URLSearchParams([
         ['id_token_hint', token.idToken],
-        ['post_logout_redirect_uri', fallbackUrl],
+        ['post_logout_redirect_uri', applicationUrl],
       ]);
       return res.status(200).json({ url: `${endsessionURL}?${endsessionParams}` });
+    }
+
+    if (!applicationUrl) {
+      console.warn('NEXTAUTH_URL is not an absolute application URL; skipping Keycloak logout.');
+      return res.status(200).json({ url: fallbackUrl });
     }
 
     console.warn('NEXT_PUBLIC_AUTH_URL is not configured; skipping Keycloak logout.');

--- a/frontend-nx/apps/edu-hub/pages/api/auth/logout.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/logout.ts
@@ -4,6 +4,10 @@ import { getToken } from 'next-auth/jwt';
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
   console.log('Calling logout handler!');
 
+  // The response may contain a per-session Keycloak URL with an id_token_hint.
+  // Never allow browsers or intermediaries to retain it.
+  res.setHeader('Cache-Control', 'no-store');
+
   // Logging out locally must still work if the Keycloak session is already
   // gone or the token does not contain an id_token. The clients use this URL
   // as their safe fallback instead of being left on an unfinished API request.

--- a/frontend-nx/apps/stujo/components/Layout.tsx
+++ b/frontend-nx/apps/stujo/components/Layout.tsx
@@ -30,9 +30,19 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
   // end-session URL, clear the NextAuth session, then redirect through
   // Keycloak back to the app.
   const logout = useCallback(async () => {
-    const res = await fetch('/api/auth/logout');
-    const jsonPayload = await res.json();
-    const url = JSON.parse(jsonPayload).url;
+    let url = '/';
+
+    try {
+      const res = await fetch('/api/auth/logout');
+      if (res.ok) {
+        const payload = await res.json();
+        if (typeof payload?.url === 'string') url = payload.url;
+      }
+    } catch (error) {
+      console.error('Failed to prepare federated logout', error);
+    }
+
+    // A stale/malformed token must not strand the user on the API route.
     await signOut({ redirect: false });
     router.push(url);
   }, [router]);
@@ -127,17 +137,14 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
             </Link>
           </span>
           {sessionStatus === 'authenticated' ? (
-            <a
-              href="/api/auth/logout"
-              onClick={(e) => {
-                e.preventDefault();
-                logout();
-              }}
+            <button
+              type="button"
+              onClick={logout}
               className="stujo-header-action stujo-header-action--uppercase"
             >
               <StuJoLegacyIcon name="unlocked" className="stujo-header-action-icon" />
               {t('logout')}
-            </a>
+            </button>
           ) : (
             <>
               <a

--- a/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
@@ -272,38 +272,40 @@ const MeinStujo: FC<Props> = ({ portal }) => {
                 <td className="stujo-muted">{posting.views}</td>
                 <td className="stujo-muted">{formatDate(posting.expiresAt)}</td>
                 <td style={{ whiteSpace: 'nowrap' }}>
-                  <Link
-                    href={`/mein-stujo/neu?id=${posting.id}`}
-                    className="stujo-button-pen"
-                    title={t('edit')}
-                    aria-label={t('edit')}
-                  />
-                  {(posting.status === 'DRAFT' || posting.status === 'PENDING_PAYMENT') && (
-                    <button
-                      className="stujo-btn stujo-btn--small"
-                      disabled={publishing}
-                      onClick={() => handlePublish(posting.id)}
-                    >
-                      {t('publish')}
-                    </button>
-                  )}
-                  {posting.status === 'EXPIRED' && (
-                    <button
-                      className="stujo-btn stujo-btn--small"
-                      disabled={publishing}
-                      onClick={() => handlePublish(posting.id)}
-                    >
-                      {t('repost')}
-                    </button>
-                  )}
-                  {posting.status === 'PUBLISHED' && (
-                    <button
-                      className="stujo-btn stujo-btn--small stujo-btn--ghost"
-                      onClick={() => handleArchive(posting.id)}
-                    >
-                      {t('archive')}
-                    </button>
-                  )}
+                  <div className="stujo-table-actions">
+                    <Link
+                      href={`/mein-stujo/neu?id=${posting.id}`}
+                      className="stujo-button-pen"
+                      title={t('edit')}
+                      aria-label={t('edit')}
+                    />
+                    {(posting.status === 'DRAFT' || posting.status === 'PENDING_PAYMENT') && (
+                      <button
+                        className="stujo-btn stujo-btn--small"
+                        disabled={publishing}
+                        onClick={() => handlePublish(posting.id)}
+                      >
+                        {t('publish')}
+                      </button>
+                    )}
+                    {posting.status === 'EXPIRED' && (
+                      <button
+                        className="stujo-btn stujo-btn--small"
+                        disabled={publishing}
+                        onClick={() => handlePublish(posting.id)}
+                      >
+                        {t('repost')}
+                      </button>
+                    )}
+                    {posting.status === 'PUBLISHED' && (
+                      <button
+                        className="stujo-btn stujo-btn--small stujo-btn--ghost"
+                        onClick={() => handleArchive(posting.id)}
+                      >
+                        {t('archive')}
+                      </button>
+                    )}
+                  </div>
                 </td>
               </tr>
             );

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -159,6 +159,19 @@ a:focus {
   gap: 0.35em;
 }
 
+button.stujo-header-action {
+  padding: 0;
+  border: 0;
+  color: #fff;
+  background: none;
+  font: inherit;
+  cursor: pointer;
+}
+
+button.stujo-header-action:hover {
+  color: var(--stujo-secondary);
+}
+
 .stujo-header-action--uppercase {
   text-transform: uppercase;
 }

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -621,6 +621,12 @@ button.stujo-header-action:hover {
   color: var(--stujo-grey);
 }
 
+.stujo-table-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
 .stujo-chip {
   display: inline-block;
   border-radius: 999px;

--- a/keycloak/imports-dev/edu-hub.json
+++ b/keycloak/imports-dev/edu-hub.json
@@ -2283,8 +2283,11 @@
       }
     ]
   },
-  "internationalizationEnabled": false,
-  "supportedLocales": [],
+  "internationalizationEnabled": true,
+  "supportedLocales": [
+    "de",
+    "en"
+  ],
   "authenticationFlows": [
     {
       "id": "16b96de6-c73d-4d8a-a640-2469471cd0a4",

--- a/keycloak/imports/edu-hub-realm.json
+++ b/keycloak/imports/edu-hub-realm.json
@@ -1383,8 +1383,8 @@
       }
     } ]
   },
-  "internationalizationEnabled" : false,
-  "supportedLocales" : [ ],
+  "internationalizationEnabled" : true,
+  "supportedLocales" : [ "de", "en" ],
   "authenticationFlows" : [ {
     "id" : "1542d79c-7036-4d8d-9fa3-da6c52ffbe8c",
     "alias" : "Account verification options",

--- a/keycloak/themes/edu-hub/login/login.ftl
+++ b/keycloak/themes/edu-hub/login/login.ftl
@@ -1,7 +1,8 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled??; section>
+<@layout.registrationLayout bodyClass="kc-login-page" displayMessage=!messagesPerField.existsError('username','password') displayInfo=realm.password && realm.registrationAllowed && !registrationDisabled??; section>
     <#if section = "header">
-        ${msg("loginAccountTitle")}
+        <span class="kc-default-login-title">${msg("loginAccountTitle")}</span>
+        <span class="kc-stujo-login-title">${msg("stujoLoginAccountTitle")}</span>
     <#elseif section = "form">
         <div id="kc-form">
           <div id="kc-form-wrapper">
@@ -33,6 +34,7 @@
                             />
                             <button class="pf-c-button pf-m-control" type="button" aria-label="${msg("showPassword")}"
                                     aria-controls="password"  data-password-toggle
+                                    data-icon-show="fa fa-eye" data-icon-hide="fa fa-eye-slash"
                                     data-label-show="${msg('showPassword')}" data-label-hide="${msg('hidePassword')}">
                                 <i class="fa fa-eye" aria-hidden="true"></i>
                             </button>

--- a/keycloak/themes/edu-hub/login/messages/messages_de.properties
+++ b/keycloak/themes/edu-hub/login/messages/messages_de.properties
@@ -23,6 +23,7 @@ bypassKerberosDetail=Sie sind entweder nicht mit Kerberos angemeldet, oder Ihr B
 kerberosNotSetUp=Kerberos ist nicht konfiguriert. Sie k\u00F6nnen sich damit nicht anmelden.
 registerTitle=Registrierung
 loginAccountTitle=Bei deinem Konto anmelden
+stujoLoginAccountTitle=Willkommen zur\u00FCck bei StuJo
 loginTitle=Anmeldung bei {0}
 loginTitleHtml={0}
 impersonateTitle={0} Identit\u00E4tswechsel
@@ -381,4 +382,5 @@ userDeletedSuccessfully=Nutzer erfolgreich gel\u00F6scht
 
 # Shown by template.ftl on the StuJo portals, which share this realm and
 # this account with EduHub (hidden on EduHub itself).
-cobrandAccountNote=StuJo l\u00E4uft \u00FCber dein Konto bei opencampus.sh \u2013 dasselbe Konto wie in EduHub. Hast du schon eins, melde dich einfach damit an; eine zweite Registrierung brauchst du nicht.
+cobrandAccountNoteTitle=Nutze dein bestehendes Konto.
+cobrandAccountNote=StuJo l\u00E4uft \u00FCber dein Konto bei opencampus.sh \u2013 dasselbe Konto, das auch f\u00FCr EduHub verwendet wird. Deine bisherigen Zugangsdaten von StuJo.net oder EduHub funktionieren weiterhin; du musst dich nicht erneut registrieren.

--- a/keycloak/themes/edu-hub/login/messages/messages_en.properties
+++ b/keycloak/themes/edu-hub/login/messages/messages_en.properties
@@ -23,6 +23,7 @@ bypassKerberosDetail=Either you are not logged in by Kerberos or your browser is
 kerberosNotSetUp=Kerberos is not set up.  You cannot login.
 registerTitle=Register
 loginAccountTitle=Sign in to your account
+stujoLoginAccountTitle=Welcome back to StuJo
 loginTitle=Sign in to {0}
 loginTitleHtml={0}
 impersonateTitle={0} Impersonate User
@@ -459,4 +460,5 @@ frontchannel-logout.message=You are logging out from following apps
 
 # Shown by template.ftl on the StuJo portals, which share this realm and
 # this account with EduHub (hidden on EduHub itself).
-cobrandAccountNote=StuJo runs on your opencampus.sh account \u2013 the same account as in EduHub. If you already have one, just sign in with it; there is no need to register again.
+cobrandAccountNoteTitle=Use your existing account.
+cobrandAccountNote=StuJo runs on your opencampus.sh account \u2013 the same account used for EduHub. Your previous StuJo.net or EduHub credentials still work here; there is no need to register again.

--- a/keycloak/themes/edu-hub/login/resources/css/stujo-portals.css
+++ b/keycloak/themes/edu-hub/login/resources/css/stujo-portals.css
@@ -191,6 +191,15 @@ html.stujo-brand #kc-locale-dropdown ul {
   list-style: none;
 }
 
+html.stujo-brand #kc-locale-dropdown ul::before {
+  position: absolute;
+  top: -5px;
+  right: 0;
+  width: 100%;
+  height: 5px;
+  content: '';
+}
+
 html.stujo-brand #kc-locale-dropdown:focus-within ul {
   display: block;
 }

--- a/keycloak/themes/edu-hub/login/resources/css/stujo-portals.css
+++ b/keycloak/themes/edu-hub/login/resources/css/stujo-portals.css
@@ -42,8 +42,8 @@ html.stujo-brand body {
 }
 
 html.stujo-brand .academy_header_guest .navbar.p-0 {
-  height: 92px;
-  padding: 20px 28px !important;
+  height: 78px;
+  padding: 15px 18px !important;
 }
 
 html.stujo-brand .navbar-logo-wrapper {
@@ -70,14 +70,14 @@ html.stujo-brand .navbar-logo-text {
 }
 
 html.stujo-brand .navbar-logo {
-  width: 40px;
-  height: 40px;
+  width: 31px;
+  height: 31px;
 }
 
 html.stujo-brand .navbar-logo-text {
-  width: 42px;
+  width: 34px;
   height: auto;
-  margin-left: 9px;
+  margin-left: 7px;
 }
 
 .navbar-cobrand-divider {
@@ -94,7 +94,7 @@ html.stujo-brand .navbar-logo-text {
 .navbar-cobrand-logo {
   display: none;
   width: auto;
-  height: 42px;
+  height: 32px;
 }
 
 html.stujo-brand .navbar-cobrand-stujo {
@@ -110,18 +110,21 @@ html.stujo-flensburg .navbar-cobrand-stujo {
 html.stujo-haw-kiel .navbar-cobrand-haw-kiel,
 html.stujo-flensburg .navbar-cobrand-flensburg {
   display: block;
-  height: 46px;
+  height: 36px;
 }
 
 /* Neutral card with StuJo-coloured actions and no decorative accent bar. */
 html.stujo-brand .card-pf {
+  width: calc(100% - 28px);
   max-width: 500px;
-  padding-right: 28px;
-  padding-left: 28px;
+  margin-right: auto;
+  margin-left: auto;
+  padding-right: 20px;
+  padding-left: 20px;
   border: 1px solid var(--kc-cobrand-border);
   border-radius: 16px;
   background-color: #fff;
-  box-shadow: 0 18px 50px rgba(51, 28, 42, 0.1);
+  box-shadow: 0 12px 35px rgba(51, 28, 42, 0.09);
 }
 
 /* Keep breathing room below tall flows such as registration. */
@@ -155,7 +158,8 @@ html.stujo-brand #kc-locale-dropdown {
 
 html.stujo-brand #kc-locale-dropdown a#kc-current-locale-link {
   display: inline-flex;
-  min-height: 32px;
+  min-width: 44px;
+  min-height: 44px;
   align-items: center;
   padding: 5px 2px;
   border: 0;
@@ -234,7 +238,7 @@ html.stujo-brand .kc-stujo-login-title {
 html.stujo-brand h1#kc-page-title {
   margin-top: 0;
   color: var(--kc-cobrand-copy);
-  font-size: 28px;
+  font-size: 24px;
   font-weight: 650;
   letter-spacing: -0.02em;
 }
@@ -373,7 +377,7 @@ html.stujo-brand #kc-social-providers li {
 
 html.stujo-brand #kc-social-providers a {
   display: flex;
-  min-height: 42px;
+  min-height: 44px;
   align-items: center;
   justify-content: center;
   padding: 9px 18px;
@@ -426,43 +430,39 @@ html.stujo-brand .kc-cobrand-note {
   line-height: 1.5;
 }
 
-@media (max-width: 767px) {
+@media (min-width: 768px) {
   html.stujo-brand .academy_header_guest .navbar.p-0 {
-    height: 78px;
-    padding: 15px 18px !important;
+    height: 92px;
+    padding: 20px 28px !important;
   }
 
   html.stujo-brand .navbar-cobrand-logo {
-    height: 32px;
+    height: 42px;
   }
 
   html.stujo-haw-kiel .navbar-cobrand-haw-kiel,
   html.stujo-flensburg .navbar-cobrand-flensburg {
-    height: 36px;
+    height: 46px;
   }
 
   html.stujo-brand .navbar-logo {
-    width: 31px;
-    height: 31px;
+    width: 40px;
+    height: 40px;
   }
 
   html.stujo-brand .navbar-logo-text {
-    width: 34px;
-    margin-left: 7px;
+    width: 42px;
+    margin-left: 9px;
   }
 
   html.stujo-brand .card-pf {
-    width: calc(100% - 28px);
-    max-width: 500px;
-    margin-right: auto;
-    margin-left: auto;
-    padding-right: 20px;
-    padding-left: 20px;
-    border: 1px solid var(--kc-cobrand-border);
-    box-shadow: 0 12px 35px rgba(51, 28, 42, 0.09);
+    width: auto;
+    padding-right: 28px;
+    padding-left: 28px;
+    box-shadow: 0 18px 50px rgba(51, 28, 42, 0.1);
   }
 
   html.stujo-brand h1#kc-page-title {
-    font-size: 24px;
+    font-size: 28px;
   }
 }

--- a/keycloak/themes/edu-hub/login/resources/css/stujo-portals.css
+++ b/keycloak/themes/edu-hub/login/resources/css/stujo-portals.css
@@ -311,6 +311,11 @@ html.stujo-brand .pf-c-input-group .pf-c-button.pf-m-control::after {
   box-shadow: none;
 }
 
+html.stujo-brand .pf-c-input-group:focus-within
+  .pf-c-button.pf-m-control {
+  border-left-color: var(--kc-cobrand-accent);
+}
+
 html.stujo-brand .pf-c-input-group .pf-c-button.pf-m-control:hover,
 html.stujo-brand .pf-c-input-group .pf-c-button.pf-m-control:focus {
   border-left-color: var(--kc-cobrand-accent);

--- a/keycloak/themes/edu-hub/login/resources/css/stujo-portals.css
+++ b/keycloak/themes/edu-hub/login/resources/css/stujo-portals.css
@@ -294,10 +294,12 @@ html.stujo-brand .pf-c-input-group .pf-c-form-control:focus-visible {
 
 html.stujo-brand .pf-c-input-group .pf-c-button.pf-m-control {
   display: inline-flex;
+  flex: 0 0 48px;
   width: 48px;
   height: 44px;
   align-items: center;
   justify-content: center;
+  margin-left: 0;
   padding: 0;
   border: 0;
   border-left: 1px solid #c6c2c5;

--- a/keycloak/themes/edu-hub/login/resources/css/stujo-portals.css
+++ b/keycloak/themes/edu-hub/login/resources/css/stujo-portals.css
@@ -1,73 +1,107 @@
 /*
  * StuJo co-branding for the shared EduHub login theme.
  *
- * StuJo and EduHub are one Keycloak realm and one account. When the login
- * looked like a standalone StuJo dialog, people with an existing EduHub
- * account did not recognise it and tried to register again, which only got
- * them "email already exists". So the page deliberately stays the EduHub
- * login — dark #222 page, light card, pill buttons, Space Grotesk — and the
- * portal only adds a small co-brand mark next to the EduHub lockup plus one
- * accent colour. Activated via html.stujo-brand (see js/stujo-portal-brand.js).
+ * StuJo and EduHub use the same Keycloak realm and account. StuJo is the
+ * primary product identity on its login routes, while the existing EduHub
+ * lockup remains visible as the shared account provider. Activated via
+ * html.stujo-brand (see js/stujo-portal-brand.js).
  *
  * White-label campus portals add html.stujo-haw-kiel / html.stujo-flensburg
- * on top of stujo-brand; they swap the co-brand logo and the accent colour
- * (values match the AppSettings primaryColor seeds).
+ * on top of stujo-brand; they swap the co-brand logo and accent colour.
  */
 
 html.stujo-brand {
   --kc-cobrand-accent: #a71580;
+  --kc-cobrand-accent-hover: #861065;
+  --kc-cobrand-background: #f5f2f4;
+  --kc-cobrand-border: #e2dde0;
+  --kc-cobrand-copy: #343238;
 }
 
 html.stujo-haw-kiel {
   --kc-cobrand-accent: #04305e;
+  --kc-cobrand-accent-hover: #032544;
 }
 
 html.stujo-flensburg {
   --kc-cobrand-accent: #025095;
+  --kc-cobrand-accent-hover: #013e74;
 }
 
-/* --------------------------------------------------------------------------
- * Header co-brand: the EduHub lockup keeps its place, the portal mark is
- * added beside it. The portal logos are dark artwork made for a white
- * header, so they sit on a small white plate to stay legible on #222.
- * -------------------------------------------------------------------------- */
+/* Space Grotesk remains part of the EduHub theme. StuJo uses neutral UI type. */
+html.stujo-brand body {
+  background-color: var(--kc-cobrand-background);
+  color: var(--kc-cobrand-copy);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica,
+    Arial, sans-serif;
+}
 
+/* StuJo is placed on the left and the existing EduHub lockup on the right. */
 .navbar-cobrand {
+  display: none;
+}
+
+html.stujo-brand .academy_header_guest .navbar.p-0 {
+  height: 92px;
+  padding: 20px 28px !important;
+}
+
+html.stujo-brand .navbar-logo-wrapper {
+  width: 100%;
+  align-items: center;
+}
+
+/* This theme has no mobile navigation links, so its Bootstrap toggle is inert. */
+html.stujo-brand .academy_header_guest .navbar-toggler {
   display: none;
 }
 
 html.stujo-brand .navbar-cobrand {
   display: flex;
   align-items: center;
+  order: -1;
+  margin-right: auto;
+}
+
+html.stujo-brand .navbar-logo,
+html.stujo-brand .navbar-logo-text {
+  filter: invert(1);
+  opacity: 0.72;
+}
+
+html.stujo-brand .navbar-logo {
+  width: 40px;
+  height: 40px;
+}
+
+html.stujo-brand .navbar-logo-text {
+  width: 42px;
+  height: auto;
+  margin-left: 9px;
 }
 
 .navbar-cobrand-divider {
-  width: 1px;
-  height: 28px;
-  margin: 0 8px;
-  background-color: #4a4a4a;
+  display: none;
 }
 
 .navbar-cobrand-plate {
   display: flex;
   align-items: center;
-  padding: 4px 8px;
-  border-radius: 6px;
-  background-color: #fff;
+  padding: 0;
+  background-color: transparent;
 }
 
 .navbar-cobrand-logo {
   display: none;
   width: auto;
-  height: 20px;
+  height: 42px;
 }
 
 html.stujo-brand .navbar-cobrand-stujo {
   display: block;
 }
 
-/* Campus lockups stack the StuJo mark above the university logo, so they
-   need more height than the plain StuJo wordmark and replace it. */
+/* Campus lockups replace the plain StuJo wordmark. */
 html.stujo-haw-kiel .navbar-cobrand-stujo,
 html.stujo-flensburg .navbar-cobrand-stujo {
   display: none;
@@ -76,61 +110,350 @@ html.stujo-flensburg .navbar-cobrand-stujo {
 html.stujo-haw-kiel .navbar-cobrand-haw-kiel,
 html.stujo-flensburg .navbar-cobrand-flensburg {
   display: block;
-  height: 28px;
+  height: 46px;
 }
 
-@media (min-width: 481px) {
-  .navbar-cobrand-divider {
-    margin: 0 14px;
+/* Neutral card with StuJo-coloured actions and no decorative accent bar. */
+html.stujo-brand .card-pf {
+  max-width: 500px;
+  padding-right: 28px;
+  padding-left: 28px;
+  border: 1px solid var(--kc-cobrand-border);
+  border-radius: 16px;
+  background-color: #fff;
+  box-shadow: 0 18px 50px rgba(51, 28, 42, 0.1);
+}
+
+/* Keep breathing room below tall flows such as registration. */
+html.stujo-brand .login-pf-page {
+  padding-bottom: 40px;
+}
+
+/* Give the full login card a little more room below on laptop viewports.
+   Other, potentially taller Keycloak flows keep their natural position. */
+@media (min-width: 768px) and (min-height: 700px) {
+  html.stujo-brand body.kc-login-page .login-pf-page {
+    transform: translateY(-24px);
+  }
+}
+
+/* Use Keycloak's locale handling, presented as a compact dropdown. */
+html.stujo-brand #kc-locale {
+  position: relative;
+  top: auto;
+  right: auto;
+  width: auto;
+  min-height: 32px;
+  margin-bottom: 20px;
+  text-align: right;
+  z-index: 10;
+}
+
+html.stujo-brand #kc-locale-dropdown {
+  position: relative;
+}
+
+html.stujo-brand #kc-locale-dropdown a#kc-current-locale-link {
+  display: inline-flex;
+  min-height: 32px;
+  align-items: center;
+  padding: 5px 2px;
+  border: 0;
+  background: transparent;
+  color: #706d73;
+  font-size: 14px;
+  line-height: 20px;
+  text-decoration: none;
+}
+
+html.stujo-brand #kc-locale-dropdown a#kc-current-locale-link:hover,
+html.stujo-brand #kc-locale-dropdown a#kc-current-locale-link:focus {
+  color: var(--kc-cobrand-accent);
+}
+
+html.stujo-brand #kc-locale-dropdown a#kc-current-locale-link:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid var(--kc-cobrand-accent);
+  outline-offset: 2px;
+}
+
+html.stujo-brand #kc-locale-dropdown ul {
+  position: absolute;
+  top: calc(100% + 4px);
+  right: 0;
+  min-width: 120px;
+  margin: 0;
+  padding: 4px;
+  border: 1px solid var(--kc-cobrand-border);
+  border-radius: 8px;
+  background-color: #fff;
+  box-shadow: 0 10px 24px rgba(51, 28, 42, 0.12);
+  list-style: none;
+}
+
+html.stujo-brand #kc-locale-dropdown:focus-within ul {
+  display: block;
+}
+
+html.stujo-brand #kc-locale-dropdown ul a {
+  display: block;
+  padding: 7px 9px;
+  border-radius: 5px;
+  color: var(--kc-cobrand-copy);
+  text-align: left;
+  text-decoration: none;
+}
+
+html.stujo-brand #kc-locale-dropdown ul a:hover,
+html.stujo-brand #kc-locale-dropdown ul a:focus {
+  background-color: #fff2f9;
+  color: var(--kc-cobrand-accent);
+}
+
+.kc-stujo-login-title {
+  display: none;
+}
+
+html.stujo-brand .kc-default-login-title {
+  display: none;
+}
+
+html.stujo-brand .kc-stujo-login-title {
+  display: inline;
+}
+
+html.stujo-brand h1#kc-page-title {
+  margin-top: 0;
+  color: var(--kc-cobrand-copy);
+  font-size: 28px;
+  font-weight: 650;
+  letter-spacing: -0.02em;
+}
+
+html.stujo-brand .pf-c-form-control {
+  height: 44px;
+  border: 1px solid #c6c2c5;
+  border-radius: 7px;
+  background-color: #fff;
+}
+
+html.stujo-brand .pf-c-form-control:hover,
+html.stujo-brand .pf-c-form-control:focus {
+  border-color: var(--kc-cobrand-accent);
+  border-bottom-width: 1px;
+}
+
+html.stujo-brand .pf-c-form-control:focus {
+  outline: none;
+  box-shadow: 0 0 0 1px var(--kc-cobrand-accent);
+}
+
+html.stujo-brand .pf-c-form-control:focus-visible {
+  outline: 1px solid var(--kc-cobrand-accent);
+  outline-offset: 1px;
+}
+
+html.stujo-brand .pf-c-input-group {
+  overflow: hidden;
+  border: 1px solid #c6c2c5;
+  border-radius: 7px;
+  background-color: #fff;
+}
+
+html.stujo-brand .pf-c-input-group:hover {
+  border-color: var(--kc-cobrand-accent);
+}
+
+html.stujo-brand .pf-c-input-group:focus-within {
+  border-color: var(--kc-cobrand-accent);
+  box-shadow: 0 0 0 1px var(--kc-cobrand-accent);
+}
+
+html.stujo-brand .pf-c-input-group .pf-c-form-control,
+html.stujo-brand .pf-c-input-group .pf-c-form-control:hover,
+html.stujo-brand .pf-c-input-group .pf-c-form-control:focus,
+html.stujo-brand .pf-c-input-group .pf-c-form-control:focus-visible {
+  border: 0;
+  border-radius: 0;
+  outline: 0;
+  box-shadow: none;
+}
+
+html.stujo-brand .pf-c-input-group .pf-c-button.pf-m-control {
+  display: inline-flex;
+  width: 48px;
+  height: 44px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  border-left: 1px solid #c6c2c5;
+  border-radius: 0;
+  background-color: #fff;
+  color: var(--kc-cobrand-copy);
+}
+
+html.stujo-brand .pf-c-input-group .pf-c-button.pf-m-control::after {
+  border: 0;
+  box-shadow: none;
+}
+
+html.stujo-brand .pf-c-input-group .pf-c-button.pf-m-control:hover,
+html.stujo-brand .pf-c-input-group .pf-c-button.pf-m-control:focus {
+  border-left-color: var(--kc-cobrand-accent);
+  outline: 0;
+  color: var(--kc-cobrand-accent);
+}
+
+html.stujo-brand .pf-c-button.pf-m-primary {
+  width: 100%;
+  margin: 0;
+  padding: 10px 24px;
+  border: 0;
+  border-radius: 8px;
+  background-color: var(--kc-cobrand-accent);
+  color: #fff;
+  font-weight: 600;
+  text-transform: none;
+}
+
+html.stujo-brand .pf-c-button.pf-m-primary:hover,
+html.stujo-brand .pf-c-button.pf-m-primary:focus {
+  background-color: var(--kc-cobrand-accent-hover);
+  color: #fff;
+}
+
+html.stujo-brand .card-pf a {
+  color: var(--kc-cobrand-accent);
+}
+
+html.stujo-brand .card-pf a:hover,
+html.stujo-brand .card-pf a:focus {
+  color: var(--kc-cobrand-accent-hover);
+}
+
+/* Identity providers remain data-driven. When DLC is configured, present it
+   as a full-width secondary action separated from the password login. */
+html.stujo-brand #kc-social-providers {
+  margin-top: 24px;
+  text-align: center;
+}
+
+html.stujo-brand #kc-social-providers hr {
+  margin: 0 0 18px;
+  border: 0;
+  border-top: 1px solid var(--kc-cobrand-border);
+}
+
+html.stujo-brand #kc-social-providers h4 {
+  margin: 0 0 14px;
+  color: #77737a;
+  font-size: 16px;
+  font-weight: 400;
+}
+
+html.stujo-brand #kc-social-providers ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+html.stujo-brand #kc-social-providers li {
+  margin-bottom: 10px;
+}
+
+html.stujo-brand #kc-social-providers a {
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  justify-content: center;
+  padding: 9px 18px;
+  border: 1px solid #cac6c9;
+  border-radius: 8px;
+  background-color: #fff;
+  color: var(--kc-cobrand-copy);
+  font-weight: 600;
+  text-decoration: none;
+}
+
+html.stujo-brand #kc-social-providers a:hover,
+html.stujo-brand #kc-social-providers a:focus {
+  border-color: var(--kc-cobrand-accent);
+  color: var(--kc-cobrand-accent);
+}
+
+/* Remove Keycloak's full-bleed grey registration footer. */
+html.stujo-brand #kc-info {
+  margin: 24px 0 0;
+}
+
+html.stujo-brand #kc-info-wrapper {
+  padding: 18px 0 0;
+  border-top: 1px solid var(--kc-cobrand-border);
+  border-radius: 0;
+  background-color: transparent;
+}
+
+html.stujo-brand #kc-registration {
+  color: #77737a;
+  text-align: center;
+}
+
+/* Account migration note, hidden on EduHub itself. */
+.kc-cobrand-note {
+  display: none;
+}
+
+html.stujo-brand .kc-cobrand-note {
+  display: flex;
+  align-items: flex-start;
+  margin: 4px 0 20px;
+  padding: 12px 14px;
+  border: 1px solid #ead4e1;
+  border-radius: 9px;
+  background-color: #fff7fb;
+  color: #4e3d47;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+@media (max-width: 767px) {
+  html.stujo-brand .academy_header_guest .navbar.p-0 {
+    height: 78px;
+    padding: 15px 18px !important;
   }
 
-  .navbar-cobrand-logo {
-    height: 24px;
+  html.stujo-brand .navbar-cobrand-logo {
+    height: 32px;
   }
 
   html.stujo-haw-kiel .navbar-cobrand-haw-kiel,
   html.stujo-flensburg .navbar-cobrand-flensburg {
     height: 36px;
   }
-}
 
-/* --------------------------------------------------------------------------
- * Card: unchanged EduHub card with a thin accent line in the portal colour.
- * No overflow:hidden here — that would clip the locale dropdown.
- * -------------------------------------------------------------------------- */
+  html.stujo-brand .navbar-logo {
+    width: 31px;
+    height: 31px;
+  }
 
-html.stujo-brand .card-pf {
-  position: relative;
-}
+  html.stujo-brand .navbar-logo-text {
+    width: 34px;
+    margin-left: 7px;
+  }
 
-html.stujo-brand .card-pf::before {
-  content: "";
-  position: absolute;
-  top: 0;
-  right: 0;
-  left: 0;
-  height: 4px;
-  border-radius: 16px 16px 0 0;
-  background-color: var(--kc-cobrand-accent);
-}
+  html.stujo-brand .card-pf {
+    width: calc(100% - 28px);
+    max-width: 500px;
+    margin-right: auto;
+    margin-left: auto;
+    padding-right: 20px;
+    padding-left: 20px;
+    border: 1px solid var(--kc-cobrand-border);
+    box-shadow: 0 12px 35px rgba(51, 28, 42, 0.09);
+  }
 
-/* --------------------------------------------------------------------------
- * Shared-account note. Rendered on every page by template.ftl and revealed
- * only for StuJo, because the brand is resolved client-side.
- * -------------------------------------------------------------------------- */
-
-.kc-cobrand-note {
-  display: none;
-}
-
-html.stujo-brand .kc-cobrand-note {
-  display: block;
-  margin: 4px 0 20px;
-  padding: 10px 14px;
-  border-left: 3px solid var(--kc-cobrand-accent);
-  border-radius: 0 8px 8px 0;
-  background-color: #fff;
-  color: #444;
-  font-size: 13px;
-  line-height: 1.45;
+  html.stujo-brand h1#kc-page-title {
+    font-size: 24px;
+  }
 }

--- a/keycloak/themes/edu-hub/login/template.ftl
+++ b/keycloak/themes/edu-hub/login/template.ftl
@@ -66,7 +66,7 @@
     </#if>
 </head>
 
-<body class="${properties.kcBodyClass!}">
+<body class="${properties.kcBodyClass!} ${bodyClass}">
     <div class="content-wrapper">
         <div class="academy_header_guest">
             <nav class="navbar navbar-light navbar-expand-md p-0">
@@ -180,7 +180,12 @@
 
                     <#-- StuJo and EduHub share one account; say so before people
                          try to register a second time. Hidden for EduHub itself. -->
-                    <div class="kc-cobrand-note">${msg("cobrandAccountNote")}</div>
+                    <div class="kc-cobrand-note">
+                        <span>
+                            <strong>${msg("cobrandAccountNoteTitle")}</strong><br>
+                            ${msg("cobrandAccountNote")}
+                        </span>
+                    </div>
 
                     <#nested "form">
 


### PR DESCRIPTION
## Summary
- Redesign the StuJo-branded Keycloak login experience for responsive, accessible use
- Enable German and English realm localization
- Clarify shared EduHub and StuJo account messaging
- Update StuJo logout, layout, profile page, and seed configuration

## Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login pages now support German and English.
  * Updated StuJo branding, account messaging, and password visibility controls.
  * Existing EduHub and StuJo credentials can be used without re-registration.
  * Added improved employer dashboard job-action layout.

* **Bug Fixes**
  * Logout now reliably clears sessions and returns users to the app even when sign-out services fail.
  * Improved handling of missing or invalid logout information.

* **Style**
  * Refreshed login-page design, navigation controls, responsive layouts, and form styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->