### PR TITLE
Prevent orphaned PostgreSQL development volumes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,6 +212,11 @@ services:
       POSTGRES_PASSWORD: postgrespassword
     volumes:
       - ./backend/init.d:/docker-entrypoint-initdb.d:rw
+      # The database is rebuilt from init.d on every container creation. Mount
+      # its data directory explicitly so the image does not create an orphaned
+      # anonymous Docker volume each time the container is replaced.
+      - type: tmpfs
+        target: /var/lib/postgresql/data
 
   keycloak:
     container_name: eduhub-keycloak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,6 +217,8 @@ services:
       # anonymous Docker volume each time the container is replaced.
       - type: tmpfs
         target: /var/lib/postgresql/data
+        tmpfs:
+          size: 1g
 
   keycloak:
     container_name: eduhub-keycloak

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -212,13 +212,9 @@ services:
       POSTGRES_PASSWORD: postgrespassword
     volumes:
       - ./backend/init.d:/docker-entrypoint-initdb.d:rw
-      # The database is rebuilt from init.d on every container creation. Mount
-      # its data directory explicitly so the image does not create an orphaned
-      # anonymous Docker volume each time the container is replaced.
-      - type: tmpfs
-        target: /var/lib/postgresql/data
-        tmpfs:
-          size: 1g
+      # Reuse one Compose-managed volume instead of creating an orphaned
+      # anonymous volume whenever the container is replaced.
+      - db_hasura_data:/var/lib/postgresql/data
 
   keycloak:
     container_name: eduhub-keycloak
@@ -250,3 +246,6 @@ services:
       - ./keycloak/themes/opencampus:/opt/keycloak/themes/opencampus
       - ./keycloak/themes/edu-hub:/opt/keycloak/themes/edu-hub
       - ./keycloak/disable-theme-cache.cli:/opt/keycloak/startup-scripts/disable-theme-cache.cli
+
+volumes:
+  db_hasura_data:


### PR DESCRIPTION
## Summary

- Mount the PostgreSQL data directory as a Compose-managed named volume.
- Prevent orphaned anonymous Docker volumes when the container is replaced.
- Preserve database data across ordinary container restarts and replacements.
- Keep explicit database resets available through `docker compose down -v`.

## Testing

- `docker compose config --quiet`
- Verified the effective volume name is `eduhub_db_hasura_data`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - PostgreSQL data now uses a reusable Compose-managed development volume.
  - Recreated database containers no longer leave anonymous volumes behind.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
