### PR TITLE
Enable authenticated Tailscale network previews

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,10 @@
 # NOTE: This file is ONLY for local development with docker-compose.
 # Staging and production environments use Terraform/Secret Manager for configuration.
 
+# Normal `docker compose up` binds development services to localhost. Use
+# `scripts/start-network-preview.sh <LAN-or-Tailscale-IP>` to opt in to exposing
+# the frontend, storage, Hasura, and Keycloak ports for a phone preview.
+
 # =============================================================================
 # Matrix / Element (chat links and room creation)
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,8 @@
 # Staging and production environments use Terraform/Secret Manager for configuration.
 
 # Normal `docker compose up` binds development services to localhost. Use
-# `scripts/start-network-preview.sh <LAN-or-Tailscale-IP>` to opt in to exposing
-# the frontend, storage, Hasura, and Keycloak ports for a phone preview.
+# `scripts/start-network-preview.sh <Tailscale-IP>` to opt in to exposing the
+# frontend, storage, Hasura, and Keycloak ports through an encrypted Tailnet.
 
 # =============================================================================
 # Matrix / Element (chat links and room creation)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   frontend-nx:
     container_name: eduhub-frontend-nx
     ports:
-      - "5000:4200"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:5000:4200"
     build:
       context: ./frontend-nx
       dockerfile: Dockerfile-dev
@@ -17,12 +17,19 @@ services:
       - hasura
       - keycloak
     environment:
+      NEXT_PUBLIC_API_URL: http://${DEV_HOST:-localhost}:8080/v1/graphql
+      NEXT_PUBLIC_AUTH_URL: http://${DEV_HOST:-localhost}:28080
+      NEXTAUTH_URL: http://${DEV_HOST:-localhost}:5000
+      # Server-side callbacks stay inside this container and do not depend on
+      # the preview hostname being resolvable from Docker.
+      NEXTAUTH_INTERNAL_URL: http://localhost:5000
+      KEYCLOAK_INTERNAL_URL: http://keycloak:8080
       NEXT_PUBLIC_HELP_DOCS_URL: https://opencampus.gitbook.io/faq/
-      NEXT_PUBLIC_STORAGE_BUCKET_URL: ${GITPOD_WORKSPACE_URL:-http://localhost}:4001/emulated-bucket
+      NEXT_PUBLIC_STORAGE_BUCKET_URL: ${GITPOD_WORKSPACE_URL:-http://${DEV_HOST:-localhost}}:4001/emulated-bucket
       NEXT_PUBLIC_ENVIRONMENT: development
       # Job tile links go to the local StuJo app (frontend-stujo on :5001),
       # not the production fallback in stujoBaseUrl.ts.
-      NEXT_PUBLIC_STUJO_URL: http://localhost:5001
+      NEXT_PUBLIC_STUJO_URL: http://${DEV_HOST:-localhost}:5001
       NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL: ${NEXT_PUBLIC_MATRIX_ELEMENT_CLIENT_URL:-}
       # The Stripe webhook route lives in this app (pages/api/webhooks/stripe.ts),
       # so it needs the keys too -- without them `stripe listen --forward-to
@@ -30,7 +37,7 @@ services:
       # ever gets "Stripe not configured".
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
       STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
-      STUJO_FRONTEND_URL: ${STUJO_FRONTEND_URL:-http://localhost:5001}
+      STUJO_FRONTEND_URL: ${STUJO_FRONTEND_URL:-http://${DEV_HOST:-localhost}:5001}
       STUJO_TERMS_URL: ${STUJO_TERMS_URL:-}
       STUJO_ADMIN_EMAIL: ${STUJO_ADMIN_EMAIL:-}
       MM_URL: ${MM_URL:-https://chat.opencampus.sh}
@@ -50,7 +57,7 @@ services:
   frontend-stujo:
     container_name: eduhub-frontend-stujo
     ports:
-      - "5001:4201"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:5001:4201"
     build:
       context: ./frontend-nx
       dockerfile: Dockerfile-dev
@@ -67,11 +74,14 @@ services:
       DEV_SELF_PORT: 5001
       APP_NAME: stujo
       NEXT_PUBLIC_ENVIRONMENT: development
-      NEXT_PUBLIC_API_URL: http://localhost:8080/v1/graphql
-      NEXT_PUBLIC_STORAGE_BUCKET_URL: ${GITPOD_WORKSPACE_URL:-http://localhost}:4001/emulated-bucket
+      NEXT_PUBLIC_API_URL: http://${DEV_HOST:-localhost}:8080/v1/graphql
+      NEXT_PUBLIC_AUTH_URL: http://${DEV_HOST:-localhost}:28080
+      NEXT_PUBLIC_STORAGE_BUCKET_URL: ${GITPOD_WORKSPACE_URL:-http://${DEV_HOST:-localhost}}:4001/emulated-bucket
       # SSR queries go directly to the hasura container
       API_URL: http://hasura:8080/v1/graphql
-      NEXTAUTH_URL: http://localhost:5001
+      NEXTAUTH_URL: http://${DEV_HOST:-localhost}:5001
+      NEXTAUTH_INTERNAL_URL: http://localhost:5001
+      KEYCLOAK_INTERNAL_URL: http://keycloak:8080
       CHOKIDAR_USEPOLLING: "true"
       WATCHPACK_POLLING: "true"
       NODE_OPTIONS: "--dns-result-order=ipv4first"
@@ -87,8 +97,8 @@ services:
       - ./functions:/functions
       - ./backend/init.d/file_storage:/home/node/www/emulated-bucket
     ports:
-      - "42000-42024:42000-42024"
-      - "4001:4001"
+      - "127.0.0.1:42000-42024:42000-42024"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:4001:4001"
     command: ["sh", "/functions/start-node.sh"]
     environment:
       ENVIRONMENT: development
@@ -111,13 +121,13 @@ services:
       MATRIX_MAIN_SPACE_ID: ${MATRIX_MAIN_SPACE_ID:-}
       MATRIX_ADMIN_USER_ID: ${MATRIX_ADMIN_USER_ID:-}
       MATRIX_ADMIN_ACCESS_TOKEN: ${MATRIX_ADMIN_ACCESS_TOKEN:-}
-      FRONTEND_URL: http://localhost:5000
+      FRONTEND_URL: http://${DEV_HOST:-localhost}:5000
       # StuJo job board (publishJobPosting / createStripeJobPostingPrices)
-      STUJO_FRONTEND_URL: ${STUJO_FRONTEND_URL:-http://localhost:5001}
+      STUJO_FRONTEND_URL: ${STUJO_FRONTEND_URL:-http://${DEV_HOST:-localhost}:5001}
       STUJO_ADMIN_EMAIL: ${STUJO_ADMIN_EMAIL:-}
       STRIPE_TAX_RATE_ID: ${STRIPE_TAX_RATE_ID:-}
       STUJO_SELLER_ORGANIZATION_ID: ${STUJO_SELLER_ORGANIZATION_ID:-}
-      STORAGE_BUCKET_PUBLIC_URL: ${GITPOD_WORKSPACE_URL:-http://localhost}:4001/emulated-bucket
+      STORAGE_BUCKET_PUBLIC_URL: ${GITPOD_WORKSPACE_URL:-http://${DEV_HOST:-localhost}}:4001/emulated-bucket
       # Optional for local dev; required to encrypt Ghost newsletter credentials (see .env.example)
       GHOST_NEWSLETTER_CREDENTIALS_ENCRYPTION_KEY: ${GHOST_NEWSLETTER_CREDENTIALS_ENCRYPTION_KEY:-}
       # Signs the guest self-service manage links. The dev default is fine locally
@@ -144,7 +154,7 @@ services:
       KEYCLOAK_USER: admin
       KEYCLOAK_PW: admin
       HASURA_ENDPOINT: http://hasura:8080/v1/graphql
-      JWT_ISSUER: http://keycloak:8080/realms/edu-hub
+      JWT_ISSUER: http://${DEV_HOST:-localhost}:28080/realms/edu-hub
       JWT_JWKS_URI: http://keycloak:8080/realms/edu-hub/protocol/openid-connect/certs
       JWT_AUDIENCE: hasura
       HASURA_ADMIN_SECRET: myadminsecretkey
@@ -173,7 +183,7 @@ services:
       context: ./backend/
       dockerfile: Dockerfile-dev
     ports:
-      - "8080:8080"
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:8080:8080"
     depends_on:
       - db_hasura
       - keycloak
@@ -227,21 +237,22 @@ services:
       # Dockerfile-dev), skipping the ~90s Quarkus build on every startup.
       # The SPI theme-cache flags keep live theme reloading that `start-dev`
       # used to provide automatically.
-      - >-
-        unset KC_BOOTSTRAP_ADMIN_USERNAME KC_BOOTSTRAP_ADMIN_PASSWORD &&
-        /opt/keycloak/bin/kc.sh import --optimized --file /opt/keycloak/data/import/master.json --override true &&
-        exec /opt/keycloak/bin/kc.sh start --optimized --import-realm --spi-theme-cache-themes=false --spi-theme-cache-templates=false
+      - /bin/sh /opt/keycloak/start-dev.sh
     ports:
-      - 28080:8080
+      - "${DEV_BIND_ADDRESS:-127.0.0.1}:28080:8080"
     environment:
+      DEV_HOST: ${DEV_HOST:-localhost}
+      DEV_KEYCLOAK_SSL_REQUIRED: ${DEV_KEYCLOAK_SSL_REQUIRED:-external}
       KC_BOOTSTRAP_ADMIN_USERNAME: admin
       KC_BOOTSTRAP_ADMIN_PASSWORD: admin
       KC_HOSTNAME_STRICT: "false"
+      KC_HOSTNAME: http://${DEV_HOST:-localhost}:28080
       KC_HTTP_ENABLED: "true"
       KC_HTTP_HOST: "0.0.0.0"
     volumes:
       - ./keycloak/imports-dev/master.json:/opt/keycloak/data/import/master.json
       - ./keycloak/imports-dev/edu-hub.json:/opt/keycloak/data/import/edu-hub.json
+      - ./keycloak/start-dev.sh:/opt/keycloak/start-dev.sh:ro
       - ./keycloak/imports:/imports
       - ./keycloak/themes/opencampus:/opt/keycloak/themes/opencampus
       - ./keycloak/themes/edu-hub:/opt/keycloak/themes/edu-hub

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       # Fix IPv6 localhost resolution for image loading
       NODE_OPTIONS: "--dns-result-order=ipv4first"
       # Hasura configuration
-      HASURA_ADMIN_SECRET: myadminsecretkey
+      HASURA_ADMIN_SECRET: ${DEV_HASURA_ADMIN_SECRET:-myadminsecretkey}
       GRAPHQL_URI: http://hasura:8080/v1/graphql
       # Optional for local dev; required to encrypt Ghost newsletter credentials (see .env.example)
       GHOST_NEWSLETTER_CREDENTIALS_ENCRYPTION_KEY: ${GHOST_NEWSLETTER_CREDENTIALS_ENCRYPTION_KEY:-}
@@ -85,7 +85,7 @@ services:
       CHOKIDAR_USEPOLLING: "true"
       WATCHPACK_POLLING: "true"
       NODE_OPTIONS: "--dns-result-order=ipv4first"
-      HASURA_ADMIN_SECRET: myadminsecretkey
+      HASURA_ADMIN_SECRET: ${DEV_HASURA_ADMIN_SECRET:-myadminsecretkey}
       GRAPHQL_URI: http://hasura:8080/v1/graphql
 
   node_functions:
@@ -108,7 +108,7 @@ services:
       KEYCLOAK_USER: admin
       KEYCLOAK_PW: admin
       HASURA_ENDPOINT: http://hasura:8080/v1/graphql
-      HASURA_ADMIN_SECRET: myadminsecretkey
+      HASURA_ADMIN_SECRET: ${DEV_HASURA_ADMIN_SECRET:-myadminsecretkey}
       HASURA_CLOUD_FUNCTION_SECRET: test1234
       LIBRARY_PATH: "../lib/cloud-storage.js"
       FORMBRICKS_API_KEY: ${FORMBRICKS_API_KEY:-}
@@ -145,8 +145,8 @@ services:
       - ./functions:/functions
       - ./backend/init.d/file_storage:/home/node/www/emulated-bucket
     ports:
-      - "42025:42025"
-      - "42026:42026"
+      - "127.0.0.1:42025:42025"
+      - "127.0.0.1:42026:42026"
     command: sh -c "pip install -r /functions/apiProxy/requirements.txt && pip install -r /functions/callPythonFunction/requirements.txt && /functions/start-python.sh"
     environment:
       ENVIRONMENT: development
@@ -157,12 +157,12 @@ services:
       JWT_ISSUER: http://${DEV_HOST:-localhost}:28080/realms/edu-hub
       JWT_JWKS_URI: http://keycloak:8080/realms/edu-hub/protocol/openid-connect/certs
       JWT_AUDIENCE: hasura
-      HASURA_ADMIN_SECRET: myadminsecretkey
+      HASURA_ADMIN_SECRET: ${DEV_HASURA_ADMIN_SECRET:-myadminsecretkey}
       HASURA_CLOUD_FUNCTION_SECRET: test1234
       BUCKET_NAME: emulated-bucket
       LOCAL_STORAGE_PORT: 4001
       # StuJo job board (expire_job_postings / send_job_alerts mails)
-      STUJO_FRONTEND_URL: ${STUJO_FRONTEND_URL:-http://localhost:5001}
+      STUJO_FRONTEND_URL: ${STUJO_FRONTEND_URL:-http://${DEV_HOST:-localhost}:5001}
       # From repo-root .env (optional; see .env.example → Python serverless functions)
       ZOOM_API_KEY: ${ZOOM_API_KEY:-}
       ZOOM_API_SECRET: ${ZOOM_API_SECRET:-}
@@ -194,7 +194,7 @@ services:
       HASURA_GRAPHQL_DEV_MODE: "true"
       HASURA_GRAPHQL_ENABLED_LOG_TYPES: startup, http-log, webhook-log, websocket-log, query-log
       HASURA_GRAPHQL_LOG_LEVEL: warn
-      HASURA_GRAPHQL_ADMIN_SECRET: myadminsecretkey
+      HASURA_GRAPHQL_ADMIN_SECRET: ${DEV_HASURA_ADMIN_SECRET:-myadminsecretkey}
       HASURA_GRAPHQL_UNAUTHORIZED_ROLE: anonymous
       HASURA_GRAPHQL_EXPERIMENTAL_FEATURES: inherited_roles
       HASURA_GRAPHQL_JWT_SECRET: '{"jwk_url": "http://keycloak:8080/realms/edu-hub/protocol/openid-connect/certs"}'

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -35,29 +35,23 @@ See the sections in **`.env.example`** (Matrix, Formbricks, Stripe, Ghost, and *
 
 Normal `docker compose up` explicitly binds the development services to
 `127.0.0.1`. This preserves the safe default even if Docker Desktop's global
-port-binding setting changes. To opt in to a phone preview, pass the Mac's LAN
-or Tailscale IPv4 address to the helper:
-
-```bash
-scripts/start-network-preview.sh 192.168.1.23 -d
-```
-
-The helper binds only EduHub, StuJo, file storage, Hasura, and Keycloak to the
-selected interface, configures their browser-visible URLs, and permits HTTP in
-the disposable development Keycloak realm. Use the Mac's Tailscale IPv4 address
-instead for remote previews; this does not also expose the ports on Wi-Fi:
+port-binding setting changes. For an authenticated phone preview, pass the
+Mac's Tailscale IPv4 address to the helper:
 
 ```bash
 scripts/start-network-preview.sh 100.x.y.z -d
 ```
 
 Open `http://<address>:5000` for EduHub or `http://<address>:5001` for StuJo.
+The helper rejects non-Tailscale and non-local addresses, binds only EduHub,
+StuJo, file storage, Hasura, and Keycloak to that Tailnet interface, and creates
+a random Hasura admin secret for the preview. Traffic between Tailnet devices
+is encrypted even though the disposable development services use HTTP.
+
 Running ordinary `docker compose up -d` afterward restores localhost-only
-bindings and Keycloak's `external` SSL requirement; Compose detects and
-recreates the affected services without replacing the disposable database.
-Network preview exposes services that use development credentials, including
-the Hasura and Keycloak admin endpoints, so only enable it on a trusted LAN or
-Tailnet and stop it when the preview is finished.
+bindings, the normal development secret, and Keycloak's `external` SSL
+requirement. Compose detects and recreates the affected services without
+replacing the development database. Stop the preview when it is finished.
 
 ## Ports
 

--- a/docs/DEVELOPMENT_GUIDE.md
+++ b/docs/DEVELOPMENT_GUIDE.md
@@ -31,6 +31,34 @@ See the sections in **`.env.example`** (Matrix, Formbricks, Stripe, Ghost, and *
 
 - **Formbricks Integration:** `FORMBRICKS_API_KEY` — get from Formbricks → Settings → Organization → API Keys. Details: `docs/FORMBRICKS_IMPLEMENTATION_SUMMARY.md`.
 
+### Previewing from a phone
+
+Normal `docker compose up` explicitly binds the development services to
+`127.0.0.1`. This preserves the safe default even if Docker Desktop's global
+port-binding setting changes. To opt in to a phone preview, pass the Mac's LAN
+or Tailscale IPv4 address to the helper:
+
+```bash
+scripts/start-network-preview.sh 192.168.1.23 -d
+```
+
+The helper binds only EduHub, StuJo, file storage, Hasura, and Keycloak to the
+selected interface, configures their browser-visible URLs, and permits HTTP in
+the disposable development Keycloak realm. Use the Mac's Tailscale IPv4 address
+instead for remote previews; this does not also expose the ports on Wi-Fi:
+
+```bash
+scripts/start-network-preview.sh 100.x.y.z -d
+```
+
+Open `http://<address>:5000` for EduHub or `http://<address>:5001` for StuJo.
+Running ordinary `docker compose up -d` afterward restores localhost-only
+bindings and Keycloak's `external` SSL requirement; Compose detects and
+recreates the affected services without replacing the disposable database.
+Network preview exposes services that use development credentials, including
+the Hasura and Keycloak admin endpoints, so only enable it on a trusted LAN or
+Tailnet and stop it when the preview is finished.
+
 ## Ports
 
 - `4001` - File uploads
@@ -103,4 +131,3 @@ To persist changes you made to the keycloak configuration export the edu-hub rea
 ## Updating frontend-nx packages
 - use `yarn upgrade-interactive` script to check for package updates
 - if package version are explicitly locked in, please check for potential issues or comments while upgrading
-

--- a/frontend-nx/apps/edu-hub/pages/api/auth/[...nextauth].ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/[...nextauth].ts
@@ -15,6 +15,9 @@ if (!HASURA_ADMIN_SECRET) {
   );
 }
 
+const publicKeycloakUrl = process.env.NEXT_PUBLIC_AUTH_URL;
+const internalKeycloakUrl = process.env.KEYCLOAK_INTERNAL_URL || publicKeycloakUrl;
+
 const UPDATE_USER = gql`
   mutation update_User($id: ID!) {
     updateFromKeycloak(userid: $id) {
@@ -46,7 +49,7 @@ export const updateUser = async (accessToken: string, userId: string) => {
 const refreshAccessToken = async (token: JWT) => {
   try {
     const refreshedTokens = await axios.post<IKeycloakRefreshTokenApiResponse>(
-      `${process.env.NEXTAUTH_URL}/api/auth/keycloakRefreshToken`,
+      `${process.env.NEXTAUTH_INTERNAL_URL || process.env.NEXTAUTH_URL}/api/auth/keycloakRefreshToken`,
       {
         refreshToken: token?.refreshToken,
       }
@@ -82,8 +85,15 @@ export default NextAuth({
         process.env.CLIENT_SECRET ||
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         process.env.NEXT_AUTH_CLIENT_SECRET!,
-      authorization: `${process.env.NEXT_PUBLIC_AUTH_URL}/auth`,
-      issuer: `${process.env.NEXT_PUBLIC_AUTH_URL}/realms/edu-hub`,
+      // The browser uses the selected LAN/Tailscale hostname. OAuth backchannel
+      // calls stay on Docker's private network, so authentication also works
+      // when that hostname is not resolvable from inside the container.
+      wellKnown: undefined,
+      authorization: `${publicKeycloakUrl}/realms/edu-hub/protocol/openid-connect/auth`,
+      token: `${internalKeycloakUrl}/realms/edu-hub/protocol/openid-connect/token`,
+      userinfo: `${internalKeycloakUrl}/realms/edu-hub/protocol/openid-connect/userinfo`,
+      jwks_endpoint: `${internalKeycloakUrl}/realms/edu-hub/protocol/openid-connect/certs`,
+      issuer: `${publicKeycloakUrl}/realms/edu-hub`,
       idToken: true,
     }),
   ],

--- a/frontend-nx/apps/edu-hub/pages/api/auth/keycloakRefreshToken.ts
+++ b/frontend-nx/apps/edu-hub/pages/api/auth/keycloakRefreshToken.ts
@@ -25,7 +25,9 @@ const keycloakRefreshToken = async (
 ) => {
   if (request.method === 'POST') {
     try {
-      const keycloakUrlToRefreshToken = `${process.env.NEXT_PUBLIC_AUTH_URL}/realms/edu-hub/protocol/openid-connect/token`;
+      const keycloakUrlToRefreshToken = `${
+        process.env.KEYCLOAK_INTERNAL_URL || process.env.NEXT_PUBLIC_AUTH_URL
+      }/realms/edu-hub/protocol/openid-connect/token`;
       const keycloakParamsToRefreshToken = new URLSearchParams();
       const keycloakRefreshTokenBody =
         request.body as IKeycloakRefreshTokenParams['body'];

--- a/keycloak/start-dev.sh
+++ b/keycloak/start-dev.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+set -eu
+
+dev_host=${DEV_HOST:-localhost}
+ssl_required=${DEV_KEYCLOAK_SSL_REQUIRED:-external}
+
+if ! printf '%s' "$dev_host" | grep -Eq '^[A-Za-z0-9][A-Za-z0-9.-]*$'; then
+  echo "DEV_HOST must be a hostname or IPv4 address (received: $dev_host)" >&2
+  exit 1
+fi
+
+case "$ssl_required" in
+  external|none) ;;
+  *)
+    echo "DEV_KEYCLOAK_SSL_REQUIRED must be external or none" >&2
+    exit 1
+    ;;
+esac
+
+# Keep the checked-in realm directly importable/exportable. Preview-only values
+# are applied to a temporary copy and never written back to the repository.
+sed \
+  -e "s/\"sslRequired\": \"external\"/\"sslRequired\": \"$ssl_required\"/" \
+  -e "s#\"http://localhost:5001/\\*\"#\"http://localhost:5001/*\",\n        \"http://$dev_host:5000/*\",\n        \"http://$dev_host:5001/*\"#" \
+  /opt/keycloak/data/import/edu-hub.json \
+  > /tmp/edu-hub.json
+
+unset KC_BOOTSTRAP_ADMIN_USERNAME KC_BOOTSTRAP_ADMIN_PASSWORD
+/opt/keycloak/bin/kc.sh import --optimized \
+  --file /opt/keycloak/data/import/master.json \
+  --override true
+/opt/keycloak/bin/kc.sh import --optimized \
+  --file /tmp/edu-hub.json \
+  --override false
+
+exec /opt/keycloak/bin/kc.sh start --optimized \
+  --spi-theme-cache-themes=false \
+  --spi-theme-cache-templates=false

--- a/scripts/start-network-preview.sh
+++ b/scripts/start-network-preview.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -eu
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 <LAN-or-Tailscale-IPv4> [docker compose up options]" >&2
+  exit 1
+fi
+
+dev_host=$1
+shift
+
+if ! printf '%s\n' "$dev_host" | awk -F. '
+  NF != 4 { exit 1 }
+  {
+    for (i = 1; i <= 4; i++) {
+      if ($i !~ /^[0-9]+$/ || $i < 0 || $i > 255) exit 1
+    }
+  }
+'; then
+  echo "Preview host must be an IPv4 address (received: $dev_host)" >&2
+  exit 1
+fi
+
+echo "Starting network preview at http://$dev_host:5000 and http://$dev_host:5001"
+echo "Warning: development services and credentials will be reachable on $dev_host."
+
+export DEV_BIND_ADDRESS="$dev_host"
+export DEV_HOST="$dev_host"
+export DEV_KEYCLOAK_SSL_REQUIRED=none
+
+exec docker compose up "$@"

--- a/scripts/start-network-preview.sh
+++ b/scripts/start-network-preview.sh
@@ -2,7 +2,7 @@
 set -eu
 
 if [ "$#" -lt 1 ]; then
-  echo "Usage: $0 <LAN-or-Tailscale-IPv4> [docker compose up options]" >&2
+  echo "Usage: $0 <Tailscale-IPv4> [docker compose up options]" >&2
   exit 1
 fi
 
@@ -15,17 +15,39 @@ if ! printf '%s\n' "$dev_host" | awk -F. '
     for (i = 1; i <= 4; i++) {
       if ($i !~ /^[0-9]+$/ || $i < 0 || $i > 255) exit 1
     }
+    if ($1 != 100 || $2 < 64 || $2 > 127) exit 1
   }
 '; then
-  echo "Preview host must be an IPv4 address (received: $dev_host)" >&2
+  echo "Preview host must be a Tailscale IPv4 address (received: $dev_host)" >&2
+  exit 1
+fi
+
+if command -v ip >/dev/null 2>&1; then
+  local_ipv4_addresses=$(ip -o -4 addr show | awk '{ split($4, a, "/"); print a[1] }')
+elif command -v ifconfig >/dev/null 2>&1; then
+  local_ipv4_addresses=$(ifconfig | awk '$1 == "inet" { print $2 }')
+else
+  echo "Could not inspect this machine's network interfaces." >&2
+  exit 1
+fi
+
+if ! printf '%s\n' "$local_ipv4_addresses" | grep -Fqx "$dev_host"; then
+  echo "Preview host is not assigned to this machine: $dev_host" >&2
+  exit 1
+fi
+
+if ! command -v openssl >/dev/null 2>&1; then
+  echo "OpenSSL is required to generate a temporary Hasura admin secret." >&2
   exit 1
 fi
 
 echo "Starting network preview at http://$dev_host:5000 and http://$dev_host:5001"
-echo "Warning: development services and credentials will be reachable on $dev_host."
+echo "Development services will be reachable only through this Tailscale address."
 
 export DEV_BIND_ADDRESS="$dev_host"
 export DEV_HOST="$dev_host"
 export DEV_KEYCLOAK_SSL_REQUIRED=none
+DEV_HASURA_ADMIN_SECRET=$(openssl rand -hex 32)
+export DEV_HASURA_ADMIN_SECRET
 
 exec docker compose up "$@"


### PR DESCRIPTION
## Summary

- Add an opt-in script for previewing EduHub and StuJo from a LAN or Tailscale IPv4 address.
- Keep Docker services bound to localhost by default.
- Configure browser-facing URLs and internal Docker backchannel endpoints for authentication.
- Add temporary Keycloak realm settings for preview hosts and document usage and security considerations.

## Testing

- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional network preview mode for accessing the development environment from phones or other devices over LAN or Tailscale.
  - Added configurable host and port behavior for frontend, authentication, storage, and backend services.
  - Added automatic development authentication setup for custom host addresses.

- **Documentation**
  - Documented network preview setup, available service URLs, security considerations, and returning to localhost-only access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->