### PR TITLE
Improve StuJo responsive mobile layout and accessibility

### DIFF
--- a/frontend-nx/apps/stujo/components/Layout.tsx
+++ b/frontend-nx/apps/stujo/components/Layout.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { signIn, signOut, useSession } from 'next-auth/react';
-import { FC, PropsWithChildren, useCallback } from 'react';
+import { FC, PropsWithChildren, useCallback, useEffect, useState } from 'react';
 import { useTranslations } from 'next-intl';
 
 import type { PortalBranding } from '../lib/portal';
@@ -24,6 +24,13 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
   const t = useTranslations('common');
   const tLayout = useTranslations('common.Layout');
   const router = useRouter();
+  const [accountMenuOpen, setAccountMenuOpen] = useState(false);
+  const [navigationOpen, setNavigationOpen] = useState(false);
+
+  useEffect(() => {
+    setAccountMenuOpen(false);
+    setNavigationOpen(false);
+  }, [router.asPath, router.locale]);
   const { status: sessionStatus } = useSession();
 
   // Keycloak end-session logout, same flow as the edu-hub app: fetch the
@@ -100,16 +107,43 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
             where the runtime injects the compiled stylesheet. */}
         {styleVars && <style>{`:root:root { ${styleVars} }`}</style>}
       </Head>
-      <header className="stujo-header">
+      <header
+        className="stujo-header"
+        onKeyDown={(event) => {
+          if (event.key === 'Escape' && accountMenuOpen) {
+            setAccountMenuOpen(false);
+            event.currentTarget.querySelector<HTMLButtonElement>('.stujo-menu-toggle')?.focus();
+          }
+        }}
+      >
         <img src="/stujo_header_diag.png" alt="" className="stujo-header-diag" />
         <Link href="/">
-          <img
-            src={portal.logoUrl || '/stujo_header_logo.png'}
-            alt={portal.title}
-            className="stujo-header-logo"
-          />
+          <picture>
+            {(!portal.logoUrl || portal.logoUrl.endsWith('/stujo_header_logo.png')) && (
+              <source media="(max-width: 767px)" srcSet="/stujo_bird.png" />
+            )}
+            <img
+              src={portal.logoUrl || '/stujo_header_logo.png'}
+              alt={portal.title}
+              className="stujo-header-logo"
+            />
+          </picture>
         </Link>
-        <nav className="stujo-header-topnav">
+        <button
+          type="button"
+          className="stujo-menu-toggle stujo-account-toggle"
+          aria-label={tLayout('account_menu')}
+          aria-expanded={accountMenuOpen}
+          aria-controls="stujo-account-menu"
+          onClick={() => setAccountMenuOpen((open) => !open)}
+        >
+          <span aria-hidden="true">{accountMenuOpen ? '×' : '☰'}</span>
+        </button>
+        <nav
+          id="stujo-account-menu"
+          aria-label={tLayout('account_menu')}
+          className={`stujo-header-topnav${accountMenuOpen ? ' stujo-header-topnav--open' : ''}`}
+        >
           <span className="stujo-lang-switch">
             <Link
               href={router.asPath}
@@ -173,8 +207,32 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
           )}
         </nav>
       </header>
-      <nav className="stujo-nav">
-        <div className="stujo-container stujo-nav-inner">
+      <nav
+        className="stujo-nav"
+        aria-label={tLayout('navigation')}
+        onKeyDown={(event) => {
+          if (event.key === 'Escape' && navigationOpen) {
+            setNavigationOpen(false);
+            event.currentTarget.querySelector<HTMLButtonElement>('.stujo-menu-toggle')?.focus();
+          }
+        }}
+      >
+        <div className="stujo-container">
+          <button
+            type="button"
+            className="stujo-menu-toggle stujo-navigation-toggle"
+            aria-expanded={navigationOpen}
+            aria-controls="stujo-navigation-menu"
+            onClick={() => setNavigationOpen((open) => !open)}
+          >
+            {tLayout('navigation')}
+            <span aria-hidden="true">{navigationOpen ? '⌃' : '⌄'}</span>
+          </button>
+        </div>
+        <div
+          id="stujo-navigation-menu"
+          className={`stujo-container stujo-nav-inner${navigationOpen ? ' stujo-nav-inner--open' : ''}`}
+        >
           <Link href="/" className={`stujo-nav-home ${navClass('/') ?? ''}`} aria-label={tLayout('home')}>
             <StuJoLegacyIcon name="home" className="stujo-nav-home-icon" />
           </Link>

--- a/frontend-nx/apps/stujo/components/Layout.tsx
+++ b/frontend-nx/apps/stujo/components/Layout.tsx
@@ -2,7 +2,7 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { signIn, signOut, useSession } from 'next-auth/react';
-import { FC, PropsWithChildren, useCallback, useEffect, useState } from 'react';
+import { FC, PropsWithChildren, useCallback } from 'react';
 import { useTranslations } from 'next-intl';
 
 import type { PortalBranding } from '../lib/portal';
@@ -24,13 +24,6 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
   const t = useTranslations('common');
   const tLayout = useTranslations('common.Layout');
   const router = useRouter();
-  const [accountMenuOpen, setAccountMenuOpen] = useState(false);
-  const [navigationOpen, setNavigationOpen] = useState(true);
-
-  useEffect(() => {
-    setAccountMenuOpen(false);
-    setNavigationOpen(true);
-  }, [router.asPath, router.locale]);
   const { status: sessionStatus } = useSession();
 
   // Keycloak end-session logout, same flow as the edu-hub app: fetch the
@@ -107,43 +100,16 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
             where the runtime injects the compiled stylesheet. */}
         {styleVars && <style>{`:root:root { ${styleVars} }`}</style>}
       </Head>
-      <header
-        className="stujo-header"
-        onKeyDown={(event) => {
-          if (event.key === 'Escape' && accountMenuOpen) {
-            setAccountMenuOpen(false);
-            event.currentTarget.querySelector<HTMLButtonElement>('.stujo-menu-toggle')?.focus();
-          }
-        }}
-      >
+      <header className="stujo-header">
         <img src="/stujo_header_diag.png" alt="" className="stujo-header-diag" />
         <Link href="/">
-          <picture>
-            {(!portal.logoUrl || portal.logoUrl.endsWith('/stujo_header_logo.png')) && (
-              <source media="(max-width: 767px)" srcSet="/stujo_bird.png" />
-            )}
-            <img
-              src={portal.logoUrl || '/stujo_header_logo.png'}
-              alt={portal.title}
-              className="stujo-header-logo"
-            />
-          </picture>
+          <img
+            src={portal.logoUrl || '/stujo_header_logo.png'}
+            alt={portal.title}
+            className="stujo-header-logo"
+          />
         </Link>
-        <button
-          type="button"
-          className="stujo-menu-toggle stujo-account-toggle"
-          aria-label={tLayout('account_menu')}
-          aria-expanded={accountMenuOpen}
-          aria-controls="stujo-account-menu"
-          onClick={() => setAccountMenuOpen((open) => !open)}
-        >
-          <StuJoLegacyIcon name={accountMenuOpen ? 'close' : 'menu'} className="stujo-menu-icon" />
-        </button>
-        <nav
-          id="stujo-account-menu"
-          aria-label={tLayout('account_menu')}
-          className={`stujo-header-topnav${accountMenuOpen ? ' stujo-header-topnav--open' : ''}`}
-        >
+        <nav className="stujo-header-topnav" aria-label={tLayout('account_menu')}>
           <span className="stujo-lang-switch">
             <Link
               href={router.asPath}
@@ -207,35 +173,8 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
           )}
         </nav>
       </header>
-      <nav
-        className="stujo-nav"
-        aria-label={tLayout('navigation')}
-        onKeyDown={(event) => {
-          if (event.key === 'Escape' && navigationOpen) {
-            setNavigationOpen(false);
-            event.currentTarget.querySelector<HTMLButtonElement>('.stujo-menu-toggle')?.focus();
-          }
-        }}
-      >
-        <div className="stujo-container">
-          <button
-            type="button"
-            className="stujo-menu-toggle stujo-navigation-toggle"
-            aria-label={tLayout('navigation')}
-            aria-expanded={navigationOpen}
-            aria-controls="stujo-navigation-menu"
-            onClick={() => setNavigationOpen((open) => !open)}
-          >
-            <StuJoLegacyIcon
-              name={navigationOpen ? 'chevron-up' : 'chevron-down'}
-              className="stujo-menu-icon"
-            />
-          </button>
-        </div>
-        <div
-          id="stujo-navigation-menu"
-          className={`stujo-container stujo-nav-inner${navigationOpen ? ' stujo-nav-inner--open' : ''}`}
-        >
+      <nav className="stujo-nav" aria-label={tLayout('navigation')}>
+        <div className="stujo-container stujo-nav-inner">
           <Link href="/" className={`stujo-nav-home ${navClass('/') ?? ''}`} aria-label={tLayout('home')}>
             <StuJoLegacyIcon name="home" className="stujo-nav-home-icon" />
           </Link>

--- a/frontend-nx/apps/stujo/components/Layout.tsx
+++ b/frontend-nx/apps/stujo/components/Layout.tsx
@@ -25,11 +25,11 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
   const tLayout = useTranslations('common.Layout');
   const router = useRouter();
   const [accountMenuOpen, setAccountMenuOpen] = useState(false);
-  const [navigationOpen, setNavigationOpen] = useState(false);
+  const [navigationOpen, setNavigationOpen] = useState(true);
 
   useEffect(() => {
     setAccountMenuOpen(false);
-    setNavigationOpen(false);
+    setNavigationOpen(true);
   }, [router.asPath, router.locale]);
   const { status: sessionStatus } = useSession();
 
@@ -137,7 +137,7 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
           aria-controls="stujo-account-menu"
           onClick={() => setAccountMenuOpen((open) => !open)}
         >
-          <span aria-hidden="true">{accountMenuOpen ? '×' : '☰'}</span>
+          <StuJoLegacyIcon name={accountMenuOpen ? 'close' : 'menu'} className="stujo-menu-icon" />
         </button>
         <nav
           id="stujo-account-menu"
@@ -221,12 +221,15 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
           <button
             type="button"
             className="stujo-menu-toggle stujo-navigation-toggle"
+            aria-label={tLayout('navigation')}
             aria-expanded={navigationOpen}
             aria-controls="stujo-navigation-menu"
             onClick={() => setNavigationOpen((open) => !open)}
           >
-            {tLayout('navigation')}
-            <span aria-hidden="true">{navigationOpen ? '⌃' : '⌄'}</span>
+            <StuJoLegacyIcon
+              name={navigationOpen ? 'chevron-up' : 'chevron-down'}
+              className="stujo-menu-icon"
+            />
           </button>
         </div>
         <div

--- a/frontend-nx/apps/stujo/components/StuJoLegacyIcon.tsx
+++ b/frontend-nx/apps/stujo/components/StuJoLegacyIcon.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 
-type StuJoLegacyIconName = 'home' | 'plus' | 'search' | 'unlocked' | 'menu' | 'close' | 'chevron-up' | 'chevron-down';
+type StuJoLegacyIconName = 'home' | 'plus' | 'search' | 'unlocked';
 
 interface Props {
   className?: string;
@@ -8,27 +8,6 @@ interface Props {
 }
 
 const glyphs: Record<StuJoLegacyIconName, { path: string; transform: string; viewBox: string }> = {
-  // Solid geometric controls matching the weight of the legacy glyphs.
-  menu: {
-    path: 'M2 3h20v4H2zM2 10h20v4H2zM2 17h20v4H2z',
-    transform: '',
-    viewBox: '0 0 24 24',
-  },
-  close: {
-    path: 'M5 2l7 7 7-7 3 3-7 7 7 7-3 3-7-7-7 7-3-3 7-7-7-7z',
-    transform: '',
-    viewBox: '0 0 24 24',
-  },
-  'chevron-down': {
-    path: 'M2 5l10 10L22 5l4 4-14 14L-2 9z',
-    transform: 'translate(2 0)',
-    viewBox: '0 0 28 28',
-  },
-  'chevron-up': {
-    path: 'M2 5l10 10L22 5l4 4-14 14L-2 9z',
-    transform: 'translate(26 28) rotate(180)',
-    viewBox: '0 0 28 28',
-  },
   // Bootstrap 3.4.1 Glyphicons Halflings, code point U+E021.
   home: {
     path: 'M18 618l620 608q8 7 18.5 7t17.5-7l608-608q8-8 5.5-13t-12.5-5h-175v-575q0-10-7.5-17.5t-17.5-7.5h-250q-10 0-17.5 7.5t-7.5 17.5v375h-300v-375q0-10-7.5-17.5t-17.5-7.5h-250q-10 0-17.5 7.5t-7.5 17.5v575h-175q-10 0-12.5 5t5.5 13z',

--- a/frontend-nx/apps/stujo/components/StuJoLegacyIcon.tsx
+++ b/frontend-nx/apps/stujo/components/StuJoLegacyIcon.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 
-type StuJoLegacyIconName = 'home' | 'plus' | 'search' | 'unlocked';
+type StuJoLegacyIconName = 'home' | 'plus' | 'search' | 'unlocked' | 'menu' | 'close' | 'chevron-up' | 'chevron-down';
 
 interface Props {
   className?: string;
@@ -8,6 +8,27 @@ interface Props {
 }
 
 const glyphs: Record<StuJoLegacyIconName, { path: string; transform: string; viewBox: string }> = {
+  // Solid geometric controls matching the weight of the legacy glyphs.
+  menu: {
+    path: 'M2 3h20v4H2zM2 10h20v4H2zM2 17h20v4H2z',
+    transform: '',
+    viewBox: '0 0 24 24',
+  },
+  close: {
+    path: 'M5 2l7 7 7-7 3 3-7 7 7 7-3 3-7-7-7 7-3-3 7-7-7-7z',
+    transform: '',
+    viewBox: '0 0 24 24',
+  },
+  'chevron-down': {
+    path: 'M2 5l10 10L22 5l4 4-14 14L-2 9z',
+    transform: 'translate(2 0)',
+    viewBox: '0 0 28 28',
+  },
+  'chevron-up': {
+    path: 'M2 5l10 10L22 5l4 4-14 14L-2 9z',
+    transform: 'translate(26 28) rotate(180)',
+    viewBox: '0 0 28 28',
+  },
   // Bootstrap 3.4.1 Glyphicons Halflings, code point U+E021.
   home: {
     path: 'M18 618l620 608q8 7 18.5 7t17.5-7l608-608q8-8 5.5-13t-12.5-5h-175v-575q0-10-7.5-17.5t-17.5-7.5h-250q-10 0-17.5 7.5t-7.5 17.5v375h-300v-375q0-10-7.5-17.5t-17.5-7.5h-250q-10 0-17.5 7.5t-7.5 17.5v575h-175q-10 0-12.5 5t5.5 13z',

--- a/frontend-nx/apps/stujo/locales/de.json
+++ b/frontend-nx/apps/stujo/locales/de.json
@@ -43,6 +43,8 @@
     "footerUniversityPartners": "Hochschulpartner",
     "footerPartners": "Gefördert durch",
     "Layout": {
+      "account_menu": "Sprache und Konto",
+      "navigation": "Navigation",
       "home": "Startseite",
       "switch_to_german": "Auf Deutsch wechseln",
       "switch_to_english": "Auf Englisch wechseln"

--- a/frontend-nx/apps/stujo/locales/en.json
+++ b/frontend-nx/apps/stujo/locales/en.json
@@ -43,6 +43,8 @@
     "footerUniversityPartners": "University partners",
     "footerPartners": "Sponsored by",
     "Layout": {
+      "account_menu": "Language and account",
+      "navigation": "Navigation",
       "home": "Home",
       "switch_to_german": "Switch to German",
       "switch_to_english": "Switch to English"

--- a/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
@@ -21,6 +21,22 @@ import { portalHost } from '../../lib/requestHost';
 
 type Props = { portal: PortalBranding };
 
+type JobPosting = {
+  id: number;
+  title: string;
+  type: string;
+  status: string;
+  views: number | null;
+  expiresAt: string | null;
+};
+
+type PostingActionsProps = {
+  posting: JobPosting;
+  publishing: boolean;
+  onPublish: (jobPostingId: number) => void;
+  onArchive: (jobPostingId: number) => void;
+};
+
 // Status label text lives in the `meinStujo.status` translation namespace;
 // only the chip styling is kept here (keyed by the same status value).
 const STATUS_CLASSNAMES: Record<string, string> = {
@@ -38,6 +54,52 @@ const formatDate = (value: string | null) =>
   value
     ? new Date(value).toLocaleDateString('de-DE', { timeZone: 'Europe/Berlin' })
     : '–';
+
+const PostingActions: FC<PostingActionsProps> = ({
+  posting,
+  publishing,
+  onPublish,
+  onArchive,
+}) => {
+  const t = useTranslations('meinStujo');
+
+  return (
+    <div className="stujo-posting-actions">
+      <Link
+        href={`/mein-stujo/neu?id=${posting.id}`}
+        className="stujo-button-pen"
+        title={t('edit')}
+        aria-label={t('edit')}
+      />
+      {(posting.status === 'DRAFT' || posting.status === 'PENDING_PAYMENT') && (
+        <button
+          className="stujo-btn stujo-btn--small"
+          disabled={publishing}
+          onClick={() => onPublish(posting.id)}
+        >
+          {t('publish')}
+        </button>
+      )}
+      {posting.status === 'EXPIRED' && (
+        <button
+          className="stujo-btn stujo-btn--small"
+          disabled={publishing}
+          onClick={() => onPublish(posting.id)}
+        >
+          {t('repost')}
+        </button>
+      )}
+      {posting.status === 'PUBLISHED' && (
+        <button
+          className="stujo-btn stujo-btn--small stujo-btn--ghost"
+          onClick={() => onArchive(posting.id)}
+        >
+          {t('archive')}
+        </button>
+      )}
+    </div>
+  );
+};
 
 /**
  * Employer dashboard ("Mein StuJo") — postings table, stats and the
@@ -167,6 +229,8 @@ const MeinStujo: FC<Props> = ({ portal }) => {
     };
   }, [data, organization]);
 
+  const postings: JobPosting[] = data?.JobPosting ?? [];
+
   if (sessionStatus !== 'authenticated' || orgsLoading) {
     return (
       <Layout portal={portal}>
@@ -255,91 +319,93 @@ const MeinStujo: FC<Props> = ({ portal }) => {
         ))}
       </div>
 
-      <div className="stujo-table-scroll" role="region" aria-label={t('title')} tabIndex={0}>
-        <table className="stujo-table">
-          <thead>
-            <tr>
-              <th>{t('colOffer')}</th>
-              <th>{t('colCategory')}</th>
-              <th>{t('colStatus')}</th>
-              <th>{t('colViews')}</th>
-              <th>{t('colExpires')}</th>
-              <th />
-            </tr>
-          </thead>
-          <tbody>
-            {loading && !data && (
-              <tr>
-                <td colSpan={6} className="stujo-muted">
-                  {t('loading')}
-                </td>
-              </tr>
-            )}
-            {data?.JobPosting?.map((posting: any) => {
+      {loading && !data ? (
+        <p className="stujo-muted">{t('loading')}</p>
+      ) : postings.length === 0 ? (
+        <p className="stujo-muted">{t('noOffers')}</p>
+      ) : (
+        <>
+          <ul className="stujo-posting-list" aria-label={t('title')}>
+            {postings.map((posting) => {
               const statusClassName =
                 STATUS_CLASSNAMES[posting.status] ?? STATUS_CLASSNAMES.DRAFT;
+
               return (
-                <tr key={posting.id}>
-                  <td>
-                    <Link href={`/mein-stujo/neu?id=${posting.id}`} style={{ fontWeight: 600 }}>
-                      {posting.title}
-                    </Link>
-                  </td>
-                  <td className="stujo-muted">{tType(posting.type)}</td>
-                  <td>
+                <li key={posting.id} className="stujo-posting-card">
+                  <div className="stujo-posting-card-head">
+                    <h2 className="stujo-posting-card-title">
+                      <Link href={`/mein-stujo/neu?id=${posting.id}`}>{posting.title}</Link>
+                    </h2>
                     <span className={statusClassName}>{t(`status.${posting.status}`)}</span>
-                  </td>
-                  <td className="stujo-muted">{posting.views}</td>
-                  <td className="stujo-muted">{formatDate(posting.expiresAt)}</td>
-                  <td>
-                    <div className="stujo-posting-actions">
-                      <Link
-                        href={`/mein-stujo/neu?id=${posting.id}`}
-                        className="stujo-button-pen"
-                        title={t('edit')}
-                        aria-label={t('edit')}
-                      />
-                      {(posting.status === 'DRAFT' || posting.status === 'PENDING_PAYMENT') && (
-                        <button
-                          className="stujo-btn stujo-btn--small"
-                          disabled={publishing}
-                          onClick={() => handlePublish(posting.id)}
-                        >
-                          {t('publish')}
-                        </button>
-                      )}
-                      {posting.status === 'EXPIRED' && (
-                        <button
-                          className="stujo-btn stujo-btn--small"
-                          disabled={publishing}
-                          onClick={() => handlePublish(posting.id)}
-                        >
-                          {t('repost')}
-                        </button>
-                      )}
-                      {posting.status === 'PUBLISHED' && (
-                        <button
-                          className="stujo-btn stujo-btn--small stujo-btn--ghost"
-                          onClick={() => handleArchive(posting.id)}
-                        >
-                          {t('archive')}
-                        </button>
-                      )}
+                  </div>
+                  <dl className="stujo-posting-details">
+                    <div>
+                      <dt>{t('colCategory')}</dt>
+                      <dd>{tType(posting.type)}</dd>
                     </div>
-                  </td>
-                </tr>
+                    <div>
+                      <dt>{t('colViews')}</dt>
+                      <dd>{posting.views}</dd>
+                    </div>
+                    <div>
+                      <dt>{t('colExpires')}</dt>
+                      <dd>{formatDate(posting.expiresAt)}</dd>
+                    </div>
+                  </dl>
+                  <PostingActions
+                    posting={posting}
+                    publishing={publishing}
+                    onPublish={handlePublish}
+                    onArchive={handleArchive}
+                  />
+                </li>
               );
             })}
-            {data?.JobPosting?.length === 0 && (
+          </ul>
+
+          <table className="stujo-table stujo-postings-table">
+            <thead>
               <tr>
-                <td colSpan={6} className="stujo-muted">
-                  {t('noOffers')}
-                </td>
+                <th>{t('colOffer')}</th>
+                <th>{t('colCategory')}</th>
+                <th>{t('colStatus')}</th>
+                <th>{t('colViews')}</th>
+                <th>{t('colExpires')}</th>
+                <th />
               </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
+            </thead>
+            <tbody>
+              {postings.map((posting) => {
+                const statusClassName =
+                  STATUS_CLASSNAMES[posting.status] ?? STATUS_CLASSNAMES.DRAFT;
+                return (
+                  <tr key={posting.id}>
+                    <td>
+                      <Link href={`/mein-stujo/neu?id=${posting.id}`} style={{ fontWeight: 600 }}>
+                        {posting.title}
+                      </Link>
+                    </td>
+                    <td className="stujo-muted">{tType(posting.type)}</td>
+                    <td>
+                      <span className={statusClassName}>{t(`status.${posting.status}`)}</span>
+                    </td>
+                    <td className="stujo-muted">{posting.views}</td>
+                    <td className="stujo-muted">{formatDate(posting.expiresAt)}</td>
+                    <td>
+                      <PostingActions
+                        posting={posting}
+                        publishing={publishing}
+                        onPublish={handlePublish}
+                        onArchive={handleArchive}
+                      />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </>
+      )}
     </Layout>
   );
 };

--- a/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
+++ b/frontend-nx/apps/stujo/pages/mein-stujo/index.tsx
@@ -255,89 +255,91 @@ const MeinStujo: FC<Props> = ({ portal }) => {
         ))}
       </div>
 
-      <table className="stujo-table">
-        <thead>
-          <tr>
-            <th>{t('colOffer')}</th>
-            <th>{t('colCategory')}</th>
-            <th>{t('colStatus')}</th>
-            <th>{t('colViews')}</th>
-            <th>{t('colExpires')}</th>
-            <th />
-          </tr>
-        </thead>
-        <tbody>
-          {loading && !data && (
+      <div className="stujo-table-scroll" role="region" aria-label={t('title')} tabIndex={0}>
+        <table className="stujo-table">
+          <thead>
             <tr>
-              <td colSpan={6} className="stujo-muted">
-                {t('loading')}
-              </td>
+              <th>{t('colOffer')}</th>
+              <th>{t('colCategory')}</th>
+              <th>{t('colStatus')}</th>
+              <th>{t('colViews')}</th>
+              <th>{t('colExpires')}</th>
+              <th />
             </tr>
-          )}
-          {data?.JobPosting?.map((posting: any) => {
-            const statusClassName =
-              STATUS_CLASSNAMES[posting.status] ?? STATUS_CLASSNAMES.DRAFT;
-            return (
-              <tr key={posting.id}>
-                <td>
-                  <Link href={`/mein-stujo/neu?id=${posting.id}`} style={{ fontWeight: 600 }}>
-                    {posting.title}
-                  </Link>
-                </td>
-                <td className="stujo-muted">{tType(posting.type)}</td>
-                <td>
-                  <span className={statusClassName}>{t(`status.${posting.status}`)}</span>
-                </td>
-                <td className="stujo-muted">{posting.views}</td>
-                <td className="stujo-muted">{formatDate(posting.expiresAt)}</td>
-                <td style={{ whiteSpace: 'nowrap' }}>
-                  <div className="stujo-table-actions">
-                    <Link
-                      href={`/mein-stujo/neu?id=${posting.id}`}
-                      className="stujo-button-pen"
-                      title={t('edit')}
-                      aria-label={t('edit')}
-                    />
-                    {(posting.status === 'DRAFT' || posting.status === 'PENDING_PAYMENT') && (
-                      <button
-                        className="stujo-btn stujo-btn--small"
-                        disabled={publishing}
-                        onClick={() => handlePublish(posting.id)}
-                      >
-                        {t('publish')}
-                      </button>
-                    )}
-                    {posting.status === 'EXPIRED' && (
-                      <button
-                        className="stujo-btn stujo-btn--small"
-                        disabled={publishing}
-                        onClick={() => handlePublish(posting.id)}
-                      >
-                        {t('repost')}
-                      </button>
-                    )}
-                    {posting.status === 'PUBLISHED' && (
-                      <button
-                        className="stujo-btn stujo-btn--small stujo-btn--ghost"
-                        onClick={() => handleArchive(posting.id)}
-                      >
-                        {t('archive')}
-                      </button>
-                    )}
-                  </div>
+          </thead>
+          <tbody>
+            {loading && !data && (
+              <tr>
+                <td colSpan={6} className="stujo-muted">
+                  {t('loading')}
                 </td>
               </tr>
-            );
-          })}
-          {data?.JobPosting?.length === 0 && (
-            <tr>
-              <td colSpan={6} className="stujo-muted">
-                {t('noOffers')}
-              </td>
-            </tr>
-          )}
-        </tbody>
-      </table>
+            )}
+            {data?.JobPosting?.map((posting: any) => {
+              const statusClassName =
+                STATUS_CLASSNAMES[posting.status] ?? STATUS_CLASSNAMES.DRAFT;
+              return (
+                <tr key={posting.id}>
+                  <td>
+                    <Link href={`/mein-stujo/neu?id=${posting.id}`} style={{ fontWeight: 600 }}>
+                      {posting.title}
+                    </Link>
+                  </td>
+                  <td className="stujo-muted">{tType(posting.type)}</td>
+                  <td>
+                    <span className={statusClassName}>{t(`status.${posting.status}`)}</span>
+                  </td>
+                  <td className="stujo-muted">{posting.views}</td>
+                  <td className="stujo-muted">{formatDate(posting.expiresAt)}</td>
+                  <td>
+                    <div className="stujo-posting-actions">
+                      <Link
+                        href={`/mein-stujo/neu?id=${posting.id}`}
+                        className="stujo-button-pen"
+                        title={t('edit')}
+                        aria-label={t('edit')}
+                      />
+                      {(posting.status === 'DRAFT' || posting.status === 'PENDING_PAYMENT') && (
+                        <button
+                          className="stujo-btn stujo-btn--small"
+                          disabled={publishing}
+                          onClick={() => handlePublish(posting.id)}
+                        >
+                          {t('publish')}
+                        </button>
+                      )}
+                      {posting.status === 'EXPIRED' && (
+                        <button
+                          className="stujo-btn stujo-btn--small"
+                          disabled={publishing}
+                          onClick={() => handlePublish(posting.id)}
+                        >
+                          {t('repost')}
+                        </button>
+                      )}
+                      {posting.status === 'PUBLISHED' && (
+                        <button
+                          className="stujo-btn stujo-btn--small stujo-btn--ghost"
+                          onClick={() => handleArchive(posting.id)}
+                        >
+                          {t('archive')}
+                        </button>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+            {data?.JobPosting?.length === 0 && (
+              <tr>
+                <td colSpan={6} className="stujo-muted">
+                  {t('noOffers')}
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
     </Layout>
   );
 };

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -496,7 +496,7 @@ button.stujo-header-action:hover {
   display: grid;
   grid-template-columns: 3fr 2fr;
   gap: 2.5rem;
-  padding: 1.5rem 0;
+  padding: 1.5rem 1rem;
 }
 
 @media (max-width: 768px) {
@@ -984,4 +984,135 @@ button.stujo-header-action:hover {
 
 .stujo-section-head h2 {
   margin: 0;
+}
+
+/* Mobile disclosures retain the portal colors and keep content in flow. */
+.stujo-menu-toggle {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .stujo-header {
+    height: auto;
+    min-height: 150px;
+    padding: 110px 1rem 1rem;
+  }
+
+  .stujo-header-diag {
+    width: 100%;
+    height: 90px;
+  }
+
+  .stujo-header-logo {
+    top: 12px;
+    left: 16px;
+    width: auto;
+    max-width: 140px;
+    height: 44px;
+    object-position: left center;
+  }
+
+  .stujo-menu-toggle {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    min-height: 48px;
+    border: 0;
+    font: inherit;
+    font-weight: 700;
+    cursor: pointer;
+    touch-action: manipulation;
+  }
+
+  .stujo-menu-toggle:focus-visible {
+    outline: 3px solid var(--stujo-primary);
+    outline-offset: 3px;
+  }
+
+  .stujo-account-toggle {
+    position: absolute;
+    top: 56px;
+    right: 1rem;
+    justify-content: center;
+    width: 48px;
+    background: #fff;
+    color: var(--stujo-primary);
+    font-size: 30px;
+    line-height: 1;
+  }
+
+  .stujo-header-topnav {
+    position: static;
+    display: none;
+    width: min(100%, 280px);
+    margin-left: auto;
+    padding: 12px 20px;
+    background: var(--stujo-secondary);
+    border-radius: 4px;
+    gap: 4px;
+  }
+
+  .stujo-header-topnav--open {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .stujo-header-topnav .stujo-header-action {
+    min-height: 48px;
+  }
+
+  .stujo-header-topnav a:hover,
+  .stujo-header-topnav button:hover {
+    color: var(--stujo-primary);
+  }
+
+  .stujo-lang-switch > a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 44px;
+    min-height: 48px;
+  }
+
+  .stujo-navigation-toggle {
+    width: 100%;
+    padding: 8px 0;
+    color: #fff;
+    background: transparent;
+    text-transform: uppercase;
+    font-size: 18px;
+  }
+
+  .stujo-navigation-toggle span {
+    font-size: 28px;
+  }
+
+  .stujo-nav-inner {
+    display: none;
+    padding-bottom: 12px;
+  }
+
+  .stujo-nav-inner--open {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .stujo-nav a {
+    min-height: 48px;
+    padding: 10px 12px;
+  }
+
+  .stujo-landing-cols > div,
+  .stujo-job-row > div {
+    min-width: 0;
+    overflow-wrap: anywhere;
+  }
+
+  .stujo-job-row {
+    flex-wrap: wrap;
+  }
+
+  .stujo-job-row > div {
+    flex: 1 1 220px;
+  }
 }

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -168,27 +168,27 @@ a:focus {
   position: absolute;
   left: 0;
   top: 0;
-  /* Span 70% of the header width so the white wedge crosses the top edge at
-     ~70% and purple covers the rest, matching the live stujo.net banner. The
-     PNG's diagonal angle already matches; anchoring left keeps the purple
-     starting far left. */
-  width: 70%;
+  /* Keep the native angle and crop the artwork on small screens. These
+     minimum dimensions also apply above the mobile breakpoint. */
+  width: max(720px, 70%);
+  height: auto;
   pointer-events: none;
 }
 
 .stujo-header-logo {
   position: absolute;
-  top: 1.5em;
-  left: 1.5em;
-  width: 13%;
-  max-width: 180px;
+  top: 16px;
+  left: 16px;
+  width: clamp(136px, 13%, 180px);
   height: auto;
   object-fit: contain;
 }
 
 .stujo-header-topnav {
   position: absolute;
-  top: 1.2em;
+  /* Clear the minimum-size wedge at tablet widths, then approach the
+     original desktop position continuously as more room becomes available. */
+  top: clamp(1.2em, calc(300px - 26vw), 100px);
   right: 1.5em;
   display: flex;
   gap: 1.5rem;
@@ -986,108 +986,53 @@ button.stujo-header-action:hover {
   margin: 0;
 }
 
-/* Mobile disclosures retain the portal colors and keep content in flow. */
-.stujo-menu-toggle {
-  display: none;
-}
-
+/* Visible mobile account actions and navigation, using the desktop branding. */
 @media (max-width: 767px) {
   .stujo-header {
     height: auto;
-    min-height: 150px;
-    padding: 110px 1rem 1rem;
-  }
-
-  .stujo-header-diag {
-    width: 100%;
-    height: 90px;
-  }
-
-  .stujo-header-logo {
-    top: 12px;
-    left: 16px;
-    width: auto;
-    max-width: 140px;
-    height: 44px;
-    object-position: left center;
-  }
-
-  .stujo-menu-toggle {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    min-height: 48px;
-    border: 0;
-    font: inherit;
-    font-weight: 700;
-    cursor: pointer;
-    touch-action: manipulation;
-  }
-
-  .stujo-menu-toggle:focus-visible {
-    outline: 3px solid var(--stujo-primary);
-    outline-offset: 3px;
-  }
-
-  .stujo-account-toggle {
-    position: absolute;
-    top: 56px;
-    right: 1rem;
-    justify-content: center;
-    width: 48px;
-    background: #fff;
-    color: var(--stujo-primary);
-  }
-
-  .stujo-menu-icon {
-    width: 28px;
-    height: 28px;
-    flex: none;
+    min-height: 210px;
+    padding: 100px 16px 16px;
   }
 
   .stujo-header-topnav {
     position: static;
-    display: none;
-    width: min(100%, 280px);
-    margin-left: auto;
-    padding: 12px 20px;
-    background: var(--stujo-secondary);
-    border-radius: 4px;
-    gap: 4px;
-  }
-
-  .stujo-header-topnav--open {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: max-content max-content;
+    justify-content: end;
+    gap: 2px 22px;
+    width: 100%;
+    font-size: 15px;
   }
 
   .stujo-header-topnav .stujo-header-action {
-    min-height: 48px;
+    min-height: 44px;
   }
 
-  .stujo-header-topnav a:hover,
-  .stujo-header-topnav button:hover {
-    color: var(--stujo-primary);
+  .stujo-header-topnav > button {
+    grid-column: 2;
+  }
+
+  .stujo-lang-switch {
+    grid-column: 1 / -1;
+    justify-self: end;
   }
 
   .stujo-lang-switch > a {
     display: flex;
     align-items: center;
     justify-content: center;
-    min-width: 44px;
-    min-height: 48px;
+    min-width: 36px;
+    min-height: 44px;
   }
 
-  .stujo-navigation-toggle {
-    width: 100%;
-    justify-content: flex-end;
-    padding: 8px 10px;
-    color: #fff;
-    background: transparent;
+  .stujo-lang-switch .stujo-lang-toggle {
+    width: 44px;
+    height: 44px;
   }
 
   .stujo-nav-inner {
-    display: none;
+    flex-direction: column;
+    padding-top: 12px;
     padding-bottom: 12px;
   }
 
@@ -1095,14 +1040,13 @@ button.stujo-header-action:hover {
     display: none;
   }
 
-  .stujo-nav-inner--open {
-    display: flex;
-    flex-direction: column;
-  }
-
   .stujo-nav a {
     min-height: 48px;
     padding: 10px 12px;
+  }
+
+  .stujo-hero-claim {
+    overflow-wrap: anywhere;
   }
 
   .stujo-landing-cols > div,

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -276,18 +276,25 @@ button.stujo-header-action:hover {
 .stujo-nav a {
   display: flex;
   align-items: center;
+  min-width: 0;
+  max-width: 100%;
   color: #fff;
   font-family: var(--stujo-font);
   font-size: 20px;
   font-weight: 700;
   text-transform: uppercase;
   padding: 0.55em 1em;
+  overflow-wrap: anywhere;
 }
 
 .stujo-nav a:hover,
 .stujo-nav a.stujo-nav--active {
   background: #fff;
   color: var(--stujo-primary);
+}
+
+.stujo-nav-home {
+  min-height: 2.53em;
 }
 
 .stujo-nav-home-icon {
@@ -604,10 +611,17 @@ button.stujo-header-action:hover {
   margin-bottom: 1rem;
 }
 
+.stujo-dash-head > div {
+  min-width: 0;
+  max-width: 100%;
+}
+
 /* Company picker, shown only when a user may post for several organizations. */
 .stujo-org-switcher {
   display: flex;
   flex-direction: column;
+  min-width: 0;
+  max-width: 100%;
   gap: 0.2rem;
   margin: 0.25rem 0 0.75rem;
   font-size: 0.8rem;
@@ -615,6 +629,8 @@ button.stujo-header-action:hover {
 
 .stujo-org-switcher select {
   /* Mobile first: full width, comfortable touch target. */
+  width: 100%;
+  max-width: 100%;
   min-height: 44px;
   padding: 0.3rem 0.6rem;
   font-family: inherit;
@@ -633,16 +649,18 @@ button.stujo-header-action:hover {
 }
 
 .stujo-stats {
-  display: flex;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 8rem), 1fr));
   gap: 1rem;
   margin: 1rem 0 1.5rem;
 }
 
 .stujo-stat {
-  flex: 1;
+  min-width: 0;
   background: #f6f6f4;
   border: 2px solid var(--stujo-border);
   padding: 1rem;
+  overflow-wrap: anywhere;
 }
 
 .stujo-stat--accent {
@@ -655,9 +673,66 @@ button.stujo-header-action:hover {
   color: var(--stujo-primary);
 }
 
-.stujo-table-scroll {
-  max-width: 100%;
-  overflow-x: auto;
+.stujo-posting-list {
+  display: grid;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.stujo-posting-card {
+  min-width: 0;
+  padding: 1rem;
+  border: 2px solid var(--stujo-border);
+  background: #fff;
+}
+
+.stujo-posting-card-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.stujo-posting-card-title {
+  min-width: 0;
+  margin: 0;
+  font-size: 1.1em;
+  overflow-wrap: anywhere;
+}
+
+.stujo-posting-card-title a {
+  color: var(--stujo-primary);
+}
+
+.stujo-posting-card-title a:hover {
+  color: var(--stujo-grey);
+}
+
+.stujo-posting-details {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.75rem 1rem;
+  margin: 1rem 0;
+}
+
+.stujo-posting-details > div:first-child {
+  grid-column: 1 / -1;
+}
+
+.stujo-posting-details dt {
+  color: var(--stujo-grey);
+  font-size: 0.8em;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.stujo-posting-details dd {
+  margin: 0.2rem 0 0;
+  overflow-wrap: anywhere;
 }
 
 .stujo-posting-actions {
@@ -668,6 +743,20 @@ button.stujo-header-action:hover {
 
 .stujo-posting-actions > * {
   flex-shrink: 0;
+}
+
+.stujo-postings-table {
+  display: none;
+}
+
+@media (min-width: 768px) {
+  .stujo-posting-list {
+    display: none;
+  }
+
+  .stujo-postings-table {
+    display: table;
+  }
 }
 
 .stujo-table {
@@ -1068,5 +1157,13 @@ button.stujo-header-action:hover {
 
   .stujo-job-row > div {
     flex: 1 1 220px;
+  }
+}
+
+@media (max-width: 280px) {
+  .stujo-nav a {
+    padding-right: 0.75em;
+    padding-left: 0.75em;
+    font-size: 16px;
   }
 }

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -1030,21 +1030,6 @@ button.stujo-header-action:hover {
     height: 44px;
   }
 
-  .stujo-nav-inner {
-    flex-direction: column;
-    padding-top: 12px;
-    padding-bottom: 12px;
-  }
-
-  .stujo-nav .stujo-nav-home {
-    display: none;
-  }
-
-  .stujo-nav a {
-    min-height: 48px;
-    padding: 10px 12px;
-  }
-
   .stujo-hero-claim {
     overflow-wrap: anywhere;
   }

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -1038,13 +1038,18 @@ button.stujo-header-action:hover {
     display: flex;
     align-items: center;
     justify-content: center;
-    min-width: 36px;
+    min-width: 44px;
     min-height: 44px;
   }
 
   .stujo-lang-switch .stujo-lang-toggle {
     width: 44px;
     height: 44px;
+  }
+
+  .stujo-posting-actions > * {
+    min-width: 44px;
+    min-height: 44px;
   }
 
   .stujo-hero-claim {

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -1037,8 +1037,12 @@ button.stujo-header-action:hover {
     width: 48px;
     background: #fff;
     color: var(--stujo-primary);
-    font-size: 30px;
-    line-height: 1;
+  }
+
+  .stujo-menu-icon {
+    width: 28px;
+    height: 28px;
+    flex: none;
   }
 
   .stujo-header-topnav {
@@ -1076,20 +1080,19 @@ button.stujo-header-action:hover {
 
   .stujo-navigation-toggle {
     width: 100%;
-    padding: 8px 0;
+    justify-content: flex-end;
+    padding: 8px 10px;
     color: #fff;
     background: transparent;
-    text-transform: uppercase;
-    font-size: 18px;
-  }
-
-  .stujo-navigation-toggle span {
-    font-size: 28px;
   }
 
   .stujo-nav-inner {
     display: none;
     padding-bottom: 12px;
+  }
+
+  .stujo-nav .stujo-nav-home {
+    display: none;
   }
 
   .stujo-nav-inner--open {

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -655,6 +655,21 @@ button.stujo-header-action:hover {
   color: var(--stujo-primary);
 }
 
+.stujo-table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+.stujo-posting-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.stujo-posting-actions > * {
+  flex-shrink: 0;
+}
+
 .stujo-table {
   width: 100%;
   border-collapse: collapse;
@@ -684,12 +699,6 @@ button.stujo-header-action:hover {
   color: var(--stujo-grey);
 }
 
-.stujo-table-actions {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-}
-
 .stujo-chip {
   display: inline-block;
   border-radius: 999px;
@@ -705,6 +714,7 @@ button.stujo-header-action:hover {
 
 .stujo-steps {
   display: flex;
+  flex-wrap: wrap;
   gap: 1.5rem;
   margin: 0.75rem 0 1.25rem;
 }
@@ -729,14 +739,17 @@ button.stujo-header-action:hover {
 
 .stujo-form-row {
   display: flex;
+  flex-wrap: wrap;
   gap: 1rem;
 }
 
 .stujo-form-row .stujo-field {
-  flex: 1;
+  flex: 1 1 12rem;
 }
 
 .stujo-field {
+  min-width: 0;
+  overflow-wrap: anywhere;
   display: flex;
   flex-direction: column;
   gap: 0.3rem;
@@ -748,6 +761,8 @@ button.stujo-header-action:hover {
 .stujo-field input,
 .stujo-field select,
 .stujo-field textarea {
+  width: 100%;
+  min-width: 0;
   font-family: inherit;
   font-weight: 400;
   font-size: 14px;
@@ -759,6 +774,8 @@ button.stujo-header-action:hover {
 
 .stujo-form-actions {
   display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
   justify-content: space-between;
   margin-top: 0.5rem;
 }


### PR DESCRIPTION
## Summary

- Improve StuJo header, navigation, forms, and content wrapping on small screens.
- Add horizontally scrollable job-posting tables and grouped action controls.
- Add localized ARIA labels for account and navigation menus.
- Improve mobile spacing, touch targets, and responsive form behavior in German and English.

## Testing

Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Added localized labels to header and main navigation for improved screen reader support.
  * Made the employer postings table keyboard-focusable and horizontally scrollable.

* **Responsive Design**
  * Improved header, navigation, logo, and artwork behavior across screen sizes.
  * Added better wrapping and spacing for forms, job listings, and landing-page content.
  * Increased mobile touch target sizes for language and account controls.

* **Usability**
  * Kept posting action buttons visible and usable on narrow screens.
  * Added English and German labels for navigation and account controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->