### PR TITLE
Add StuJo FAQ collection and dedicated /faq page

### DIFF
--- a/backend/migrations/default/1788800000000_insert_stujo_faq_collection/down.sql
+++ b/backend/migrations/default/1788800000000_insert_stujo_faq_collection/down.sql
@@ -1,0 +1,3 @@
+-- Faq and FaqTranslation are removed by the ON DELETE CASCADE chain from
+-- FaqCollection.
+DELETE FROM "public"."FaqCollection" WHERE "name" = 'stujo';

--- a/backend/migrations/default/1788800000000_insert_stujo_faq_collection/up.sql
+++ b/backend/migrations/default/1788800000000_insert_stujo_faq_collection/up.sql
@@ -1,0 +1,109 @@
+-- StuJo FAQ content, ported from the legacy Rails page (app/views/pages/
+-- faq.html.erb on www.stujo.net/faq) into the EduHub Faq tables.
+--
+-- One shared collection for all StuJo portals: portals are a branding
+-- dimension only (docs/STUJO_INTEGRATION_PLAN.md 2.4), so the FAQ is the
+-- same everywhere and apps/stujo/pages/faq.tsx names this collection
+-- directly.
+--
+-- The answers are NOT a 1:1 copy: every legacy answer was checked against
+-- how the new app actually behaves and corrected where it had drifted
+-- (account model, price page URL, 8-week visibility window, Stripe
+-- pre-payment instead of the old post-hoc invoice). The legacy question
+-- about agencies posting on behalf of third companies is intentionally
+-- dropped. German uses the informal "Du" form (AGENTS.md rule 4).
+
+INSERT INTO "public"."FaqCollection" ("name") VALUES ('stujo');
+
+-- 12 entries; display order is insertion order (Faq has no order column,
+-- the query breaks the created_at tie on id).
+INSERT INTO "public"."Faq" ("collectionId")
+SELECT c.id
+FROM "public"."FaqCollection" c, generate_series(1, 12)
+WHERE c.name = 'stujo';
+
+WITH numbered AS (
+  SELECT id, (row_number() OVER (ORDER BY id))::int AS n
+  FROM "public"."Faq"
+  WHERE "collectionId" = (
+    SELECT id FROM "public"."FaqCollection" WHERE name = 'stujo'
+  )
+),
+content (n, lang, question, answer) AS (VALUES
+  (1, 'DE',
+   'Brauche ich einen Account für die Jobsuche bei StuJo?',
+   'Nein. Für die Jobsuche brauchst Du keinen Account. Die neuesten Angebote findest Du direkt auf der Startseite, und unter [Stellenangebote](/stellenangebote) kannst Du nach Kategorie, Ort/Region und Berufsfeld filtern oder nach einem Stichwort bzw. einem Unternehmen suchen.'),
+  (2, 'DE',
+   'Brauche ich als Unternehmen einen Account bei StuJo und kostet dieser etwas?',
+   'Ja. Um ein Stellenangebot zu veröffentlichen, brauchst Du ein Konto bei opencampus.sh – dasselbe Konto wie in EduHub. Nach der Anmeldung wählst Du unter „Mein StuJo“ das Unternehmen aus, für das Du Anzeigen veröffentlichen möchtest. Das Konto selbst ist kostenlos; Kosten entstehen erst beim Veröffentlichen einer kostenpflichtigen Anzeige.'),
+  (3, 'DE',
+   'Fallen für die Jobsuche Kosten an?',
+   'Nein, für die Jobsuche fallen keine Kosten an.'),
+  (4, 'DE',
+   'Wie viel kostet es, eine Stellenausschreibung zu inserieren?',
+   'Eine Übersicht über alle Leistungen und Preise findest Du unter [Für Arbeitgeber](/fuer-arbeitgeber). Minijobs sind kostenlos; alle Preise verstehen sich netto zuzüglich der gesetzlichen Umsatzsteuer.'),
+  (5, 'DE',
+   'Ist StuJo ausschließlich für Studierende nutzbar?',
+   'Der Schwerpunkt von StuJo liegt in der Vermittlung von Studierenden an Unternehmen in der unmittelbaren Umgebung in Schleswig-Holstein und Hamburg. Durch den engen Kontakt zu den Hochschulen in Kiel und Flensburg werden zudem häufig Jobs an der Hochschule selbst ausgeschrieben.'),
+  (6, 'DE',
+   'Was ist das Besondere an StuJo?',
+   'StuJo ist ein im Rahmen von opencampus.sh gegründetes Start-up von Studierenden der Universität Kiel mit dem Ziel, die Jobsuche für den lokalen Markt auf kluge Weise zu vereinfachen. Heute wird StuJo vom gemeinnützigen Verein Campus Business Box e.V. (opencampus.sh) betrieben und läuft auf derselben Plattform wie EduHub – Du nutzt also überall dasselbe Konto. Durch den engen Kontakt zu den lokalen Unternehmen und den Hochschulen in der Umgebung ist StuJo eine sehr persönliche und effektive Brücke zwischen Arbeitgebern und Jobsuchenden.'),
+  (7, 'DE',
+   'Wie lange sind die Stellenangebote sichtbar?',
+   'Ein Angebot bleibt ab der Veröffentlichung 8 Wochen (56 Tage) online und läuft danach automatisch ab. Über einen früheren Bewerbungsschluss kannst Du den Zeitraum individuell verkürzen. Abgelaufene Angebote kannst Du unter „Mein StuJo“ jederzeit erneut inserieren.'),
+  (8, 'DE',
+   'Wohin fließen die Einnahmen von StuJo?',
+   'Die Einnahmen von StuJo decken die Kosten für den Betrieb und die Weiterentwicklung der Plattform. Eventuelle Überschüsse fließen dem gemeinnützigen Verein Campus Business Box e.V. (opencampus.sh) zu. Dieser setzt sich für die Erhaltung eines vielfältigen Arbeitsmarkts sowie für die Förderung der Start-up-Kultur in Schleswig-Holstein ein.'),
+  (9, 'DE',
+   'Von wem werden die Inserate eingestellt?',
+   'Die Inserate werden von den Arbeitgebern selbstständig über das Online-Formular unter „Mein StuJo“ eingestellt. StuJo stellt dafür die Plattform bereit und wird nicht vermittelnd tätig.'),
+  (10, 'DE',
+   'Können die Anzeigen nachträglich geändert werden?',
+   'Ja. Unter „Mein StuJo“ kannst Du Deine Anzeigen jederzeit bearbeiten – auch nach der Veröffentlichung. Die Änderungen sind sofort sichtbar.'),
+  (11, 'DE',
+   'Aus welchem Umkreis werden Jobangebote inseriert?',
+   'Durch die Anbindung an opencampus.sh und die Hochschulen in Kiel und Flensburg liegt der Fokus der Inserate auf diesem Raum und auf ganz Schleswig-Holstein. Angebote aus dem übrigen Deutschland, aus Dänemark und aus dem weiteren Ausland sind aber ebenfalls zu finden und herzlich willkommen.'),
+  (12, 'DE',
+   'Wie bezahle ich, nachdem ich ein Angebot gebucht habe?',
+   'Kostenpflichtige Anzeigen werden per Vorkasse abgerechnet: Beim Veröffentlichen wirst Du zu unserem Zahlungsdienstleister Stripe weitergeleitet und bezahlst dort mit einer der angebotenen Zahlungsarten (z. B. Kreditkarte oder SEPA-Lastschrift). Die Rechnung bekommst Du elektronisch als PDF per E-Mail an die im Konto hinterlegte Adresse, dazu einen Zugriffslink auf das Rechnungsdokument. Ist für Dein Unternehmen noch ein Freikontingent hinterlegt, wird dieses automatisch eingelöst und es fällt keine Zahlung an.'),
+  (1, 'EN',
+   'Do I need an account to search for jobs on StuJo?',
+   'No. You do not need an account to look for a job. The latest offers are on the home page, and under [Job offers](/stellenangebote) you can filter by category, location/region and occupational field, or search for a keyword or a company.'),
+  (2, 'EN',
+   'Do I need a company account on StuJo, and does it cost anything?',
+   'Yes. To publish a job offer you need an opencampus.sh account – the same account as in EduHub. After signing in, pick the company you want to publish offers for under "Mein StuJo". The account itself is free; costs only arise when you publish a paid ad.'),
+  (3, 'EN',
+   'Are there any costs for job seekers?',
+   'No, searching for a job is free of charge.'),
+  (4, 'EN',
+   'How much does it cost to post a job ad?',
+   'You will find an overview of all services and prices under [For employers](/fuer-arbeitgeber). Mini jobs are free; all prices are net and exclude statutory VAT.'),
+  (5, 'EN',
+   'Is StuJo only for students?',
+   'StuJo focuses on connecting students with companies in their immediate surroundings in Schleswig-Holstein and Hamburg. Thanks to the close contact with the universities in Kiel and Flensburg, jobs at the universities themselves are also advertised regularly.'),
+  (6, 'EN',
+   'What makes StuJo special?',
+   'StuJo is a start-up founded within opencampus.sh by students of Kiel University, with the goal of making the local job search simpler. Today StuJo is run by the non-profit association Campus Business Box e.V. (opencampus.sh) and runs on the same platform as EduHub – so you use the same account everywhere. Through its close contact with local companies and the nearby universities, StuJo is a personal and effective bridge between employers and job seekers.'),
+  (7, 'EN',
+   'How long are job offers visible?',
+   'An offer stays online for 8 weeks (56 days) from publication and then expires automatically. You can shorten that period individually via an earlier application deadline. Expired offers can be re-posted at any time under "Mein StuJo".'),
+  (8, 'EN',
+   'Where does StuJo''s revenue go?',
+   'StuJo''s revenue covers the cost of running and further developing the platform. Any surplus goes to the non-profit association Campus Business Box e.V. (opencampus.sh), which works to sustain a diverse labour market and to promote start-up culture in Schleswig-Holstein.'),
+  (9, 'EN',
+   'Who posts the job ads?',
+   'Employers post their ads themselves, using the online form under "Mein StuJo". StuJo provides the platform and does not act as a placement agency.'),
+  (10, 'EN',
+   'Can ads be edited after publication?',
+   'Yes. Under "Mein StuJo" you can edit your ads at any time – including after they have been published. Changes are visible immediately.'),
+  (11, 'EN',
+   'Which regions do the job offers come from?',
+   'Because of the link with opencampus.sh and the universities in Kiel and Flensburg, the focus is on that area and on Schleswig-Holstein as a whole. Offers from the rest of Germany, from Denmark and from further abroad can be found here too and are very welcome.'),
+  (12, 'EN',
+   'How do I pay after booking an ad?',
+   'Paid ads are charged in advance: when you publish, you are forwarded to our payment provider Stripe and pay there using one of the offered payment methods (e.g. credit card or SEPA direct debit). You receive the invoice electronically as a PDF by e-mail to the address stored in your account, plus a link to the invoice document. If your company still has a free credit available, it is redeemed automatically and no payment is due.')
+)
+INSERT INTO "public"."FaqTranslation" ("faqId", "lang", "question", "answer")
+SELECT numbered.id, content.lang, content.question, content.answer
+FROM content
+JOIN numbered USING (n);

--- a/backend/seeds/README.md
+++ b/backend/seeds/README.md
@@ -119,12 +119,9 @@ These tables are typically managed through migrations rather than seeds. The `Co
 
 ### FAQ Data Handling
 
-The FAQ tables (`FaqCollection`, `Faq`, `FaqTranslation`) are included in seed exports, but the script automatically filters out FAQ data that is created by migrations to prevent conflicts:
+All FAQ content (`FaqCollection`, `Faq`, `FaqTranslation`) is owned by migrations, not by seeds — the "default" sample collection from `1753957404053`/`1753957404056` and the StuJo collection from `1788800000000_insert_stujo_faq_collection`. The export script therefore strips those three tables from the snapshot entirely, so a fresh database gets its FAQs from the migrations and never re-inserts them from the seed.
 
-- **Excluded**: The initial "default" FAQ collection and its 3 sample FAQs (created by migrations `1753957404053` and `1753957404056`)
-- **Included**: Any additional FAQ collections, FAQs, or translations that you add manually
-
-This allows you to add custom FAQ content via seeds while avoiding conflicts with the migration-created initial FAQ data.
+Add or change FAQ content in a migration; anything inserted only through the Hasura console will not survive an export.
 
 ## Requirements
 

--- a/backend/seeds/utils/export_seeds.sh
+++ b/backend/seeds/utils/export_seeds.sh
@@ -75,19 +75,14 @@ if [ $? -eq 0 ]; then
         docker exec -w /hasura $CONTAINER_NAME bash -c "
             seed_file=\"seeds/default/$SEED_NAME.sql\"
             
-            # Remove FAQ data created by migrations
-            # Migration 1753957404053 creates FaqCollection with name='default' (id=1)
-            # Migration 1753957404056 creates Faq entries with ids 1-3 and FaqTranslation entries with ids 1-6
-            sed -i \"/INSERT INTO public.\\\"FaqCollection\\\" (id, name.*VALUES (1, 'default'/d\" \"\$seed_file\"
-            sed -i \"/INSERT INTO public.\\\"Faq\\\" (id, \\\"collectionId\\\".*VALUES (1, 1,/d\" \"\$seed_file\"
-            sed -i \"/INSERT INTO public.\\\"Faq\\\" (id, \\\"collectionId\\\".*VALUES (2, 1,/d\" \"\$seed_file\"
-            sed -i \"/INSERT INTO public.\\\"Faq\\\" (id, \\\"collectionId\\\".*VALUES (3, 1,/d\" \"\$seed_file\"
-            sed -i \"/INSERT INTO public.\\\"FaqTranslation\\\" (id, \\\"faqId\\\".*VALUES (1, /d\" \"\$seed_file\"
-            sed -i \"/INSERT INTO public.\\\"FaqTranslation\\\" (id, \\\"faqId\\\".*VALUES (2, /d\" \"\$seed_file\"
-            sed -i \"/INSERT INTO public.\\\"FaqTranslation\\\" (id, \\\"faqId\\\".*VALUES (3, /d\" \"\$seed_file\"
-            sed -i \"/INSERT INTO public.\\\"FaqTranslation\\\" (id, \\\"faqId\\\".*VALUES (4, /d\" \"\$seed_file\"
-            sed -i \"/INSERT INTO public.\\\"FaqTranslation\\\" (id, \\\"faqId\\\".*VALUES (5, /d\" \"\$seed_file\"
-            sed -i \"/INSERT INTO public.\\\"FaqTranslation\\\" (id, \\\"faqId\\\".*VALUES (6, /d\" \"\$seed_file\"
+            # Remove FAQ data created by migrations.
+            # ALL FAQ content is migration-owned (the 'default' sample set and
+            # the 'stujo' collection), so strip the tables wholesale rather
+            # than listing ids — a new FAQ migration would otherwise be
+            # re-inserted by the seed and collide with itself.
+            sed -i \"/INSERT INTO public.\\\"FaqCollection\\\" /d\" \"\$seed_file\"
+            sed -i \"/INSERT INTO public.\\\"Faq\\\" /d\" \"\$seed_file\"
+            sed -i \"/INSERT INTO public.\\\"FaqTranslation\\\" /d\" \"\$seed_file\"
             sed -i \"/SELECT pg_catalog.setval('public.\\\"FaqCollection_id_seq\\\"'/d\" \"\$seed_file\"
             sed -i \"/SELECT pg_catalog.setval('public.\\\"Faq_id_seq\\\"'/d\" \"\$seed_file\"
             sed -i \"/SELECT pg_catalog.setval('public.\\\"FaqTranslation_id_seq\\\"'/d\" \"\$seed_file\"

--- a/frontend-nx/apps/edu-hub/components/common/FaqSection.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/FaqSection.tsx
@@ -33,24 +33,24 @@ const FaqItemComponent: FC<FaqItemProps> = ({ faq }) => {
   };
 
   return (
-    <div className="border border-gray-600 rounded-lg mb-4">
+    <div className="border border-border-primary rounded-lg mb-4">
       <button
-        className="w-full p-4 text-left flex justify-between items-center hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50"
+        className="w-full p-4 text-left flex justify-between items-center hover:bg-bg-secondary focus:outline-none focus:ring-2 focus:ring-brand focus:ring-opacity-50"
         onClick={toggleExpanded}
         aria-expanded={isExpanded}
       >
-        <h3 className="text-lg font-medium text-white pr-4">{faq.question}</h3>
+        <h3 className="text-lg font-medium text-label-primary pr-4">{faq.question}</h3>
         {isExpanded ? (
-          <MdExpandLess className="text-gray-400 flex-shrink-0" size={24} />
+          <MdExpandLess className="text-label-secondary flex-shrink-0" size={24} />
         ) : (
-          <MdExpandMore className="text-gray-400 flex-shrink-0" size={24} />
+          <MdExpandMore className="text-label-secondary flex-shrink-0" size={24} />
         )}
       </button>
       {isExpanded && (
-        <div className="px-4 pb-4 border-t border-gray-700">
-          <div className="pt-4 text-gray-200 leading-relaxed">
+        <div className="px-4 pb-4 border-t border-border-primary">
+          <div className="pt-4 text-label-primary leading-relaxed">
             <ReactMarkdown 
-              className="prose prose-invert max-w-none"
+              className="prose max-w-none prose-headings:text-label-primary prose-p:text-label-primary prose-li:text-label-primary prose-strong:text-label-primary prose-a:text-brand"
               remarkPlugins={[remarkGfm]}
             >
               {faq.answer}
@@ -62,6 +62,13 @@ const FaqItemComponent: FC<FaqItemProps> = ({ faq }) => {
   );
 };
 
+/**
+ * Accordion of the FAQ entries in one FaqCollection, in the active locale
+ * (falling back to the English translation). Shared between edu-hub's
+ * homepage section and StuJo's /faq page, so every colour goes through the
+ * `--eduhub-*` design tokens rather than literal greys — StuJo redefines
+ * those tokens light in its globals.css (AGENTS.md rule 10).
+ */
 const FaqSection: FC<FaqSectionProps> = ({ collection = 'default', className = '' }) => {
   const t = useTranslations('common');
   const locale = useLocale();
@@ -110,7 +117,7 @@ const FaqSection: FC<FaqSectionProps> = ({ collection = 'default', className = '
     return (
       <div className={`faq-section ${className}`}>
         <div className="text-center py-8">
-          <p className="text-gray-400">{t('faq.error_loading')}</p>
+          <p className="text-label-secondary">{t('faq.error_loading')}</p>
         </div>
       </div>
     );
@@ -120,7 +127,7 @@ const FaqSection: FC<FaqSectionProps> = ({ collection = 'default', className = '
     return (
       <div className={`faq-section ${className}`}>
         <div className="text-center py-8">
-          <p className="text-gray-400">{t('faq.no_faqs_available')}</p>
+          <p className="text-label-secondary">{t('faq.no_faqs_available')}</p>
         </div>
       </div>
     );
@@ -129,7 +136,7 @@ const FaqSection: FC<FaqSectionProps> = ({ collection = 'default', className = '
   return (
     <div className={`faq-section ${className}`}>
       <div className="max-w-4xl mx-auto">
-        <h2 className="text-3xl font-bold text-center mb-8 text-white">{t('faq.title')}</h2>
+        <h2 className="text-3xl font-bold text-center mb-8 text-label-primary">{t('faq.title')}</h2>
         <div className="space-y-2">
           {faqs.map((faq) => (
             <FaqItemComponent key={faq.id} faq={faq} />

--- a/frontend-nx/apps/edu-hub/components/common/__tests__/FaqSection.test.tsx
+++ b/frontend-nx/apps/edu-hub/components/common/__tests__/FaqSection.test.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+import FaqSection from '../FaqSection';
+
+const useQuery = jest.fn();
+
+jest.mock('@apollo/client', () => ({
+  useQuery: (...args: unknown[]) => useQuery(...args),
+  gql: (strings: TemplateStringsArray) => strings.join(''),
+}));
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) => key,
+  useLocale: () => 'de',
+}));
+
+// react-markdown/remark-gfm ship as ESM and are not part of what this test
+// exercises; render the answer as plain text instead.
+jest.mock('react-markdown', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+jest.mock('remark-gfm', () => ({ __esModule: true, default: () => undefined }));
+
+const faq = (id: number, translations: unknown[], fallback: unknown[] = []) => ({
+  id,
+  FaqTranslations: translations,
+  FaqTranslations_fallback: fallback,
+});
+
+const de = (question: string, answer: string) => ({ id: 1, lang: 'DE', question, answer });
+const en = (question: string, answer: string) => ({ id: 2, lang: 'EN', question, answer });
+
+const mockFaqs = (Faqs: unknown[]) =>
+  useQuery.mockReturnValue({
+    data: { FaqCollection: [{ id: 1, name: 'stujo', Faqs }] },
+    loading: false,
+    error: undefined,
+  });
+
+describe('FaqSection', () => {
+  beforeEach(() => {
+    useQuery.mockReset();
+  });
+
+  it('queries the requested collection in the active locale', () => {
+    mockFaqs([]);
+    render(<FaqSection collection="stujo" />);
+
+    expect(useQuery).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ variables: { collection: 'stujo', lang: 'DE' } })
+    );
+  });
+
+  it('renders the questions in the order the query returned them', () => {
+    mockFaqs([
+      faq(1, [de('Erste Frage', 'Erste Antwort')]),
+      faq(2, [de('Zweite Frage', 'Zweite Antwort')]),
+    ]);
+    render(<FaqSection collection="stujo" />);
+
+    const questions = screen.getAllByRole('heading', { level: 3 }).map((h) => h.textContent);
+    expect(questions).toEqual(['Erste Frage', 'Zweite Frage']);
+  });
+
+  it('falls back to the English translation when the locale one is missing', () => {
+    mockFaqs([faq(1, [], [en('Only English', 'English answer')])]);
+    render(<FaqSection collection="stujo" />);
+
+    expect(screen.getByRole('heading', { level: 3 })).toHaveTextContent('Only English');
+  });
+
+  it('drops entries that have no translation at all', () => {
+    mockFaqs([faq(1, [de('Übersetzt', 'Antwort')]), faq(2, [])]);
+    render(<FaqSection collection="stujo" />);
+
+    expect(screen.getAllByRole('heading', { level: 3 })).toHaveLength(1);
+  });
+
+  it('reveals the answer when the question is clicked', () => {
+    mockFaqs([faq(1, [de('Eine Frage', 'Die Antwort')])]);
+    render(<FaqSection collection="stujo" />);
+
+    const button = screen.getByRole('button', { name: /Eine Frage/ });
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.queryByText('Die Antwort')).not.toBeInTheDocument();
+
+    fireEvent.click(button);
+
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Die Antwort')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when the collection has no entries', () => {
+    mockFaqs([]);
+    render(<FaqSection collection="stujo" />);
+
+    expect(screen.getByText('faq.no_faqs_available')).toBeInTheDocument();
+  });
+});

--- a/frontend-nx/apps/edu-hub/queries/faqQueries.ts
+++ b/frontend-nx/apps/edu-hub/queries/faqQueries.ts
@@ -6,7 +6,10 @@ export const GET_FAQS_BY_COLLECTION_AND_LANG = gql`
     FaqCollection(where: {name: {_eq: $collection}}) {
       id
       name
-      Faqs(order_by: {created_at: asc}) {
+      # Faq has no order column and every row inserted by one migration
+      # shares that transaction's now(), so id breaks the tie and keeps the
+      # authored order stable.
+      Faqs(order_by: [{created_at: asc}, {id: asc}]) {
         id
         FaqTranslations(where: {lang: {_eq: $lang}}) {
           id

--- a/frontend-nx/apps/stujo/components/Layout.tsx
+++ b/frontend-nx/apps/stujo/components/Layout.tsx
@@ -202,7 +202,7 @@ const Layout: FC<LayoutProps> = ({ children, fullWidthMain = false, portal }) =>
             <h3>{t('footerLinksHead')}</h3>
             <a href={termsUrl}>AGB</a>
             <Link href="/fuer-arbeitgeber">{t('footerPrices')}</Link>
-            <a href="https://www.stujo.net/faq">FAQ</a>
+            <Link href="/faq">FAQ</Link>
             <a href={imprintUrl}>Impressum</a>
             <a href={privacyUrl}>Datenschutz</a>
           </div>

--- a/frontend-nx/apps/stujo/locales/de.json
+++ b/frontend-nx/apps/stujo/locales/de.json
@@ -52,6 +52,11 @@
     "JobList": {
       "search_placeholder": "Suchbegriff, z. B. Marketing, Software, …"
     },
+    "faq": {
+      "title": "Häufig gestellte Fragen",
+      "error_loading": "Fehler beim Laden der FAQs. Bitte versuche es später erneut.",
+      "no_faqs_available": "Keine FAQs verfügbar."
+    },
     "dropdown_selector": {
       "create_option": "\"{option}\" neu hinzufügen",
       "none_option": "-- Keine Auswahl --",

--- a/frontend-nx/apps/stujo/locales/en.json
+++ b/frontend-nx/apps/stujo/locales/en.json
@@ -52,6 +52,11 @@
     "JobList": {
       "search_placeholder": "Search term, e.g. marketing, software, …"
     },
+    "faq": {
+      "title": "Frequently Asked Questions",
+      "error_loading": "Error loading FAQs. Please try again later.",
+      "no_faqs_available": "No FAQs available."
+    },
     "dropdown_selector": {
       "create_option": "Create new entry \"{option}\"",
       "none_option": "-- None --",

--- a/frontend-nx/apps/stujo/pages/faq.tsx
+++ b/frontend-nx/apps/stujo/pages/faq.tsx
@@ -1,0 +1,42 @@
+import Head from 'next/head';
+import { FC } from 'react';
+import { GetServerSideProps } from 'next';
+
+import FaqSection from '@eduhub/components/common/FaqSection';
+
+import Layout from '../components/Layout';
+import { resolvePortal, PortalBranding } from '../lib/portal';
+import { portalHost } from '../lib/requestHost';
+
+type Props = { portal: PortalBranding };
+
+// One collection serves every portal: portals are a branding dimension, not
+// a content dimension (docs/STUJO_INTEGRATION_PLAN.md 2.4).
+const FAQ_COLLECTION = 'stujo';
+
+/**
+ * FAQ page, replacing the footer link that used to point at the legacy
+ * Rails page on www.stujo.net/faq.
+ *
+ * The content lives in the `stujo` FaqCollection (migration
+ * 1788800000000_insert_stujo_faq_collection), and the accordion is the very
+ * same FaqSection edu-hub renders on its homepage — it resolves the locale
+ * and the DE/EN translation itself, and its colours come from the
+ * `--eduhub-*` tokens StuJo redefines in globals.css.
+ */
+const Faq: FC<Props> = ({ portal }) => (
+  <Layout portal={portal}>
+    <Head>
+      <title>FAQ | {portal.title}</title>
+    </Head>
+
+    <FaqSection collection={FAQ_COLLECTION} />
+  </Layout>
+);
+
+export const getServerSideProps: GetServerSideProps<Props> = async ({ req }) => {
+  const portal = await resolvePortal(portalHost(req));
+  return { props: { portal } };
+};
+
+export default Faq;


### PR DESCRIPTION
## Summary
This PR adds a complete FAQ system for StuJo by creating a dedicated FAQ collection in the database and a new `/faq` page in the StuJo app. The FAQ content is ported from the legacy Rails page and includes both German and English translations.

## Key Changes

- **Database Migration**: Added `1788800000000_insert_stujo_faq_collection` migration that:
  - Creates a new `stujo` FaqCollection
  - Inserts 12 FAQ entries with German and English translations
  - Updates answers to reflect current app behavior (8-week visibility window, Stripe pre-payment, etc.)
  - Uses informal "Du" form in German per style guidelines

- **StuJo /faq Page**: Created new `frontend-nx/apps/stujo/pages/faq.tsx` that:
  - Renders the shared `FaqSection` component with the `stujo` collection
  - Integrates with StuJo's Layout and portal branding system
  - Reuses the same FAQ accordion UI as edu-hub's homepage

- **FaqSection Component Improvements**:
  - Refactored color classes from hardcoded greys to design tokens (`--eduhub-*`)
  - Updated Tailwind classes to use semantic tokens: `border-border-primary`, `bg-bg-secondary`, `text-label-primary`, etc.
  - Enhanced prose styling for markdown rendering with proper color inheritance
  - Added comprehensive documentation explaining the shared component design

- **Query Optimization**: Updated `GET_FAQS_BY_COLLECTION_AND_LANG` to order by both `created_at` and `id` to maintain stable insertion order when multiple FAQs share the same transaction timestamp

- **Localization**: Added FAQ-related translation keys to StuJo's German and English locale files

- **Seed Export Script**: Simplified FAQ data handling in `export_seeds.sh` to strip all FAQ tables wholesale (since all FAQ content is now migration-owned) rather than maintaining a fragile list of specific IDs

- **Test Coverage**: Added comprehensive test suite for `FaqSection` covering:
  - Locale-aware querying
  - Fallback to English translations
  - Accordion expand/collapse behavior
  - Empty state handling

## Implementation Details

- The FAQ collection is shared across all StuJo portals since portals are purely a branding dimension (per STUJO_INTEGRATION_PLAN.md 2.4)
- Color tokens allow StuJo to redefine `--eduhub-*` variables in its globals.css for light theme while reusing the same component
- All FAQ content is migration-owned to prevent seed conflicts and ensure consistency across environments

https://claude.ai/code/session_01P5CDi69AffXLpUc9g4bA72