### PR TITLE
fix(stujo): hide Safari header wedge seam

### DIFF
--- a/design/stujo-header-wedge-comparison.html
+++ b/design/stujo-header-wedge-comparison.html
@@ -192,6 +192,10 @@
         pointer-events: none;
       }
 
+      .wedge[src$=".svg"] {
+        left: -2px;
+      }
+
       .wedge-css {
         aspect-ratio: 1477 / 256;
         background: linear-gradient(

--- a/frontend-nx/apps/stujo/styles/globals.css
+++ b/frontend-nx/apps/stujo/styles/globals.css
@@ -166,7 +166,7 @@ a:focus {
 
 .stujo-header-diag {
   position: absolute;
-  left: 0;
+  left: -2px;
   top: 0;
   /* Keep the native angle and crop the artwork on small screens. These
      minimum dimensions also apply above the mobile breakpoint. */


### PR DESCRIPTION
## Summary

- hide Safari's antialiased header-wedge seam by shifting the SVG 2px left
- apply the same positioning to the tracked visual comparison page

## Verification

- verified the StuJo header in Safari 26.2, including maximum page zoom
- compared the PNG and shifted SVG in the header-wedge comparison page
- ran `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted diagonal header artwork positioning for improved alignment.
  * Standardized SVG wedge positioning with the PNG reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->