### PR TITLE
feat(functions): record Mailgun delivery outcomes on MailLog

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -133,3 +133,18 @@ LMS_ATTENDANCE_SURVEY_ID=
 # --- Mattermost (Admin API) — see functions/shared_libs/api_clients/mattermost_client.py
 MM_URL=
 MM_TOKEN=
+
+# --- Mailgun events (delivery status) — see functions/shared_libs/api_clients/mailgun_client.py
+# Read side of mail: sync_mail_delivery_status pulls delivered/bounced/complained
+# events and records them on MailLog. Leave empty unless you are debugging
+# against the real account -- there is no local emulator for the events API, and
+# the function reports the missing key rather than running.
+# The account is on Mailgun EU; MAILGUN_API_BASE_URL only needs setting for US.
+MAILGUN_API_KEY=
+# Sending domains to read events for. Same values the sendMail function uses.
+MAILGUN_DOMAIN=
+MAILGUN_ADDITIONAL_DOMAINS=
+# Optional: trailing window per run, in hours (default 3).
+# MAIL_DELIVERY_SYNC_LOOKBACK_HOURS=
+# Recipient of the bounce-rate alert; falls back to STUJO_ADMIN_EMAIL.
+# MAIL_DELIVERY_ALERT_EMAIL=

--- a/backend/metadata/cron_triggers.yaml
+++ b/backend/metadata/cron_triggers.yaml
@@ -135,6 +135,28 @@
     - name: Hasura-Secret
       value_from_env: HASURA_CLOUD_FUNCTION_SECRET
   comment: Enforces the guest data retention period - anonymizes guests whose events all ended more than AppSettings.guestDataRetentionMonths ago, and deletes signups that were never confirmed (GDPR Art. 5(1)(e))
+- name: sync_mail_delivery_status
+  webhook: '{{CLOUD_FUNCTION_LINK_CALL_PYTHON_FUNCTION}}'
+  # Offset off the hour so it does not compete with expire_invitations at 0 * * * *.
+  schedule: 15 * * * *
+  include_in_metadata: true
+  payload: {}
+  retry_conf:
+    num_retries: 0
+    retry_interval_seconds: 10
+    timeout_seconds: 3699
+    tolerance_seconds: 21600
+  headers:
+    - name: Function-Name
+      value: sync_mail_delivery_status
+    - name: Hasura-Secret
+      value_from_env: HASURA_CLOUD_FUNCTION_SECRET
+  comment: >-
+    Reads Mailgun delivery events back onto MailLog (DELIVERED / BOUNCED /
+    COMPLAINED) by the v:maillogId variable sendMail attaches, and mails the
+    admin when permanent failures exceed 5% of the window's decided mail. No
+    retries: the run reads a trailing window with deliberate overlap, so the
+    next hour covers whatever this one missed.
 - name: send_pending_job_posting_mails
   webhook: '{{CLOUD_FUNCTION_LINK_CALL_NODE_FUNCTION}}'
   schedule: '*/15 * * * *'

--- a/backend/metadata/databases/default/tables/public_MailStatus.yaml
+++ b/backend/metadata/databases/default/tables/public_MailStatus.yaml
@@ -7,7 +7,10 @@ array_relationships:
     using:
       manual_configuration:
         column_mapping:
-          value: id
+          # MailStatus.value -> MailLog.status. This mapped to MailLog.id until
+          # 2026-09, which joined a status string against a serial primary key
+          # and therefore returned nothing for every row.
+          value: status
         insertion_order: null
         remote_table:
           name: MailLog

--- a/backend/migrations/default/1789117455103_insert_into_public_MailStatus/down.sql
+++ b/backend/migrations/default/1789117455103_insert_into_public_MailStatus/down.sql
@@ -1,0 +1,7 @@
+-- Only removes the lookup rows. MailLog.status has no foreign key to this table,
+-- so rows already carrying these values keep them -- which is what we want: a
+-- rollback of the lookup table must not rewrite delivery history.
+DELETE FROM "public"."MailStatus" WHERE "value" = 'READY_TO_SEND';
+DELETE FROM "public"."MailStatus" WHERE "value" = 'DELIVERED';
+DELETE FROM "public"."MailStatus" WHERE "value" = 'BOUNCED';
+DELETE FROM "public"."MailStatus" WHERE "value" = 'COMPLAINED';

--- a/backend/migrations/default/1789117455103_insert_into_public_MailStatus/up.sql
+++ b/backend/migrations/default/1789117455103_insert_into_public_MailStatus/up.sql
@@ -1,0 +1,16 @@
+-- MailStatus is the lookup table for MailLog.status, but it only ever held the
+-- three values from 2021 (UNSENT, SENT, SENDING_ERROR). Meanwhile every queueing
+-- path in the codebase writes READY_TO_SEND -- mail_helpers.queue_mail,
+-- queueEmail.js, guestRegistration, publishJobPosting, sendEnrollmentEmail,
+-- sendSessionReminders, stripeJobPosting and the cutover scripts -- so the table
+-- has been contradicting the data for years. MailLog.status is plain text with
+-- no foreign key, which is the only reason that never failed.
+--
+-- The three delivery outcomes are new: sync_mail_delivery_status reads them back
+-- from the Mailgun events API and writes them onto the row that was sent.
+INSERT INTO "public"."MailStatus" ("value", "comment") VALUES
+  (E'READY_TO_SEND', E'The mail is queued and the send_mail event trigger will deliver it'),
+  (E'DELIVERED',     E'Mailgun confirmed the receiving server accepted the mail'),
+  (E'BOUNCED',       E'Mailgun gave up permanently - the address is invalid or refuses mail'),
+  (E'COMPLAINED',    E'The recipient marked the mail as spam - do not mail this address again')
+ON CONFLICT ("value") DO NOTHING;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -174,7 +174,15 @@ services:
       LMS_ATTENDANCE_SURVEY_ID: ${LMS_ATTENDANCE_SURVEY_ID:-}
       MM_URL: ${MM_URL:-}
       MM_TOKEN: ${MM_TOKEN:-}
-      
+      # sync_mail_delivery_status reads the Mailgun events API. Unset locally,
+      # where the function then reports a missing key instead of running -- the
+      # events endpoint has no emulator, so there is nothing to point it at.
+      MAILGUN_API_KEY: ${MAILGUN_API_KEY:-}
+      MAILGUN_DOMAIN: ${MAILGUN_DOMAIN:-}
+      MAILGUN_ADDITIONAL_DOMAINS: ${MAILGUN_ADDITIONAL_DOMAINS:-}
+      MAIL_DELIVERY_SYNC_LOOKBACK_HOURS: ${MAIL_DELIVERY_SYNC_LOOKBACK_HOURS:-}
+      STUJO_ADMIN_EMAIL: ${STUJO_ADMIN_EMAIL:-}
+
 
   hasura:
     container_name: eduhub-hasura

--- a/functions/callNodeFunction/__tests__/sendMailDeliveryVariables.test.js
+++ b/functions/callNodeFunction/__tests__/sendMailDeliveryVariables.test.js
@@ -1,0 +1,110 @@
+import { jest } from '@jest/globals';
+import { createRequire } from 'node:module';
+
+// sendMail is CommonJS and lives in a sibling function package; callNodeFunction
+// is the only place in functions/ with a test runner.
+const require = createRequire(import.meta.url);
+const { sendMail } = require('../../sendMail/index.js');
+
+const SECRET = 'test-cloud-function-secret';
+
+function makeRequest(newRow) {
+  return {
+    headers: { secret: SECRET },
+    body: { event: { data: { new: newRow } } },
+  };
+}
+
+function makeResponse() {
+  const res = {
+    statusCode: 200,
+    body: undefined,
+    status(code) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload) {
+      res.body = payload;
+      return res;
+    },
+  };
+  return res;
+}
+
+const baseRow = {
+  id: 4711,
+  subject: 'Neue Stellenanzeige',
+  content: '<p>Hallo</p>',
+  to: 'employer@example.org',
+  from: 'team@stujo.net',
+};
+
+describe('sendMail delivery-status variables', () => {
+  let logSpy;
+  const saved = {};
+  const ENV = {
+    // The development branch logs the assembled message instead of sending it,
+    // which is the only way to observe the outgoing Mailgun payload without
+    // mocking the client.
+    ENVIRONMENT: 'development',
+    HASURA_CLOUD_FUNCTION_SECRET: SECRET,
+    // Set so team@stujo.net resolves as an aligned sender; otherwise every
+    // case here also trips the sender-fallback warning.
+    MAILGUN_DOMAIN: 'edu.opencampus.sh',
+    MAILGUN_ADDITIONAL_DOMAINS: 'stujo.net',
+  };
+
+  beforeEach(() => {
+    for (const [key, value] of Object.entries(ENV)) {
+      saved[key] = process.env[key];
+      process.env[key] = value;
+    }
+    logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    for (const key of Object.keys(ENV)) {
+      if (saved[key] === undefined) delete process.env[key];
+      else process.env[key] = saved[key];
+    }
+  });
+
+  function loggedMail() {
+    const call = logSpy.mock.calls.find(([label]) => label === 'Development email:');
+    expect(call).toBeDefined();
+    return call[1];
+  }
+
+  it('carries the MailLog id as a Mailgun custom variable', async () => {
+    const res = makeResponse();
+    await sendMail(makeRequest(baseRow), res);
+
+    expect(res.body).toEqual({ success: true });
+    // A string, because Mailgun echoes v: variables back as strings and the
+    // sync cron parses them straight into MailLog.id.
+    expect(loggedMail().maillogId).toBe('4711');
+  });
+
+  it('omits the variable when the row carries no usable id', async () => {
+    // Without an id there is nothing to join an event back onto, and a literal
+    // 'undefined' in the variable would produce events that look keyed but
+    // match no row.
+    for (const id of [undefined, null, 'not-a-number', 12.5]) {
+      logSpy.mockClear();
+      const res = makeResponse();
+      await sendMail(makeRequest({ ...baseRow, id }), res);
+
+      expect(res.body).toEqual({ success: true });
+      expect(loggedMail().maillogId).toBeUndefined();
+    }
+  });
+
+  it('rejects an unauthorized request before assembling a message', async () => {
+    const res = makeResponse();
+    await sendMail({ headers: { secret: 'wrong' }, body: { event: { data: { new: baseRow } } } }, res);
+
+    expect(res.statusCode).toBe(401);
+    expect(logSpy.mock.calls.some(([label]) => label === 'Development email:')).toBe(false);
+  });
+});

--- a/functions/callPythonFunction/__tests__/test_sync_mail_delivery_status.py
+++ b/functions/callPythonFunction/__tests__/test_sync_mail_delivery_status.py
@@ -1,0 +1,534 @@
+"""Unit tests for the Mailgun delivery-status sync.
+
+The incident this function exists for is a mass send through a stale recipient
+list, so the cases that matter are: a permanent failure is recorded, a temporary
+one is not, a row is never walked backwards, and the bounce-rate check fires
+loudly enough to stop the next batch.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from api_clients.mailgun_client import (
+    EVENT_FILTER,
+    MailgunClient,
+    PAGE_LIMIT,
+    configured_domains,
+    maillog_id,
+)
+from pythonFunctions.sync_mail_delivery_status import (
+    BOUNCE_RATE_MIN_SAMPLE,
+    BOUNCE_RATE_THRESHOLD,
+    MAX_LOOKBACK_HOURS,
+    STATUS_BOUNCED,
+    STATUS_COMPLAINED,
+    STATUS_DELIVERED,
+    apply_statuses,
+    bounce_rate,
+    check_bounce_threshold,
+    classify_event,
+    collect_statuses,
+    resolve_begin,
+)
+
+
+class FakeEduHubClient:
+    """Records mutations and replays canned responses."""
+
+    def __init__(self, responses=None, affected=1):
+        self.calls = []
+        self.responses = list(responses or [])
+        self.affected = affected
+
+    def send_query(self, query, variables):
+        self.calls.append({"query": query, "variables": variables})
+        if self.responses:
+            return self.responses.pop(0)
+        if "update_MailLog" in query:
+            ids = variables["where"]["id"]["_in"]
+            return {"data": {"update_MailLog": {"affected_rows": len(ids)}}}
+        return {"data": {"MailLog": []}}
+
+
+class FakeMailgunClient:
+    """Yields canned events per domain; raises for domains in `failing`."""
+
+    def __init__(self, events_by_domain, failing=()):
+        self.domains = list(events_by_domain)
+        self.events_by_domain = events_by_domain
+        self.failing = set(failing)
+        self.begins = []
+
+    def iter_events(self, domain, begin_timestamp):
+        self.begins.append((domain, begin_timestamp))
+        if domain in self.failing:
+            raise RuntimeError("401 Unauthorized")
+        return iter(self.events_by_domain[domain])
+
+
+def event(name, maillog=None, severity=None):
+    payload = {"event": name}
+    if severity is not None:
+        payload["severity"] = severity
+    if maillog is not None:
+        payload["user-variables"] = {"maillogId": str(maillog)}
+    return payload
+
+
+class TestClassifyEvent:
+    def test_delivered_and_complained_map_straight_through(self):
+        assert classify_event(event("delivered")) == STATUS_DELIVERED
+        assert classify_event(event("complained")) == STATUS_COMPLAINED
+
+    def test_permanent_failure_is_a_bounce(self):
+        assert classify_event(event("failed", severity="permanent")) == STATUS_BOUNCED
+
+    def test_temporary_failure_is_left_alone(self):
+        # The bug worth guarding: Mailgun is still retrying, and a later
+        # delivered event for the same message is expected. Writing BOUNCED
+        # here would condemn mail that is about to arrive.
+        assert classify_event(event("failed", severity="temporary")) is None
+
+    def test_unknown_severity_is_not_treated_as_a_bounce(self):
+        assert classify_event(event("failed", severity="deferred?")) is None
+        assert classify_event(event("failed")) is None
+
+    def test_events_we_do_not_track_are_ignored(self):
+        for name in ("accepted", "opened", "clicked", "unsubscribed", ""):
+            assert classify_event({"event": name}) is None
+
+    def test_case_is_not_significant(self):
+        assert classify_event({"event": "DELIVERED"}) == STATUS_DELIVERED
+        assert classify_event({"event": "Failed", "severity": "Permanent"}) == STATUS_BOUNCED
+
+
+class TestMaillogId:
+    def test_reads_the_custom_variable_as_an_int(self):
+        assert maillog_id(event("delivered", maillog=4711)) == 4711
+
+    def test_missing_variable_is_none(self):
+        assert maillog_id({"event": "delivered"}) is None
+        assert maillog_id({"event": "delivered", "user-variables": {}}) is None
+
+    def test_unusable_variable_is_none_rather_than_an_exception(self):
+        # Mail sent before v:maillogId existed, or a hand-crafted send.
+        assert maillog_id({"user-variables": {"maillogId": "not-a-number"}}) is None
+        assert maillog_id({"user-variables": {"maillogId": None}}) is None
+
+
+class TestConfiguredDomains:
+    def test_reads_the_default_plus_the_additional_domains(self, monkeypatch):
+        monkeypatch.setenv("MAILGUN_DOMAIN", "edu.opencampus.sh")
+        monkeypatch.setenv("MAILGUN_ADDITIONAL_DOMAINS", "stujo.net, Example.ORG ")
+
+        assert configured_domains() == ["edu.opencampus.sh", "stujo.net", "example.org"]
+
+    def test_deduplicates_and_drops_blanks(self, monkeypatch):
+        monkeypatch.setenv("MAILGUN_DOMAIN", "stujo.net")
+        monkeypatch.setenv("MAILGUN_ADDITIONAL_DOMAINS", "stujo.net,,")
+
+        assert configured_domains() == ["stujo.net"]
+
+    def test_client_refuses_to_run_without_a_domain(self, monkeypatch):
+        monkeypatch.delenv("MAILGUN_DOMAIN", raising=False)
+        monkeypatch.delenv("MAILGUN_ADDITIONAL_DOMAINS", raising=False)
+
+        with pytest.raises(ValueError, match="sending domain"):
+            MailgunClient(api_key="key")
+
+    def test_client_refuses_to_run_without_a_key(self, monkeypatch):
+        monkeypatch.delenv("MAILGUN_API_KEY", raising=False)
+
+        with pytest.raises(ValueError, match="MAILGUN_API_KEY"):
+            MailgunClient(domains=["stujo.net"])
+
+
+class TestIterEvents:
+    """The paging walk, with requests.get stubbed out."""
+
+    def _client(self, monkeypatch, pages):
+        client = MailgunClient(api_key="key", domains=["stujo.net"])
+        calls = []
+
+        class FakeResponse:
+            def __init__(self, payload):
+                self._payload = payload
+
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return self._payload
+
+        def fake_get(url, auth=None, params=None, timeout=None):
+            calls.append({"url": url, "params": params, "auth": auth})
+            return FakeResponse(pages[len(calls) - 1])
+
+        monkeypatch.setattr("api_clients.mailgun_client.requests.get", fake_get)
+        return client, calls
+
+    def test_follows_paging_next_until_a_page_is_empty(self, monkeypatch):
+        pages = [
+            {"items": [event("delivered", 1)], "paging": {"next": "https://next/1"}},
+            {"items": [event("delivered", 2)], "paging": {"next": "https://next/2"}},
+            {"items": [], "paging": {"next": "https://next/3"}},
+        ]
+        client, calls = self._client(monkeypatch, pages)
+
+        events = list(client.iter_events("stujo.net", 1_700_000_000))
+
+        assert [maillog_id(e) for e in events] == [1, 2]
+        # Stopped at the empty page, did not follow its `next`.
+        assert [call["url"] for call in calls] == [
+            "https://api.eu.mailgun.net/v3/stujo.net/events",
+            "https://next/1",
+            "https://next/2",
+        ]
+
+    def test_first_request_carries_the_filter_and_window(self, monkeypatch):
+        client, calls = self._client(monkeypatch, [{"items": []}])
+
+        list(client.iter_events("stujo.net", 1_700_000_000))
+
+        assert calls[0]["params"] == {
+            "event": EVENT_FILTER,
+            "begin": 1_700_000_000,
+            "ascending": "yes",
+            "limit": PAGE_LIMIT,
+        }
+        assert calls[0]["auth"] == ("api", "key")
+
+    def test_paging_urls_are_not_given_duplicate_params(self, monkeypatch):
+        pages = [
+            {"items": [event("delivered", 1)], "paging": {"next": "https://next/1"}},
+            {"items": []},
+        ]
+        client, calls = self._client(monkeypatch, pages)
+
+        list(client.iter_events("stujo.net", 1_700_000_000))
+
+        # paging.next already encodes the query; re-sending params would reset
+        # the cursor and loop over the first page forever.
+        assert calls[1]["params"] is None
+
+    def test_a_short_page_is_not_the_end_of_the_walk(self, monkeypatch):
+        pages = [
+            {"items": [event("delivered", 1)], "paging": {"next": "https://next/1"}},
+            {"items": [event("delivered", 2)], "paging": {}},
+        ]
+        client, calls = self._client(monkeypatch, pages)
+
+        events = list(client.iter_events("stujo.net", 1_700_000_000))
+
+        assert [maillog_id(e) for e in events] == [1, 2]
+        assert len(calls) == 2
+
+    def test_ends_when_a_page_offers_no_next(self, monkeypatch):
+        client, calls = self._client(monkeypatch, [{"items": [event("delivered", 1)]}])
+
+        assert len(list(client.iter_events("stujo.net", 1_700_000_000))) == 1
+        assert len(calls) == 1
+
+
+class TestResolveBegin:
+    def test_defaults_to_a_trailing_window_with_overlap(self):
+        begin, description = resolve_begin({})
+
+        age = datetime.now(timezone.utc) - begin
+        assert timedelta(hours=2, minutes=55) < age < timedelta(hours=3, minutes=5)
+        assert description == "lookback=3.0h"
+
+    def test_explicit_lookback_hours_wins(self):
+        begin, description = resolve_begin({"lookbackHours": 72})
+
+        age = datetime.now(timezone.utc) - begin
+        assert timedelta(hours=71, minutes=55) < age < timedelta(hours=72, minutes=5)
+        assert description == "lookback=72.0h"
+
+    def test_explicit_begin_is_used_verbatim(self):
+        begin, description = resolve_begin({"begin": "2026-09-05T00:00:00Z"})
+
+        assert begin == datetime(2026, 9, 5, tzinfo=timezone.utc)
+        assert "2026-09-05" in description
+
+    def test_a_naive_begin_is_read_as_utc(self):
+        begin, _ = resolve_begin({"begin": "2026-09-05T00:00:00"})
+
+        assert begin.tzinfo is not None
+        assert begin == datetime(2026, 9, 5, tzinfo=timezone.utc)
+
+    def test_an_ancient_begin_is_clamped_rather_than_walking_all_history(self):
+        begin, _ = resolve_begin({"begin": "2019-01-01T00:00:00Z"})
+
+        age = datetime.now(timezone.utc) - begin
+        assert age <= timedelta(hours=MAX_LOOKBACK_HOURS) + timedelta(minutes=1)
+
+    def test_an_unusable_lookback_falls_back_to_the_default(self):
+        begin, description = resolve_begin({"lookbackHours": "soon"})
+
+        age = datetime.now(timezone.utc) - begin
+        assert timedelta(hours=2, minutes=55) < age < timedelta(hours=3, minutes=5)
+        assert description == "lookback=3.0h"
+
+    def test_a_non_dict_payload_is_tolerated(self):
+        begin, description = resolve_begin(None)
+
+        assert description == "lookback=3.0h"
+        assert begin < datetime.now(timezone.utc)
+
+
+class TestCollectStatuses:
+    def test_reduces_events_to_one_status_per_mail(self):
+        client = FakeMailgunClient({
+            "stujo.net": [
+                event("delivered", 1),
+                event("failed", 2, severity="permanent"),
+                event("failed", 3, severity="temporary"),
+                event("complained", 4),
+            ]
+        })
+
+        statuses, counts, failed = collect_statuses(client, datetime.now(timezone.utc))
+
+        assert statuses == {1: STATUS_DELIVERED, 2: STATUS_BOUNCED, 4: STATUS_COMPLAINED}
+        assert counts == {STATUS_DELIVERED: 1, STATUS_BOUNCED: 1, STATUS_COMPLAINED: 1}
+        assert failed == []
+
+    def test_the_stronger_status_wins_regardless_of_event_order(self):
+        # A delivered mail can still be reported as spam afterwards, and the
+        # events do not necessarily arrive in that order.
+        forward = FakeMailgunClient({"d": [event("delivered", 1), event("complained", 1)]})
+        reverse = FakeMailgunClient({"d": [event("complained", 1), event("delivered", 1)]})
+
+        assert collect_statuses(forward, datetime.now(timezone.utc))[0] == {1: STATUS_COMPLAINED}
+        assert collect_statuses(reverse, datetime.now(timezone.utc))[0] == {1: STATUS_COMPLAINED}
+
+    def test_a_temporary_failure_does_not_mask_a_later_delivery(self):
+        client = FakeMailgunClient({
+            "d": [event("failed", 1, severity="temporary"), event("delivered", 1)]
+        })
+
+        statuses, counts, _ = collect_statuses(client, datetime.now(timezone.utc))
+
+        assert statuses == {1: STATUS_DELIVERED}
+        assert counts[STATUS_BOUNCED] == 0
+
+    def test_unkeyed_events_still_count_toward_the_rate(self):
+        # Mail sent before v:maillogId existed cannot be attributed to a row,
+        # but it is still evidence about the recipient list.
+        client = FakeMailgunClient({
+            "d": [event("failed", severity="permanent"), event("delivered")]
+        })
+
+        statuses, counts, _ = collect_statuses(client, datetime.now(timezone.utc))
+
+        assert statuses == {}
+        assert counts[STATUS_BOUNCED] == 1
+        assert counts[STATUS_DELIVERED] == 1
+
+    def test_one_failing_domain_does_not_lose_the_others(self):
+        client = FakeMailgunClient(
+            {"stujo.net": [event("delivered", 1)], "edu.opencampus.sh": []},
+            failing=["edu.opencampus.sh"],
+        )
+
+        statuses, counts, failed = collect_statuses(client, datetime.now(timezone.utc))
+
+        assert statuses == {1: STATUS_DELIVERED}
+        assert [entry["domain"] for entry in failed] == ["edu.opencampus.sh"]
+
+    def test_every_domain_is_read_from_the_same_window(self):
+        begin = datetime(2026, 9, 5, tzinfo=timezone.utc)
+        client = FakeMailgunClient({"a": [], "b": []})
+
+        collect_statuses(client, begin)
+
+        assert client.begins == [("a", begin.timestamp()), ("b", begin.timestamp())]
+
+
+class TestApplyStatuses:
+    def test_writes_one_mutation_per_status(self):
+        client = FakeEduHubClient()
+
+        applied = apply_statuses(client, {1: STATUS_DELIVERED, 2: STATUS_DELIVERED, 3: STATUS_BOUNCED})
+
+        assert applied == {STATUS_DELIVERED: 2, STATUS_BOUNCED: 1}
+        assert len(client.calls) == 2
+
+    def test_delivered_never_overwrites_a_terminal_status(self):
+        client = FakeEduHubClient()
+
+        apply_statuses(client, {1: STATUS_DELIVERED})
+
+        where = client.calls[0]["variables"]["where"]
+        blocked = where["_or"][1]["status"]["_nin"]
+        assert set(blocked) == {STATUS_DELIVERED, STATUS_BOUNCED, STATUS_COMPLAINED}
+
+    def test_complained_is_blocked_only_by_itself(self):
+        client = FakeEduHubClient()
+
+        apply_statuses(client, {1: STATUS_COMPLAINED})
+
+        where = client.calls[0]["variables"]["where"]
+        # Nothing outranks a complaint, so the only row it skips is one that is
+        # already COMPLAINED -- re-confirming it would just bump updated_at.
+        assert where["_or"][1]["status"]["_nin"] == [STATUS_COMPLAINED]
+
+    def test_rows_without_a_status_are_still_matched(self):
+        # MailLog.status is nullable and NOT IN never matches NULL, so the null
+        # case has to be spelled out or those rows would be skipped forever.
+        client = FakeEduHubClient()
+
+        apply_statuses(client, {1: STATUS_BOUNCED})
+
+        where = client.calls[0]["variables"]["where"]
+        assert {"status": {"_is_null": True}} in where["_or"]
+
+    def test_the_stronger_write_is_applied_last(self):
+        client = FakeEduHubClient()
+
+        apply_statuses(client, {1: STATUS_COMPLAINED, 2: STATUS_DELIVERED, 3: STATUS_BOUNCED})
+
+        order = [call["variables"]["status"] for call in client.calls]
+        assert order == [STATUS_DELIVERED, STATUS_BOUNCED, STATUS_COMPLAINED]
+
+    def test_ids_are_chunked(self, monkeypatch):
+        monkeypatch.setattr(
+            "pythonFunctions.sync_mail_delivery_status.UPDATE_CHUNK_SIZE", 2
+        )
+        client = FakeEduHubClient()
+
+        applied = apply_statuses(client, {i: STATUS_DELIVERED for i in range(5)})
+
+        assert [len(c["variables"]["where"]["id"]["_in"]) for c in client.calls] == [2, 2, 1]
+        assert applied == {STATUS_DELIVERED: 5}
+
+    def test_a_failed_chunk_does_not_abort_the_rest(self, monkeypatch):
+        monkeypatch.setattr(
+            "pythonFunctions.sync_mail_delivery_status.UPDATE_CHUNK_SIZE", 2
+        )
+        client = FakeEduHubClient(responses=[
+            {"errors": [{"message": "boom"}]},
+            {"data": {"update_MailLog": {"affected_rows": 2}}},
+        ])
+
+        applied = apply_statuses(client, {i: STATUS_DELIVERED for i in range(4)})
+
+        assert applied == {STATUS_DELIVERED: 2}
+
+    def test_nothing_to_do_makes_no_calls(self):
+        client = FakeEduHubClient()
+
+        assert apply_statuses(client, {}) == {}
+        assert client.calls == []
+
+
+class TestBounceRate:
+    def test_complaints_are_excluded_from_the_denominator(self):
+        # A complaint is a delivered mail the recipient disliked, not a delivery
+        # failure; counting it would dilute the signal.
+        rate, decided = bounce_rate(
+            {STATUS_DELIVERED: 90, STATUS_BOUNCED: 10, STATUS_COMPLAINED: 100}
+        )
+
+        assert decided == 100
+        assert rate == pytest.approx(0.10)
+
+    def test_an_empty_window_is_not_a_division_by_zero(self):
+        assert bounce_rate({STATUS_DELIVERED: 0, STATUS_BOUNCED: 0, STATUS_COMPLAINED: 0}) == (0.0, 0)
+
+
+class TestCheckBounceThreshold:
+    def counts(self, delivered, bounced, complained=0):
+        return {
+            STATUS_DELIVERED: delivered,
+            STATUS_BOUNCED: bounced,
+            STATUS_COMPLAINED: complained,
+        }
+
+    def test_a_healthy_window_raises_nothing(self):
+        client = FakeEduHubClient()
+
+        assert check_bounce_threshold(client, self.counts(1000, 5), "lookback=3.0h") is None
+        assert client.calls == []
+
+    def test_a_small_sample_is_not_an_alert(self):
+        # 2 of 3 is 67% and means nothing.
+        client = FakeEduHubClient()
+
+        assert check_bounce_threshold(client, self.counts(1, 2), "lookback=3.0h") is None
+        assert client.calls == []
+
+    def test_a_bad_recipient_list_alerts_and_mails(self, monkeypatch):
+        monkeypatch.setenv("MAIL_DELIVERY_ALERT_EMAIL", "admin@opencampus.sh")
+        monkeypatch.setenv("MAILGUN_DOMAIN", "edu.opencampus.sh")
+        # The shape of the cutover incident: a big batch, a quarter of it dead.
+        client = FakeEduHubClient(responses=[
+            {"data": {"MailLog": []}},
+            {"data": {"insert_MailLog_one": {"id": 99}}},
+        ])
+
+        alert = check_bounce_threshold(client, self.counts(750, 250), "lookback=3.0h")
+
+        assert alert["bounceRatePercent"] == 25.0
+        assert alert["bounced"] == 250
+        assert alert["mailed"] is True
+
+        queued = client.calls[-1]["variables"]
+        assert queued["to"] == "admin@opencampus.sh"
+        assert queued["from"] == "noreply@edu.opencampus.sh"
+        assert queued["metadata"] == {
+            "type": "MAIL_DELIVERY_BOUNCE_ALERT",
+            "day": datetime.now(timezone.utc).date().isoformat(),
+        }
+        assert "25.0%" in queued["subject"]
+
+    def test_the_alert_is_sent_at_most_once_a_day(self, monkeypatch):
+        monkeypatch.setenv("MAIL_DELIVERY_ALERT_EMAIL", "admin@opencampus.sh")
+        day = datetime.now(timezone.utc).date().isoformat()
+        # An alert mail for today is already in MailLog.
+        client = FakeEduHubClient(responses=[
+            {"data": {"MailLog": [{"metadata": {"type": "MAIL_DELIVERY_BOUNCE_ALERT", "day": day}}]}}
+        ])
+
+        alert = check_bounce_threshold(client, self.counts(750, 250), "lookback=3.0h")
+
+        # Still reported to the caller and still logged, just not re-mailed --
+        # the alert itself is mail, so a broken mail path must not amplify.
+        assert alert["bounceRatePercent"] == 25.0
+        assert alert["mailed"] is False
+        assert len(client.calls) == 1
+
+    def test_a_missing_recipient_still_reports_the_alert(self, monkeypatch):
+        monkeypatch.delenv("MAIL_DELIVERY_ALERT_EMAIL", raising=False)
+        monkeypatch.delenv("STUJO_ADMIN_EMAIL", raising=False)
+        client = FakeEduHubClient()
+
+        alert = check_bounce_threshold(client, self.counts(750, 250), "lookback=3.0h")
+
+        assert alert["mailed"] is False
+        assert client.calls == []
+
+    def test_it_falls_back_to_the_stujo_admin_address(self, monkeypatch):
+        monkeypatch.delenv("MAIL_DELIVERY_ALERT_EMAIL", raising=False)
+        monkeypatch.setenv("STUJO_ADMIN_EMAIL", "stujo@opencampus.sh")
+        client = FakeEduHubClient(responses=[
+            {"data": {"MailLog": []}},
+            {"data": {"insert_MailLog_one": {"id": 99}}},
+        ])
+
+        check_bounce_threshold(client, self.counts(750, 250), "lookback=3.0h")
+
+        assert client.calls[-1]["variables"]["to"] == "stujo@opencampus.sh"
+
+    def test_the_threshold_boundary_is_exclusive(self):
+        client = FakeEduHubClient()
+        # Exactly at the threshold is still healthy.
+        at_threshold = self.counts(
+            int(BOUNCE_RATE_MIN_SAMPLE * (1 - BOUNCE_RATE_THRESHOLD) * 10),
+            int(BOUNCE_RATE_MIN_SAMPLE * BOUNCE_RATE_THRESHOLD * 10),
+        )
+
+        assert bounce_rate(at_threshold)[0] == pytest.approx(BOUNCE_RATE_THRESHOLD)
+        assert check_bounce_threshold(client, at_threshold, "lookback=3.0h") is None

--- a/functions/callPythonFunction/main.py
+++ b/functions/callPythonFunction/main.py
@@ -14,6 +14,7 @@ from pythonFunctions.expire_job_postings import expire_job_postings
 from pythonFunctions.load_participation_data import load_participation_data
 from pythonFunctions.send_job_alerts import send_job_alerts
 from pythonFunctions.send_project_deadline_reminders import send_project_deadline_reminders
+from pythonFunctions.sync_mail_delivery_status import sync_mail_delivery_status
 from pythonFunctions.update_enrollment_locations import update_enrollment_locations
 
 # Initialize the logger level
@@ -34,6 +35,7 @@ PYTHON_FUNCTIONS: Dict[str, Callable] = {
     "load_participation_data": load_participation_data,
     "send_job_alerts": send_job_alerts,
     "send_project_deadline_reminders": send_project_deadline_reminders,
+    "sync_mail_delivery_status": sync_mail_delivery_status,
     "update_enrollment_locations": update_enrollment_locations,
 }
 

--- a/functions/callPythonFunction/pythonFunctions/sync_mail_delivery_status.py
+++ b/functions/callPythonFunction/pythonFunctions/sync_mail_delivery_status.py
@@ -1,0 +1,367 @@
+"""Reads delivery outcomes back from Mailgun onto the MailLog rows that were sent.
+
+Until now MailLog recorded only the *intent* to send: every queueing path writes
+READY_TO_SEND and nothing ever wrote a later status, so a mail that hard-bounced
+looked exactly like a mail that arrived. That is what allowed the StuJo cutover
+announcement (scripts/stujo_cutover_employer_mail.sql) to keep sending through
+1004 legacy employer addresses with nobody seeing the failure rate until the
+whole batch was out.
+
+Two things happen here, and the second is the one that matters operationally:
+
+1. **Per-row bookkeeping.** Each Mailgun event carries ``v:maillogId``, so a
+   delivered / bounced / complained event maps onto an exact MailLog row.
+2. **A bounce-rate check.** If permanent failures exceed
+   BOUNCE_RATE_THRESHOLD of the window's decided mail, this logs an error and
+   mails the admin. Run hourly, that surfaces a bad recipient list after the
+   first batch instead of after the last one.
+
+Status transitions are monotonic -- COMPLAINED > BOUNCED > DELIVERED -- so
+re-reading an overlapping window can never walk a row backwards, which is what
+makes both the hourly overlap and a manual backfill safe to repeat.
+
+Window: the run reads the trailing DEFAULT_LOOKBACK_HOURS rather than persisting
+a cursor. The overlap is deliberate (an hourly cron reading 3h self-heals across
+a couple of missed runs) and costs nothing because the updates are idempotent.
+For a longer gap, or to backfill a batch sent before this function existed, pass
+a payload:
+
+    {"lookbackHours": 72}          # trailing 72 hours
+    {"begin": "2026-09-05T00:00Z"} # explicit start
+"""
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+from api_clients import EduHubClient, MailgunClient
+from api_clients.mailgun_client import maillog_id
+from pythonFunctions.mail_helpers import already_sent_keys, queue_mail
+
+STATUS_DELIVERED = "DELIVERED"
+STATUS_BOUNCED = "BOUNCED"
+STATUS_COMPLAINED = "COMPLAINED"
+
+# Higher wins when one window holds several events for the same mail (a delivered
+# mail can still be marked as spam afterwards), and a status is only written over
+# a lower-ranked one. Anything not listed -- READY_TO_SEND, SENT, NULL -- ranks 0
+# and is always safe to overwrite.
+PRECEDENCE = {STATUS_DELIVERED: 1, STATUS_BOUNCED: 2, STATUS_COMPLAINED: 3}
+
+DEFAULT_LOOKBACK_HOURS = 3
+# Generous, but bounded: an unbounded `begin` would walk the whole event
+# retention period and time the invocation out.
+MAX_LOOKBACK_HOURS = 24 * 30
+
+# Ids per update mutation. MailLog updates by primary key are cheap; this only
+# keeps the generated document from growing without limit on a large backfill.
+UPDATE_CHUNK_SIZE = 500
+
+# Share of *decided* mail (delivered + permanently failed) that may bounce before
+# this is treated as a broken recipient list rather than ordinary churn. Real
+# lists sit well under 1%; the cutover batch was far above this.
+BOUNCE_RATE_THRESHOLD = 0.05
+# Below this, a rate is noise -- 1 bounce out of 3 mails is 33% and means nothing.
+BOUNCE_RATE_MIN_SAMPLE = 20
+
+ALERT_MAIL_TYPE = "MAIL_DELIVERY_BOUNCE_ALERT"
+
+
+def classify_event(event):
+    """Maps a Mailgun event to a MailLog status, or None to leave the row alone.
+
+    A *temporary* failure is deliberately not a status: Mailgun is still
+    retrying and will emit either a delivered or a permanent failed event for
+    the same message later. Writing BOUNCED here would condemn mail that is
+    about to arrive.
+    """
+    name = str(event.get("event") or "").lower()
+
+    if name == "delivered":
+        return STATUS_DELIVERED
+    if name == "complained":
+        return STATUS_COMPLAINED
+    if name == "failed":
+        severity = str(event.get("severity") or "").lower()
+        if severity == "permanent":
+            return STATUS_BOUNCED
+        if severity == "temporary":
+            return None
+        # Undocumented severity: treat as unknown rather than as a bounce, and
+        # say so, because silently dropping these would hide a Mailgun change.
+        logging.warning("Mailgun 'failed' event with unexpected severity %r", event.get("severity"))
+        return None
+    return None
+
+
+def resolve_begin(arguments):
+    """Works out the start of the window to read, as (datetime, description)."""
+    payload = arguments if isinstance(arguments, dict) else {}
+    now = datetime.now(timezone.utc)
+
+    explicit = payload.get("begin")
+    if explicit:
+        begin = datetime.fromisoformat(str(explicit).replace("Z", "+00:00"))
+        if begin.tzinfo is None:
+            begin = begin.replace(tzinfo=timezone.utc)
+        earliest = now - timedelta(hours=MAX_LOOKBACK_HOURS)
+        if begin < earliest:
+            logging.warning(
+                "Requested begin %s is older than the %d hour cap; clamping",
+                begin.isoformat(),
+                MAX_LOOKBACK_HOURS,
+            )
+            begin = earliest
+        return begin, f"begin={begin.isoformat()}"
+
+    hours = payload.get("lookbackHours") or os.getenv("MAIL_DELIVERY_SYNC_LOOKBACK_HOURS")
+    try:
+        hours = float(hours) if hours else DEFAULT_LOOKBACK_HOURS
+    except (TypeError, ValueError):
+        logging.warning("Unusable lookbackHours %r, falling back to %d", hours, DEFAULT_LOOKBACK_HOURS)
+        hours = DEFAULT_LOOKBACK_HOURS
+    hours = max(0.0, min(float(hours), MAX_LOOKBACK_HOURS))
+
+    return now - timedelta(hours=hours), f"lookback={hours}h"
+
+
+def collect_statuses(mailgun_client, begin):
+    """Reads every configured domain and reduces its events to one status per mail.
+
+    Returns:
+        tuple: ({maillogId: status}, counts dict, [domains that failed])
+    """
+    begin_timestamp = begin.timestamp()
+    statuses = {}
+    counts = {STATUS_DELIVERED: 0, STATUS_BOUNCED: 0, STATUS_COMPLAINED: 0}
+    unkeyed = 0
+    failed_domains = []
+
+    for domain in mailgun_client.domains:
+        try:
+            for event in mailgun_client.iter_events(domain, begin_timestamp):
+                status = classify_event(event)
+                if status is None:
+                    continue
+
+                # Counted per event, not per mail: the bounce rate is about how
+                # much mail this window decided, and dedup would understate a
+                # domain that bounced the same address repeatedly.
+                counts[status] += 1
+
+                mail_id = maillog_id(event)
+                if mail_id is None:
+                    unkeyed += 1
+                    continue
+
+                current = statuses.get(mail_id)
+                if current is None or PRECEDENCE[status] > PRECEDENCE[current]:
+                    statuses[mail_id] = status
+        except Exception as error:
+            # One unverified or key-restricted domain must not cost the run the
+            # domains that do work -- notably, the prod sending key is
+            # domain-restricted, so a new portal host can 401 on its own.
+            logging.exception("Reading Mailgun events for %s failed", domain)
+            failed_domains.append({"domain": domain, "error": str(error)})
+
+    if unkeyed:
+        # Expected for anything sent before v:maillogId existed; a steady stream
+        # of these later would mean the send path stopped attaching it.
+        logging.info("%d event(s) carried no maillogId and were counted but not applied", unkeyed)
+
+    return statuses, counts, failed_domains
+
+
+def apply_statuses(eduhub_client, statuses):
+    """Writes the statuses onto MailLog, never downgrading a row.
+
+    Returns:
+        dict: {status: affected_rows}
+    """
+    applied = {}
+
+    # Ascending precedence, so that when the same window decides both DELIVERED
+    # and COMPLAINED for one mail the stronger write lands last regardless of
+    # how the ids are chunked.
+    for status in sorted(PRECEDENCE, key=PRECEDENCE.get):
+        ids = sorted(mail_id for mail_id, value in statuses.items() if value == status)
+        if not ids:
+            continue
+
+        blocked = [other for other, rank in PRECEDENCE.items() if rank >= PRECEDENCE[status]]
+        affected = 0
+
+        for start in range(0, len(ids), UPDATE_CHUNK_SIZE):
+            chunk = ids[start:start + UPDATE_CHUNK_SIZE]
+            where = {"id": {"_in": chunk}}
+            if blocked:
+                # status is nullable, and NOT IN never matches NULL, so the
+                # null case has to be spelled out or rows that were never given
+                # a status would be skipped.
+                where["_or"] = [
+                    {"status": {"_is_null": True}},
+                    {"status": {"_nin": blocked}},
+                ]
+
+            mutation = """
+            mutation SetMailDeliveryStatus($where: MailLog_bool_exp!, $status: String!) {
+                update_MailLog(where: $where, _set: {status: $status}) {
+                    affected_rows
+                }
+            }
+            """
+            result = eduhub_client.send_query(mutation, {"where": where, "status": status})
+            if not isinstance(result, dict) or result.get("errors"):
+                logging.error("Failed to set %s on %d mail(s): %s", status, len(chunk), result)
+                continue
+            affected += result["data"]["update_MailLog"]["affected_rows"]
+
+        applied[status] = affected
+        logging.info("Set %s on %d MailLog row(s)", status, affected)
+
+    return applied
+
+
+def bounce_rate(counts):
+    """Permanent failures as a share of the mail this window actually decided.
+
+    Complaints are excluded from the denominator: a complaint is a delivered
+    mail the recipient disliked, not a delivery failure, so counting it would
+    dilute exactly the signal this is here to catch.
+    """
+    decided = counts[STATUS_DELIVERED] + counts[STATUS_BOUNCED]
+    if decided == 0:
+        return 0.0, 0
+    return counts[STATUS_BOUNCED] / decided, decided
+
+
+def check_bounce_threshold(eduhub_client, counts, window_description):
+    """Logs and mails the admin when the window's bounce rate is out of band.
+
+    Returns:
+        dict|None: the alert that was raised, or None.
+    """
+    rate, decided = bounce_rate(counts)
+    if decided < BOUNCE_RATE_MIN_SAMPLE or rate <= BOUNCE_RATE_THRESHOLD:
+        return None
+
+    percent = round(rate * 100, 1)
+    logging.error(
+        "Mail bounce rate %.1f%% over %s (%d bounced of %d decided) exceeds the %.0f%% threshold",
+        percent,
+        window_description,
+        counts[STATUS_BOUNCED],
+        decided,
+        BOUNCE_RATE_THRESHOLD * 100,
+    )
+
+    alert = {
+        "bounceRatePercent": percent,
+        "bounced": counts[STATUS_BOUNCED],
+        "delivered": counts[STATUS_DELIVERED],
+        "decided": decided,
+        "window": window_description,
+        "mailed": False,
+    }
+
+    recipient = os.getenv("MAIL_DELIVERY_ALERT_EMAIL") or os.getenv("STUJO_ADMIN_EMAIL")
+    if not recipient:
+        logging.error("No MAIL_DELIVERY_ALERT_EMAIL/STUJO_ADMIN_EMAIL configured; alert not mailed")
+        return alert
+
+    # One mail per UTC day. The log line above fires on every run so the
+    # condition stays visible, but a sustained problem must not turn into an
+    # hourly mail -- and the alert itself is mail, so a genuinely broken mail
+    # path would otherwise amplify itself.
+    day = datetime.now(timezone.utc).date().isoformat()
+    if already_sent_keys(eduhub_client, ALERT_MAIL_TYPE, [{"day": day}], ["day"]):
+        logging.info("Bounce-rate alert for %s already sent", day)
+        return alert
+
+    template = {
+        "subject": f"[EduHub] Zustellquote auffällig: {percent}% Bounces",
+        "content": (
+            "<p>Die Bounce-Quote der letzten Zustellungen liegt über dem Schwellwert.</p>"
+            f"<ul><li>Bounce-Quote: <strong>{percent}%</strong> "
+            f"(Schwellwert {BOUNCE_RATE_THRESHOLD * 100:.0f}%)</li>"
+            f"<li>Dauerhaft fehlgeschlagen: {counts[STATUS_BOUNCED]}</li>"
+            f"<li>Zugestellt: {counts[STATUS_DELIVERED]}</li>"
+            f"<li>Beschwerden: {counts[STATUS_COMPLAINED]}</li>"
+            f"<li>Zeitfenster: {window_description}</li></ul>"
+            "<p>Bitte prüfen, ob gerade ein Massenversand mit einer veralteten "
+            "Empfängerliste läuft, und ihn gegebenenfalls stoppen, bevor weitere "
+            "Batches rausgehen. Betroffene Adressen stehen in MailLog mit Status "
+            "BOUNCED.</p>"
+        ),
+        "from": f"noreply@{_sender_domain()}",
+    }
+    alert["mailed"] = queue_mail(
+        eduhub_client,
+        template,
+        recipient,
+        {},
+        metadata={"type": ALERT_MAIL_TYPE, "day": day},
+    )
+    return alert
+
+
+def _sender_domain():
+    """The domain the alert mail is sent from -- sendMail only signs its own."""
+    from api_clients.mailgun_client import configured_domains
+
+    domains = configured_domains()
+    return domains[0] if domains else "opencampus.sh"
+
+
+def sync_mail_delivery_status(arguments):
+    """
+    Pulls Mailgun delivery events and records the outcome on each MailLog row,
+    then checks the window's bounce rate against BOUNCE_RATE_THRESHOLD.
+
+    Runs hourly via the sync_mail_delivery_status cron trigger. Also usable as a
+    one-off backfill by passing {"lookbackHours": N} or {"begin": "<ISO>"}.
+
+    Args:
+        arguments (dict): Cron payload; optional "lookbackHours" / "begin".
+
+    Returns:
+        dict: Response containing:
+            - success (bool): Whether the operation was successful
+            - data (dict, optional): Event counts, rows updated, any alert
+            - error (str, optional): Error message if operation failed
+    """
+    logging.info("########## Sync Mail Delivery Status Function ##########")
+    logging.debug(f"arguments: {arguments}")
+
+    try:
+        eduhub_client = EduHubClient()
+        mailgun_client = MailgunClient()
+
+        begin, window_description = resolve_begin(arguments)
+        logging.info(
+            "Reading Mailgun events since %s for %s",
+            begin.isoformat(),
+            ", ".join(mailgun_client.domains),
+        )
+
+        statuses, counts, failed_domains = collect_statuses(mailgun_client, begin)
+        applied = apply_statuses(eduhub_client, statuses)
+        alert = check_bounce_threshold(eduhub_client, counts, window_description)
+
+        return {
+            "success": True,
+            "data": {
+                "window": window_description,
+                "begin": begin.isoformat(),
+                "domains": mailgun_client.domains,
+                "eventCounts": counts,
+                "matchedMails": len(statuses),
+                "updated": applied,
+                "failedDomains": failed_domains,
+                "alert": alert,
+            },
+        }
+
+    except Exception as e:
+        logging.exception("sync_mail_delivery_status failed")
+        return {"success": False, "error": str(e)}

--- a/functions/sendMail/index.js
+++ b/functions/sendMail/index.js
@@ -267,6 +267,15 @@ exports.sendMail = async (req, res) => {
     'o:tracking': true  // Enable Mailgun's email tracking features
   };
 
+  // Mailgun echoes custom `v:` variables on every event it records for this
+  // message, so sync_mail_delivery_status can join a delivered/bounced event
+  // back onto the exact MailLog row. The alternative -- storing the Mailgun
+  // message id -- would need a write back to the database on the send path,
+  // which this function deliberately does not do: it runs from a Hasura event
+  // trigger with 10 retries, and a failed write would be indistinguishable
+  // from a failed send. Only ever set from MailLog.id, never from the payload.
+  if (Number.isInteger(id)) msg['v:maillogId'] = String(id);
+
   // Add optional email parameters if provided
   if (replyTo) msg['h:Reply-To'] = replyTo;
   if (cc) msg.cc = cc;
@@ -283,6 +292,7 @@ exports.sendMail = async (req, res) => {
       case 'development':
         // Development mode: Log all email attempts without actually sending
         console.log('Development email:', {
+          maillogId: msg['v:maillogId'],
           to: msg.to,
           from: msg.from,
           subject: msg.subject,

--- a/functions/shared_libs/api_clients/__init__.py
+++ b/functions/shared_libs/api_clients/__init__.py
@@ -1,4 +1,5 @@
 from .eduhub_client import EduHubClient
+from .mailgun_client import MailgunClient
 from .zoom_client import ZoomClient
 from .limesurvey_client import LimeSurveyClient
 from .mattermost_client import MattermostClient

--- a/functions/shared_libs/api_clients/mailgun_client.py
+++ b/functions/shared_libs/api_clients/mailgun_client.py
@@ -1,0 +1,162 @@
+"""Mailgun client for reading delivery events.
+
+This is the read side of mail. The write side lives in the ``sendMail`` cloud
+function (``functions/sendMail/index.js``), which sends each MailLog row through
+the Mailgun messages API and attaches ``v:maillogId`` to it. Mailgun echoes
+custom ``v:`` variables on every event it records for a message, so an event
+read back here carries the exact MailLog primary key -- no address matching, no
+message-id column, and no database write on the send path.
+
+Only the events endpoint is used:
+
+    GET /v3/<domain>/events?event=delivered OR failed OR complained&begin=<ts>
+
+Two details that are easy to get wrong:
+
+* **Region.** This account is on Mailgun EU, so the host is
+  ``api.eu.mailgun.net``. The US host answers with an empty event list for an
+  EU domain rather than an error, which would look exactly like "no mail was
+  sent" and is the reason this is not left to a default.
+* **Pagination.** The events endpoint does not return a total. It returns a
+  page plus ``paging.next``, and the walk ends when a page comes back empty --
+  not when a page comes back short.
+"""
+
+import logging
+import os
+from typing import Dict, Iterator, List, Optional
+
+import requests
+
+# Mailgun EU. The US region is api.mailgun.net; a mismatch reads as "no events".
+DEFAULT_BASE_URL = "https://api.eu.mailgun.net"
+
+# Mailgun's documented maximum for this endpoint.
+PAGE_LIMIT = 300
+
+# (connect, read). The sync cron runs hourly and has no partial-failure state to
+# resume from, so a hung connection must fail fast enough to leave the run time
+# for the domains that still work.
+DEFAULT_TIMEOUT = (10, 30)
+
+# A runaway paging loop would hold the invocation until the platform kills it.
+# At PAGE_LIMIT events per page this caps one domain's run at 60k events, far
+# above the largest batch this system has ever sent (1004).
+MAX_PAGES = 200
+
+# The three terminal outcomes. Mailgun accepts an OR filter expression here, so
+# one walk per domain covers all of them and events arrive interleaved in time.
+EVENT_FILTER = "delivered OR failed OR complained"
+
+
+class MailgunClient:
+    """Reads delivery events for the configured Mailgun sending domains."""
+
+    def __init__(self, api_key=None, base_url=None, domains=None, timeout=DEFAULT_TIMEOUT):
+        self.api_key = api_key if api_key is not None else os.getenv("MAILGUN_API_KEY")
+        if not self.api_key:
+            raise ValueError("MAILGUN_API_KEY is not set")
+
+        self.base_url = (base_url or os.getenv("MAILGUN_API_BASE_URL") or DEFAULT_BASE_URL).rstrip("/")
+        self.domains = domains if domains is not None else configured_domains()
+        if not self.domains:
+            raise ValueError("No Mailgun sending domain configured (MAILGUN_DOMAIN)")
+        self.timeout = timeout
+
+    def iter_events(self, domain: str, begin_timestamp: float) -> Iterator[Dict]:
+        """Yields delivered / failed / complained events for one domain.
+
+        Args:
+            domain: a verified Mailgun sending domain.
+            begin_timestamp: Unix seconds; events at or after this are returned.
+
+        Yields:
+            dict: raw Mailgun event objects, oldest first.
+        """
+        url = f"{self.base_url}/v3/{domain}/events"
+        params = {
+            "event": EVENT_FILTER,
+            "begin": begin_timestamp,
+            # Oldest first, so a truncated walk still leaves the newest events
+            # for the next run's overlapping window rather than losing the old.
+            "ascending": "yes",
+            "limit": PAGE_LIMIT,
+        }
+
+        for page in range(MAX_PAGES):
+            payload = self._get(url, params)
+            items = payload.get("items") or []
+            for item in items:
+                yield item
+
+            # An empty page is the documented end of the walk. A short page is
+            # not: Mailgun fills pages by time bucket, not by count.
+            if not items:
+                return
+
+            url = (payload.get("paging") or {}).get("next")
+            if not url:
+                return
+            # paging.next carries every parameter already.
+            params = None
+
+            if page == MAX_PAGES - 1:
+                logging.error(
+                    "Mailgun event walk for %s hit the %d page cap; "
+                    "remaining events are left to the next run",
+                    domain,
+                    MAX_PAGES,
+                )
+
+    def _get(self, url: str, params: Optional[Dict]) -> Dict:
+        response = requests.get(
+            url,
+            auth=("api", self.api_key),
+            params=params,
+            timeout=self.timeout,
+        )
+        # 401 here almost always means the key is scoped to a different domain
+        # rather than being wrong outright -- the prod sending key is
+        # domain-restricted -- so keep the domain in the message.
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise ValueError(f"Mailgun events: expected JSON object, got {type(payload).__name__}")
+        return payload
+
+
+def configured_domains() -> List[str]:
+    """The sending domains to read events for.
+
+    Mirrors ``configuredDomains()`` in functions/sendMail/index.js so the read
+    side cannot drift from the write side: a domain that sendMail is allowed to
+    send through is a domain whose bounces must be read back. Hard-coding the
+    pair here would silently stop covering the next portal that gets added.
+    """
+    raw = [os.getenv("MAILGUN_DOMAIN", "")]
+    raw.extend(os.getenv("MAILGUN_ADDITIONAL_DOMAINS", "").split(","))
+
+    domains = []
+    for entry in raw:
+        domain = str(entry or "").strip().lower()
+        if domain and domain not in domains:
+            domains.append(domain)
+    return domains
+
+
+def maillog_id(event: Dict) -> Optional[int]:
+    """The MailLog id a Mailgun event belongs to, or None.
+
+    Mailgun returns user variables as strings, and events predating the
+    ``v:maillogId`` change carry none at all -- those are skipped rather than
+    guessed at from the recipient address, which is not unique in MailLog.
+    """
+    variables = event.get("user-variables") or {}
+    raw = variables.get("maillogId")
+    if raw is None:
+        return None
+    try:
+        return int(str(raw).strip())
+    except (TypeError, ValueError):
+        logging.warning("Mailgun event carries an unusable maillogId: %r", raw)
+        return None

--- a/infrastructure/application/06_cloud-functions.tf
+++ b/infrastructure/application/06_cloud-functions.tf
@@ -178,6 +178,14 @@ resource "google_cloudfunctions2_function" "call_python_function" {
       # StuJo job board (expire_job_postings / send_job_alerts mails). Follows
       # the canonical host, so mail links move to stujo.net at cutover.
       STUJO_FRONTEND_URL = "https://${local.stujo_public_host}"
+      # Mailgun sending domains, mirrored from the send_mail function below:
+      # sync_mail_delivery_status reads delivery events for exactly the domains
+      # this deployment is allowed to send through, so a newly added portal
+      # host gets bounce tracking without a code change.
+      MAILGUN_DOMAIN             = var.mailgun_domain
+      MAILGUN_ADDITIONAL_DOMAINS = join(",", var.mailgun_additional_domains)
+      # Recipient of the sync_mail_delivery_status bounce-rate alert.
+      STUJO_ADMIN_EMAIL = var.stujo_admin_email
     }
 
     secret_environment_variables {
@@ -219,6 +227,19 @@ resource "google_cloudfunctions2_function" "call_python_function" {
       key        = "MM_TOKEN"
       project_id = var.project_id
       secret     = google_secret_manager_secret.mm_token.secret_id
+      version    = "latest"
+    }
+
+    # sync_mail_delivery_status reads the Mailgun events API. This is the same
+    # credential the send_mail function sends with, which is more privilege than
+    # the cron needs -- it never sends. A key scoped to read-only would be the
+    # better shape; it needs minting in Mailgun first, and note the prod key is
+    # domain-restricted, so any replacement must cover every sending domain
+    # above or the events walk 401s per domain.
+    secret_environment_variables {
+      key        = "MAILGUN_API_KEY"
+      project_id = var.project_id
+      secret     = google_secret_manager_secret.mailgun_api_key.secret_id
       version    = "latest"
     }
 
@@ -271,6 +292,13 @@ resource "google_secret_manager_secret_iam_member" "call_python_function_mm_toke
   member     = "serviceAccount:${google_service_account.custom_cloud_function_account.email}"
   depends_on = [google_secret_manager_secret.mm_token]
 }
+
+# No call_python_function_mailgun_api_key binding on purpose. Every function in
+# this file runs as custom_cloud_function_account, and send_mail_mailgun_api_key
+# further down already grants that exact member secretAccessor on this secret.
+# A second google_secret_manager_secret_iam_member for the same
+# (secret, role, member) triple would be two resources managing one binding, so
+# destroying either one would silently revoke the other function's access.
 
 ###############################################################################
 # Create Google cloud function for callNodeFunction


### PR DESCRIPTION
## Why

`MailLog` only ever recorded the *intent* to send. Every queueing path writes
`READY_TO_SEND`, and nothing ever wrote a later status — so a mail that
hard-bounced was indistinguishable from one that arrived.

That is what allowed the StuJo cutover announcement
(`scripts/stujo_cutover_employer_mail.sql`) to run through 1004 legacy employer
addresses with nobody seeing the failure rate until the whole batch was out.

## What changed

**Send path** — `sendMail` attaches `v:maillogId` to each Mailgun message.
Mailgun echoes custom `v:` variables on every event it records for that
message, so the read side gets an exact `MailLog` key. The alternative, storing
Mailgun's message id, would need a database write on the send path — which this
function deliberately does not do: it runs from a Hasura event trigger with 10
retries, and a failed write would be indistinguishable from a failed send.

**Read path** — new hourly cron `sync_mail_delivery_status` (`15 * * * *`,
offset so it does not compete with `expire_invitations`):

| Mailgun event | MailLog status |
|---|---|
| `delivered` | `DELIVERED` |
| `failed` + `severity=permanent` | `BOUNCED` |
| `failed` + `severity=temporary` | *left alone — Mailgun is still retrying* |
| `complained` | `COMPLAINED` |

Transitions are monotonic (`COMPLAINED` > `BOUNCED` > `DELIVERED`), so a row is
never walked backwards. That is what makes both the deliberate window overlap
and a manual backfill safe to repeat:

```
{"lookbackHours": 72}          # trailing 72 hours
{"begin": "2026-09-05T00:00Z"} # explicit start
```

The run reads a trailing 3h window rather than persisting a cursor — an hourly
cron with 3× overlap self-heals across a couple of missed runs and costs
nothing, because the updates are idempotent.

**The part that addresses the incident** — each run compares permanent failures
against the window's *decided* mail (delivered + permanently failed; complaints
are excluded, since a complaint is a delivered mail the recipient disliked, not
a delivery failure). Above 5%, with at least 20 samples, it logs an error and
mails the admin. The mail is deduped to once per UTC day: the alert is itself
mail, so a genuinely broken mail path must not amplify itself. Run hourly, this
surfaces a bad recipient list after the first batch of 250 rather than after
all 1004.

**Schema** — `MailStatus` held only the three values from 2021. Added
`DELIVERED`, `BOUNCED`, `COMPLAINED`, and `READY_TO_SEND`, which the whole
codebase has been writing for years while the lookup table denied it existed.
`MailLog.status` is plain `text` with no foreign key, which is the only reason
that never failed — and the reason adding these rows is purely additive.

**Bug found on the way** — `public_MailStatus.yaml` mapped its `MailLogs`
relationship `value: id`, joining a status string against a serial primary key,
so it matched nothing. Now `value: status`; `READY_TO_SEND` resolves to 1447
rows locally where it previously resolved to none.

## Two places the spec and the repo disagreed

- **No new secret IAM member.** Every function in `06_cloud-functions.tf` runs
  as `custom_cloud_function_account`, and `send_mail_mailgun_api_key` already
  grants it `secretAccessor` on this secret. A second
  `google_secret_manager_secret_iam_member` for the same (secret, role, member)
  triple would be two resources managing one binding — destroying either would
  silently revoke the other function's access. Documented in place.
- **Domains are config-driven**, not the hard-coded `edu.opencampus.sh` /
  `stujo.net` pair: `MAILGUN_DOMAIN` + `MAILGUN_ADDITIONAL_DOMAINS` are
  mirrored from `sendMail`, so a domain this deployment may send through is
  automatically a domain whose bounces get read back.

## Verification

- **168 python tests pass** (48 new), **268 node tests pass** (3 new).
  `matrixRoomUtils.test.js` fails identically on a clean tree — a `node:test`
  file Jest cannot parse, untouched here.
- **Migration + metadata applied locally**; `terraform validate` and
  `terraform fmt -check` clean.
- **End-to-end against the local Hasura** with only the Mailgun HTTP call
  faked — real inserts, real update mutation, real guard:

  | row | event | result |
  |---|---|---|
  | 1475 | `delivered` | `DELIVERED` |
  | 1476 | `failed`/permanent | `BOUNCED` |
  | 1477 | `failed`/temporary | `READY_TO_SEND` (untouched) |
  | 1478 | `complained` | `COMPLAINED` |
  | 1479 (already `COMPLAINED`) | `delivered` | `COMPLAINED` (not downgraded) |

- **Real dispatch path** through the container:
  `Function-Name: sync_mail_delivery_status` → `{"error": "MAILGUN_API_KEY is
  not set", "success": false}` — routed correctly, fails cleanly.

## Before this helps in prod

1. `terraform apply` — the function needs `MAILGUN_API_KEY` before the cron can
   do anything; until then every run returns the error above.
2. Only mail sent *after* this deploys carries `v:maillogId`. Events without it
   are counted toward the bounce rate but cannot be attributed to a row, so the
   already-sent cutover batch will not be backfilled per-row.
3. Recommended, needs a human in Mailgun: a **read-only key** for a cron that
   never sends. Note the prod key is domain-restricted, so any replacement must
   cover every sending domain or the events walk 401s per domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic tracking of email delivery outcomes, including delivered, bounced, and complained messages.
  - Added scheduled synchronization of delivery statuses with Mailgun.
  - Added bounce-rate monitoring and administrator alerts when failures exceed configured thresholds.
  - Added support for configuring Mailgun domains and delivery-sync settings.

- **Bug Fixes**
  - Corrected email status lookups so delivery statuses are associated with the correct mail records.

- **Tests**
  - Added coverage for delivery tracking, status updates, pagination, and bounce-rate alerting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->