### PR TITLE
fix(edu-hub): align hero fade and header controls

### DIFF
--- a/frontend-nx/apps/edu-hub/components/layout/Header.tsx
+++ b/frontend-nx/apps/edu-hub/components/layout/Header.tsx
@@ -45,8 +45,8 @@ export const Header: FC = () => {
   };
 
   return (
-    <header className="z-10 w-full absolute top-0 left-0" style={{ backgroundColor: 'rgba(34, 34, 34, 0.5)' }}>
-      <div className="flex py-4 px-3 md:px-16 max-w-screen-xl w-full mx-auto justify-between">
+    <header className="z-10 w-full absolute top-0 left-0 py-4" style={{ backgroundColor: 'rgba(34, 34, 34, 0.5)' }}>
+      <div className="flex min-h-11 items-center px-3 md:px-16 max-w-screen-xl w-full mx-auto justify-between">
         <div className="flex-grow w-full items-center">
           <Link href={`/`}>
             <div className="flex cursor-pointer">

--- a/frontend-nx/apps/edu-hub/styles/globals.css
+++ b/frontend-nx/apps/edu-hub/styles/globals.css
@@ -39,7 +39,7 @@
   /* Homepage hero overlay: the bottom fade into the page plus the bottom-left
      scrim that carries the white headline. Intentionally not overridden for
      light mode - the headline over the hero artwork is always white. */
-  --eduhub-hero-fade: #0F0F0F;
+  --eduhub-hero-fade: var(--eduhub-bg-primary);
   --eduhub-hero-scrim: rgba(0, 0, 0, 0.8);
   
   /* Functional Colors (consistent across modes) */


### PR DESCRIPTION
## Summary

- fade the homepage hero into the primary page background
- vertically center the header controls
- reserve the standard control-row height across hydration

## Verification

- `git diff --check`
- manually verified the homepage in Safari

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted header spacing and minimum height for more consistent layout.
  - Updated the hero fade effect to follow the app’s primary background color.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->